### PR TITLE
Bug Fix: Function is not converting data into enum Action properly

### DIFF
--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -787,7 +787,7 @@ impl MboMsg {
     /// This function returns an error if the `action` field does not
     /// contain a valid [`Action`](crate::enums::Action).
     pub fn action(&self) -> crate::error::Result<Action> {
-        Action::try_from(self.side as u8)
+        Action::try_from(self.action as u8)
             .map_err(|_| ConversionError::TypeConversion("Invalid action"))
     }
 }
@@ -808,7 +808,7 @@ impl TradeMsg {
     /// This function returns an error if the `action` field does not
     /// contain a valid [`Action`](crate::enums::Action).
     pub fn action(&self) -> crate::error::Result<Action> {
-        Action::try_from(self.side as u8)
+        Action::try_from(self.action as u8)
             .map_err(|_| ConversionError::TypeConversion("Invalid action"))
     }
 }
@@ -829,7 +829,7 @@ impl Mbp1Msg {
     /// This function returns an error if the `action` field does not
     /// contain a valid [`Action`](crate::enums::Action).
     pub fn action(&self) -> crate::error::Result<Action> {
-        Action::try_from(self.side as u8)
+        Action::try_from(self.action as u8)
             .map_err(|_| ConversionError::TypeConversion("Invalid action"))
     }
 }
@@ -850,7 +850,7 @@ impl Mbp10Msg {
     /// This function returns an error if the `action` field does not
     /// contain a valid [`Action`](crate::enums::Action).
     pub fn action(&self) -> crate::error::Result<Action> {
-        Action::try_from(self.side as u8)
+        Action::try_from(self.action as u8)
             .map_err(|_| ConversionError::TypeConversion("Invalid action"))
     }
 }


### PR DESCRIPTION
# Pull Request
Bux fixes. `fn action` was using `side` instead of `action` when converting data into action enum.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?
No tests.
