### PR TITLE
FIX typo on README.md on dbn crate

### DIFF
--- a/rust/dbn/README.md
+++ b/rust/dbn/README.md
@@ -19,7 +19,7 @@ To read a DBN file with MBO data and print each row:
 ```rust
 use dbn::{
     decode::dbn::Decoder,
-    records::MboMsg,
+    record::MboMsg,
 };
 use streaming_iterator::StreamingIterator;
 


### PR DESCRIPTION
# Pull Request

This PR fixes the typo.
Module `dbn::records` doesn't exist but `dbn::record` does.

BEFORE FIX:
```rust
    records::MboMsg,
```

AFTER FIX:
This PR fixes the typo.
```rust
    record::MboMsg,
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this change been tested?

I tested on my local computer.
