### PR TITLE
VER: Release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog
 
-## 0.14.1 - 2023-11-16
+## 0.14.1 - 2023-11-17
 ### Enhancements
 - Added new trait `compat::SymbolMappingRec` for code reuse when working with
   both versions of `SymbolMappingMsg`
 - Changed `PitSymbolMap::on_symbol_mapping` to accept either version of
   `SymbolMappingMsg`
 
+
 ### Bug fixes
 - Fixed missing DBNv1 compatibility in `PitSymbolMap::on_record`
+- Fixed missing Python export for `VersionUpgradePolicy`
+- Fixed missing Python export and methods for `InstrumentDefMsgV1` and
+  `SymbolMappingMsgV1`
+- Fixed bug where Python `DbnDecoder` and `Transcoder` would throw exceptions
+  when attempting to decode partial metadata
 
 ## 0.14.0 - 2023-11-15
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.14.1 - TBD
+## 0.14.1 - 2023-11-16
 ### Enhancements
 - Added new trait `compat::SymbolMappingRec` for code reuse when working with
   both versions of `SymbolMappingMsg`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.14.1 - TBD
+### Enhancements
+- Added new trait `compat::SymbolMappingRec` for code reuse when working with
+  both versions of `SymbolMappingMsg`
+- Changed `PitSymbolMap::on_symbol_mapping` to accept either version of
+  `SymbolMappingMsg`
+
+### Bug fixes
+- Fixed missing DBNv1 compatibility in `PitSymbolMap::on_record`
+
 ## 0.14.0 - 2023-11-15
 ### Enhancements
 - This version begins the transition to DBN version 2 (DBNv2). In this version, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "dbn",
  "pyo3",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-compression",
  "csv",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "csv",
  "dbn",

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dbn-c"
 authors = ["Databento <support@databento.com>"]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "C bindings for working with Databento Binary Encoding (DBN)"
 license = "Apache-2.0"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "databento-dbn"
 authors = ["Databento <support@databento.com>"]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Python library written in Rust for working with Databento Binary Encoding (DBN)"
 license = "Apache-2.0"

--- a/python/databento_dbn.pyi
+++ b/python/databento_dbn.pyi
@@ -22,9 +22,11 @@ _DBNRecord = Union[
     OHLCVMsg,
     TradeMsg,
     InstrumentDefMsg,
+    InstrumentDefMsgV1,
     ImbalanceMsg,
     ErrorMsg,
     SymbolMappingMsg,
+    SymbolMappingMsgV1,
     SystemMsg,
     StatMsg,
 ]
@@ -1933,6 +1935,811 @@ class InstrumentDefMsg(Record):
 
         """
 
+class InstrumentDefMsgV1(Record):
+    """
+    A DBN version 1 definition of an instrument.
+    """
+
+    @property
+    def pretty_ts_recv(self) -> datetime:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime
+
+        """
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as number of
+        nanoseconds since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_min_price_increment(self) -> float:
+        """
+        The minimum constant tick for the instrument as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment
+
+        """
+    @property
+    def min_price_increment(self) -> int:
+        """
+        The minimum constant tick for the instrument in units of 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment
+
+        """
+    @property
+    def display_factor(self) -> int:
+        """
+        The multiplier to convert the venue’s display price to the conventional
+        price.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_expiration(self) -> datetime:
+        """
+        The last eligible trade time expressed as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime
+
+        """
+    @property
+    def expiration(self) -> int:
+        """
+        The last eligible trade time expressed as a number of nanoseconds since
+        the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_activation(self) -> datetime:
+        """
+        The time of instrument activation expressed as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime
+
+        """
+    @property
+    def activation(self) -> int:
+        """
+        The time of instrument activation expressed as a number of nanoseconds
+        since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_high_limit_price(self) -> float:
+        """
+        The allowable high limit price for the trading day as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        high_limit_price
+
+        """
+    @property
+    def high_limit_price(self) -> int:
+        """
+        The allowable high limit price for the trading day in units of 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_high_limit_price
+
+        """
+    @property
+    def pretty_low_limit_price(self) -> float:
+        """
+        The allowable low limit price for the trading day as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        low_limit_price
+
+        """
+    @property
+    def low_limit_price(self) -> int:
+        """
+        The allowable low limit price for the trading day in units of 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_low_limit_price
+
+        """
+    @property
+    def pretty_max_price_variation(self) -> float:
+        """
+        The differential value for price banding in units as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        max_price_variation
+
+        """
+    @property
+    def max_price_variation(self) -> int:
+        """
+        The differential value for price banding in units of 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_max_price_variation
+
+        """
+    @property
+    def pretty_trading_reference_price(self) -> float:
+        """
+        The trading session settlement price on `trading_reference_date` as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        trading_reference_price
+
+        """
+    @property
+    def trading_reference_price(self) -> int:
+        """
+        The trading session settlement price on `trading_reference_date` in units of 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_trading_reference_price
+
+        """
+    @property
+    def unit_of_measure_qty(self) -> int:
+        """
+        The contract size for each instrument, in combination with
+        `unit_of_measure`.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_min_price_increment_amount(self) -> float:
+        """
+        The value currently under development by the venue as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment_amount
+
+        """
+    @property
+    def min_price_increment_amount(self) -> int:
+        """
+        The value currently under development by the venue. Converted to units
+        of 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment_amount
+
+        """
+    @property
+    def pretty_price_ratio(self) -> float:
+        """
+        The value used for price calculation in spread and leg pricing as a
+        float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price_ratio
+
+        """
+    @property
+    def price_ratio(self) -> int:
+        """
+        The value used for price calculation in spread and leg pricing in units
+        of 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price_ratio
+
+        """
+    @property
+    def inst_attrib_value(self) -> int:
+        """
+        A bitmap of instrument eligibility attributes.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def underlying_id(self) -> int:
+        """
+        The `instrument_id` of the first underlying instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def raw_instrument_id(self) -> int:
+        """
+        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def market_depth_implied(self) -> int:
+        """
+        The implied book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def market_depth(self) -> int:
+        """
+        The (outright) book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def market_segment_id(self) -> int:
+        """
+        The market segment of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def max_trade_vol(self) -> int:
+        """
+        The maximum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def min_lot_size(self) -> int:
+        """
+        The minimum order entry quantity for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def min_lot_size_block(self) -> int:
+        """
+        The minimum quantity required for a block trade of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def min_lot_size_round_lot(self) -> int:
+        """
+        The minimum quantity required for a round lot of the instrument.
+        Multiples of this quantity are also round lots.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def min_trade_vol(self) -> int:
+        """
+        The minimum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def contract_multiplier(self) -> int:
+        """
+        The number of deliverables per instrument, i.e. peak days.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def decay_quantity(self) -> int:
+        """
+        The quantity that a contract will decay daily, after `decay_start_date`
+        has been reached.
+
+        Retruns
+        -------
+        int
+
+        """
+    @property
+    def original_contract_size(self) -> int:
+        """
+        The fixed contract value assigned to each instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def trading_reference_date(self) -> int:
+        """
+        The trading session date corresponding to the settlement price in
+        `trading_reference_price`, in number of days since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def appl_id(self) -> int:
+        """
+        The channel ID assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def maturity_year(self) -> int:
+        """
+        The calendar year reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def decay_start_date(self) -> int:
+        """
+        The date at which a contract will begin to decay.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def channel_id(self) -> int:
+        """
+        The channel ID assigned by Databento as an incrementing integer
+        starting at zero.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def currency(self) -> str:
+        """
+        The currency used for price fields.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def settl_currency(self) -> str:
+        """
+        The currency used for settlement, if different from `currency`.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def secsubtype(self) -> str:
+        """
+        The strategy type of the spread.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def raw_symbol(self) -> str:
+        """
+        The instrument name (symbol).
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def group(self) -> str:
+        """
+        The security group code of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def exchange(self) -> str:
+        """
+        The exchange used to identify the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def asset(self) -> str:
+        """
+        The underlying asset code (product code) of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def cfi(self) -> str:
+        """
+        The ISO standard instrument categorization code.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def security_type(self) -> str:
+        """
+        The type of the instrument, e.g. FUT for future or future spread.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def unit_of_measure(self) -> str:
+        """
+        The unit of measure for the instrument’s original contract size, e.g.
+        USD or LBS.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def underlying(self) -> str:
+        """
+        The symbol of the first underlying instrument.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def strike_price_currency(self) -> str:
+        """
+        The currency of `strike_price`.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def instrument_class(self) -> str:
+        """
+        The classification of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def pretty_strike_price(self) -> float:
+        """
+        The strike price of the option as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        strike_price
+
+        """
+    @property
+    def strike_price(self) -> int:
+        """
+        The strike price of the option. Converted to units of 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_strike_price
+
+        """
+    @property
+    def match_algorithm(self) -> str:
+        """
+        The matching algorithm used for the instrument, typically **F**IFO.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def md_security_trading_status(self) -> int:
+        """
+        The current trading state of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def main_fraction(self) -> int:
+        """
+        The price denominator of the main fraction.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def price_display_format(self) -> int:
+        """
+        The number of digits to the right of the tick mark, to display
+        fractional prices.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def settl_price_type(self) -> int:
+        """
+        The type indicators for the settlement price, as a bitmap.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def sub_fraction(self) -> int:
+        """
+        The price denominator of the sub fraction.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def underlying_product(self) -> int:
+        """
+        The product complex of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def security_update_action(self) -> str:
+        """
+        Indicates if the instrument definition has been added, modified, or
+        deleted.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def maturity_month(self) -> int:
+        """
+        The calendar month reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def maturity_day(self) -> int:
+        """
+        The calendar day reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def maturity_week(self) -> int:
+        """
+        The calendar week reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def user_defined_instrument(self) -> str:
+        """
+        Indicates if the instrument is user defined: `Y`es or `N`o.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def contract_multiplier_unit(self) -> int:
+        """
+        The type of `contract_multiplier`. Either `1` for hours, or `2` for
+        days.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def flow_schedule_type(self) -> int:
+        """
+        The schedule for delivering electricity.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def tick_rule(self) -> int:
+        """
+        The tick rule of the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
 class ImbalanceMsg(Record):
     """
     An auction imbalance message.
@@ -2406,6 +3213,76 @@ class SymbolMappingMsg(Record):
         Returns
         -------
         SType
+
+        """
+    @property
+    def stype_out_symbol(self) -> str:
+        """
+        The output symbol.
+
+        Returns
+        -------
+        str
+
+        """
+    @property
+    def pretty_start_ts(self) -> datetime:
+        """
+        The start of the mapping interval expressed as a datetime
+        or `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime
+
+        """
+    @property
+    def start_ts(self) -> int:
+        """
+        The start of the mapping interval expressed as the number of
+        nanoseconds since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+    @property
+    def pretty_end_ts(self) -> datetime:
+        """
+        The end of the mapping interval expressed as a datetime
+        or `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime
+
+        """
+    @property
+    def end_ts(self) -> int:
+        """
+        The end of the mapping interval expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+
+class SymbolMappingMsgV1(Record):
+    """A DBN version 1 symbol mapping message which maps a symbol of one `SType`
+    to another.
+    """
+
+    @property
+    def stype_in_symbol(self) -> str:
+        """
+        The input symbol.
+
+        Returns
+        -------
+        str
 
         """
     @property

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.14.0"
+version = "0.14.1"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.14.0"
+version = "0.14.1"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3,6 +3,7 @@
 use pyo3::{prelude::*, wrap_pyfunction, PyClass};
 
 use dbn::{
+    compat::{InstrumentDefMsgV1, SymbolMappingMsgV1},
     enums::{Compression, Encoding, SType, Schema},
     flags,
     python::EnumIterator,
@@ -10,8 +11,8 @@ use dbn::{
         BidAskPair, ErrorMsg, ImbalanceMsg, InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg,
         RecordHeader, StatMsg, StatusMsg, SymbolMappingMsg, SystemMsg, TradeMsg,
     },
-    Metadata, RType, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_STAT_QUANTITY,
-    UNDEF_TIMESTAMP,
+    Metadata, RType, VersionUpgradePolicy, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE,
+    UNDEF_STAT_QUANTITY, UNDEF_TIMESTAMP,
 };
 
 mod dbn_decoder;
@@ -44,16 +45,19 @@ fn databento_dbn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     checked_add_class::<ImbalanceMsg>(m)?;
     checked_add_class::<StatusMsg>(m)?;
     checked_add_class::<InstrumentDefMsg>(m)?;
+    checked_add_class::<InstrumentDefMsgV1>(m)?;
     checked_add_class::<ErrorMsg>(m)?;
     checked_add_class::<SymbolMappingMsg>(m)?;
+    checked_add_class::<SymbolMappingMsgV1>(m)?;
     checked_add_class::<SystemMsg>(m)?;
     checked_add_class::<StatMsg>(m)?;
     // PyClass enums
     checked_add_class::<Compression>(m)?;
     checked_add_class::<Encoding>(m)?;
-    checked_add_class::<Schema>(m)?;
-    checked_add_class::<SType>(m)?;
     checked_add_class::<RType>(m)?;
+    checked_add_class::<SType>(m)?;
+    checked_add_class::<Schema>(m)?;
+    checked_add_class::<VersionUpgradePolicy>(m)?;
     // constants
     m.add("FIXED_PRICE_SCALE", FIXED_PRICE_SCALE)?;
     m.add("UNDEF_PRICE", UNDEF_PRICE)?;

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dbn-cli"
 authors = ["Databento <support@databento.com>"]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Command-line utility for converting Databento Binary Encoding (DBN) files to text-based formats"
 default-run = "dbn"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Databento common DBN library
-dbn = { path = "../dbn", version = "=0.14.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.14.1", default-features = false }
 
 # Error handling
 anyhow = "1.0"

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dbn-macros"
 authors = ["Databento <support@databento.com>"]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Proc macros for dbn crate"
 license = "Apache-2.0"

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dbn"
 authors = ["Databento <support@databento.com>"]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Library for working with Databento Binary Encoding (DBN)"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.14.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.14.1", path = "../dbn-macros" }
 
 # async (de)compression
 async-compression = { version = "0.4.4", features = ["tokio", "zstd"], optional = true }

--- a/rust/dbn/src/compat.rs
+++ b/rust/dbn/src/compat.rs
@@ -4,8 +4,8 @@ use std::os::raw::c_char;
 use crate::{
     macros::{dbn_record, CsvSerialize, JsonSerialize},
     record::{transmute_header_bytes, transmute_record_bytes},
-    rtype, InstrumentDefMsg, RecordHeader, RecordRef, SecurityUpdateAction, SymbolMappingMsg,
-    UserDefinedInstrument, VersionUpgradePolicy,
+    rtype, HasRType, InstrumentDefMsg, RecordHeader, RecordRef, SecurityUpdateAction,
+    SymbolMappingMsg, UserDefinedInstrument, VersionUpgradePolicy,
 };
 
 // Dummy derive macro to get around `cfg_attr` incompatibility of several
@@ -448,6 +448,65 @@ impl From<&SymbolMappingMsgV1> for SymbolMappingMsg {
             );
         }
         res
+    }
+}
+
+/// A trait for symbol mapping records.
+pub trait SymbolMappingRec: HasRType {
+    /// Returns the input symbol as a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `stype_in_symbol` contains invalid UTF-8.
+    fn stype_in_symbol(&self) -> crate::Result<&str>;
+
+    /// Returns the output symbol as a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `stype_out_symbol` contains invalid UTF-8.
+    fn stype_out_symbol(&self) -> crate::Result<&str>;
+
+    /// Parses the raw start of the mapping interval into a datetime. Returns `None` if
+    /// `start_ts` contains the sentinel for a null timestamp.
+    fn start_ts(&self) -> Option<time::OffsetDateTime>;
+
+    /// Parses the raw end of the mapping interval into a datetime. Returns `None` if
+    /// `end_ts` contains the sentinel for a null timestamp.
+    fn end_ts(&self) -> Option<time::OffsetDateTime>;
+}
+
+impl SymbolMappingRec for SymbolMappingMsgV1 {
+    fn stype_in_symbol(&self) -> crate::Result<&str> {
+        Self::stype_in_symbol(self)
+    }
+
+    fn stype_out_symbol(&self) -> crate::Result<&str> {
+        Self::stype_out_symbol(self)
+    }
+
+    fn start_ts(&self) -> Option<time::OffsetDateTime> {
+        Self::start_ts(self)
+    }
+
+    fn end_ts(&self) -> Option<time::OffsetDateTime> {
+        Self::end_ts(self)
+    }
+}
+
+impl SymbolMappingRec for SymbolMappingMsgV2 {
+    fn stype_in_symbol(&self) -> crate::Result<&str> {
+        Self::stype_in_symbol(self)
+    }
+
+    fn stype_out_symbol(&self) -> crate::Result<&str> {
+        Self::stype_out_symbol(self)
+    }
+
+    fn start_ts(&self) -> Option<time::OffsetDateTime> {
+        Self::start_ts(self)
+    }
+
+    fn end_ts(&self) -> Option<time::OffsetDateTime> {
+        Self::end_ts(self)
     }
 }
 

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -8,11 +8,12 @@ use pyo3::{
 };
 
 use crate::{
-    record::str_to_c_chars, rtype, BidAskPair, ErrorMsg, HasRType, ImbalanceMsg, InstrumentDefMsg,
-    MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Record, RecordHeader, SType, SecurityUpdateAction,
-    StatMsg, StatUpdateAction, StatusMsg, SymbolMappingMsg, SystemMsg, TradeMsg,
-    UserDefinedInstrument, WithTsOut, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE,
-    UNDEF_TIMESTAMP,
+    compat::{InstrumentDefMsgV1, SymbolMappingMsgV1},
+    record::str_to_c_chars,
+    rtype, BidAskPair, ErrorMsg, HasRType, ImbalanceMsg, InstrumentDefMsg, MboMsg, Mbp10Msg,
+    Mbp1Msg, OhlcvMsg, Record, RecordHeader, SType, SecurityUpdateAction, StatMsg,
+    StatUpdateAction, StatusMsg, SymbolMappingMsg, SystemMsg, TradeMsg, UserDefinedInstrument,
+    WithTsOut, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
 };
 
 use super::{to_val_err, PyFieldDesc};
@@ -1289,6 +1290,418 @@ impl InstrumentDefMsg {
 }
 
 #[pymethods]
+impl InstrumentDefMsgV1 {
+    #[new]
+    fn py_new(
+        publisher_id: u16,
+        instrument_id: u32,
+        ts_event: u64,
+        ts_recv: u64,
+        min_price_increment: i64,
+        display_factor: i64,
+        min_lot_size_round_lot: i32,
+        raw_symbol: &str,
+        group: &str,
+        exchange: &str,
+        instrument_class: c_char,
+        match_algorithm: c_char,
+        md_security_trading_status: u8,
+        security_update_action: SecurityUpdateAction,
+        expiration: Option<u64>,
+        activation: Option<u64>,
+        high_limit_price: Option<i64>,
+        low_limit_price: Option<i64>,
+        max_price_variation: Option<i64>,
+        trading_reference_price: Option<i64>,
+        unit_of_measure_qty: Option<i64>,
+        min_price_increment_amount: Option<i64>,
+        price_ratio: Option<i64>,
+        inst_attrib_value: Option<i32>,
+        underlying_id: Option<u32>,
+        raw_instrument_id: Option<u32>,
+        market_depth_implied: Option<i32>,
+        market_depth: Option<i32>,
+        market_segment_id: Option<u32>,
+        max_trade_vol: Option<u32>,
+        min_lot_size: Option<i32>,
+        min_lot_size_block: Option<i32>,
+        min_trade_vol: Option<u32>,
+        contract_multiplier: Option<i32>,
+        decay_quantity: Option<i32>,
+        original_contract_size: Option<i32>,
+        trading_reference_date: Option<u16>,
+        appl_id: Option<i16>,
+        maturity_year: Option<u16>,
+        decay_start_date: Option<u16>,
+        channel_id: Option<u16>,
+        currency: Option<&str>,
+        settl_currency: Option<&str>,
+        secsubtype: Option<&str>,
+        asset: Option<&str>,
+        cfi: Option<&str>,
+        security_type: Option<&str>,
+        unit_of_measure: Option<&str>,
+        underlying: Option<&str>,
+        strike_price_currency: Option<&str>,
+        strike_price: Option<i64>,
+        main_fraction: Option<u8>,
+        price_display_format: Option<u8>,
+        settl_price_type: Option<u8>,
+        sub_fraction: Option<u8>,
+        underlying_product: Option<u8>,
+        maturity_month: Option<u8>,
+        maturity_day: Option<u8>,
+        maturity_week: Option<u8>,
+        user_defined_instrument: Option<UserDefinedInstrument>,
+        contract_multiplier_unit: Option<i8>,
+        flow_schedule_type: Option<i8>,
+        tick_rule: Option<u8>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            hd: RecordHeader::new::<Self>(
+                rtype::INSTRUMENT_DEF,
+                publisher_id,
+                instrument_id,
+                ts_event,
+            ),
+            ts_recv,
+            min_price_increment,
+            display_factor,
+            expiration: expiration.unwrap_or(UNDEF_TIMESTAMP),
+            activation: activation.unwrap_or(UNDEF_TIMESTAMP),
+            high_limit_price: high_limit_price.unwrap_or(UNDEF_PRICE),
+            low_limit_price: low_limit_price.unwrap_or(UNDEF_PRICE),
+            max_price_variation: max_price_variation.unwrap_or(UNDEF_PRICE),
+            trading_reference_price: trading_reference_price.unwrap_or(UNDEF_PRICE),
+            unit_of_measure_qty: unit_of_measure_qty.unwrap_or(i64::MAX),
+            min_price_increment_amount: min_price_increment_amount.unwrap_or(UNDEF_PRICE),
+            price_ratio: price_ratio.unwrap_or(UNDEF_PRICE),
+            inst_attrib_value: inst_attrib_value.unwrap_or(i32::MAX),
+            underlying_id: underlying_id.unwrap_or_default(),
+            raw_instrument_id: raw_instrument_id.unwrap_or(instrument_id),
+            market_depth_implied: market_depth_implied.unwrap_or(i32::MAX),
+            market_depth: market_depth.unwrap_or(i32::MAX),
+            market_segment_id: market_segment_id.unwrap_or(u32::MAX),
+            max_trade_vol: max_trade_vol.unwrap_or(u32::MAX),
+            min_lot_size: min_lot_size.unwrap_or(i32::MAX),
+            min_lot_size_block: min_lot_size_block.unwrap_or(i32::MAX),
+            min_lot_size_round_lot,
+            min_trade_vol: min_trade_vol.unwrap_or(u32::MAX),
+            contract_multiplier: contract_multiplier.unwrap_or(i32::MAX),
+            decay_quantity: decay_quantity.unwrap_or(i32::MAX),
+            original_contract_size: original_contract_size.unwrap_or(i32::MAX),
+            trading_reference_date: trading_reference_date.unwrap_or(u16::MAX),
+            appl_id: appl_id.unwrap_or(i16::MAX),
+            maturity_year: maturity_year.unwrap_or(u16::MAX),
+            decay_start_date: decay_start_date.unwrap_or(u16::MAX),
+            channel_id: channel_id.unwrap_or(u16::MAX),
+            currency: str_to_c_chars(currency.unwrap_or_default()).map_err(to_val_err)?,
+            settl_currency: str_to_c_chars(settl_currency.unwrap_or_default())
+                .map_err(to_val_err)?,
+            secsubtype: str_to_c_chars(secsubtype.unwrap_or_default()).map_err(to_val_err)?,
+            raw_symbol: str_to_c_chars(raw_symbol).map_err(to_val_err)?,
+            group: str_to_c_chars(group).map_err(to_val_err)?,
+            exchange: str_to_c_chars(exchange).map_err(to_val_err)?,
+            asset: str_to_c_chars(asset.unwrap_or_default()).map_err(to_val_err)?,
+            cfi: str_to_c_chars(cfi.unwrap_or_default()).map_err(to_val_err)?,
+            security_type: str_to_c_chars(security_type.unwrap_or_default()).map_err(to_val_err)?,
+            unit_of_measure: str_to_c_chars(unit_of_measure.unwrap_or_default())
+                .map_err(to_val_err)?,
+            underlying: str_to_c_chars(underlying.unwrap_or_default()).map_err(to_val_err)?,
+            strike_price_currency: str_to_c_chars(strike_price_currency.unwrap_or_default())
+                .map_err(to_val_err)?,
+            instrument_class,
+            strike_price: strike_price.unwrap_or(UNDEF_PRICE),
+            match_algorithm,
+            md_security_trading_status,
+            main_fraction: main_fraction.unwrap_or(u8::MAX),
+            price_display_format: price_display_format.unwrap_or(u8::MAX),
+            settl_price_type: settl_price_type.unwrap_or(u8::MAX),
+            sub_fraction: sub_fraction.unwrap_or(u8::MAX),
+            underlying_product: underlying_product.unwrap_or(u8::MAX),
+            security_update_action,
+            maturity_month: maturity_month.unwrap_or(u8::MAX),
+            maturity_day: maturity_day.unwrap_or(u8::MAX),
+            maturity_week: maturity_week.unwrap_or(u8::MAX),
+            user_defined_instrument: user_defined_instrument.unwrap_or_default(),
+            contract_multiplier_unit: contract_multiplier_unit.unwrap_or(i8::MAX),
+            flow_schedule_type: flow_schedule_type.unwrap_or(i8::MAX),
+            tick_rule: tick_rule.unwrap_or(u8::MAX),
+            _reserved2: Default::default(),
+            _reserved3: Default::default(),
+            _reserved4: Default::default(),
+            _reserved5: Default::default(),
+            _dummy: Default::default(),
+        })
+    }
+
+    fn __bytes__(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self:?}")
+    }
+
+    #[getter]
+    fn rtype(&self) -> u8 {
+        self.hd.rtype
+    }
+
+    #[getter]
+    fn publisher_id(&self) -> u16 {
+        self.hd.publisher_id
+    }
+
+    #[getter]
+    fn instrument_id(&self) -> u32 {
+        self.hd.instrument_id
+    }
+
+    #[getter]
+    fn ts_event(&self) -> u64 {
+        self.hd.ts_event
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_min_price_increment")]
+    fn py_pretty_min_price_increment(&self) -> f64 {
+        self.min_price_increment as f64 / FIXED_PRICE_SCALE as f64
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_high_limit_price")]
+    fn py_pretty_high_limit_price(&self) -> f64 {
+        match self.high_limit_price {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.high_limit_price as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_low_limit_price")]
+    fn py_pretty_low_limit_price(&self) -> f64 {
+        match self.low_limit_price {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.low_limit_price as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_max_price_variation")]
+    fn py_pretty_max_price_variation(&self) -> f64 {
+        match self.max_price_variation {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.max_price_variation as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_trading_reference_price")]
+    fn py_pretty_trading_reference_price(&self) -> f64 {
+        match self.trading_reference_price {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.trading_reference_price as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_min_price_increment_amount")]
+    fn py_pretty_min_price_increment_amount(&self) -> f64 {
+        match self.min_price_increment_amount {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.min_price_increment_amount as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_price_ratio")]
+    fn py_pretty_price_ratio(&self) -> f64 {
+        match self.price_ratio {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.price_ratio as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_strike_price")]
+    fn py_pretty_strike_price(&self) -> f64 {
+        match self.strike_price {
+            UNDEF_PRICE => f64::NAN,
+            _ => self.strike_price as f64 / FIXED_PRICE_SCALE as f64,
+        }
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_ts_event")]
+    fn py_pretty_ts_event(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.ts_event())
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_ts_recv")]
+    fn py_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.ts_recv)
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_activation")]
+    fn py_pretty_activation(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.expiration)
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_expiration")]
+    fn py_pretty_expiration(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.expiration)
+    }
+
+    #[pyo3(name = "record_size")]
+    fn py_record_size(&self) -> usize {
+        self.record_size()
+    }
+
+    #[classattr]
+    fn size_hint() -> PyResult<usize> {
+        Ok(mem::size_of::<InstrumentDefMsg>())
+    }
+
+    #[getter]
+    #[pyo3(name = "currency")]
+    fn py_currency(&self) -> PyResult<&str> {
+        self.currency().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "settl_currency")]
+    fn py_settl_currency(&self) -> PyResult<&str> {
+        self.settl_currency().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "secsubtype")]
+    fn py_secsubtype(&self) -> PyResult<&str> {
+        self.secsubtype().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "raw_symbol")]
+    fn py_raw_symbol(&self) -> PyResult<&str> {
+        self.raw_symbol().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "group")]
+    fn py_group(&self) -> PyResult<&str> {
+        self.group().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "exchange")]
+    fn py_exchange(&self) -> PyResult<&str> {
+        self.exchange().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "asset")]
+    fn py_asset(&self) -> PyResult<&str> {
+        self.asset().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "cfi")]
+    fn py_cfi(&self) -> PyResult<&str> {
+        self.cfi().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "security_type")]
+    fn py_security_type(&self) -> PyResult<&str> {
+        self.security_type().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "unit_of_measure")]
+    fn py_unit_of_measure(&self) -> PyResult<&str> {
+        self.unit_of_measure().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "underlying")]
+    fn py_underlying(&self) -> PyResult<&str> {
+        self.underlying().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "strike_price_currency")]
+    fn py_strike_price_currency(&self) -> PyResult<&str> {
+        self.strike_price_currency().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "instrument_class")]
+    fn py_instrument_class(&self) -> char {
+        self.instrument_class as u8 as char
+    }
+
+    #[getter]
+    #[pyo3(name = "match_algorithm")]
+    fn py_match_algorithm(&self) -> char {
+        self.match_algorithm as u8 as char
+    }
+
+    #[getter]
+    #[pyo3(name = "security_update_action")]
+    fn py_security_update_action(&self) -> char {
+        self.security_update_action as u8 as char
+    }
+
+    #[getter]
+    #[pyo3(name = "user_defined_instrument")]
+    fn py_user_defined_instrument(&self) -> char {
+        self.user_defined_instrument as u8 as char
+    }
+
+    #[classattr]
+    #[pyo3(name = "_dtypes")]
+    fn py_dtypes() -> Vec<(String, String)> {
+        Self::field_dtypes("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_price_fields")]
+    fn py_price_fields() -> Vec<String> {
+        Self::price_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_timestamp_fields")]
+    fn py_timestamp_fields() -> Vec<String> {
+        Self::timestamp_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_hidden_fields")]
+    fn py_hidden_fields() -> Vec<String> {
+        Self::hidden_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_ordered_fields")]
+    fn py_ordered_fields() -> Vec<String> {
+        Self::ordered_fields("")
+    }
+}
+
+#[pymethods]
 impl ImbalanceMsg {
     #[new]
     fn py_new(
@@ -1806,6 +2219,140 @@ impl SymbolMappingMsg {
     #[pyo3(name = "stype_out")]
     fn py_stype_out(&self) -> PyResult<SType> {
         self.stype_out().map_err(to_val_err)
+    }
+
+    #[getter]
+    #[pyo3(name = "stype_out_symbol")]
+    fn py_stype_out_symbol(&self) -> PyResult<&str> {
+        self.stype_out_symbol().map_err(to_val_err)
+    }
+
+    #[classattr]
+    #[pyo3(name = "_dtypes")]
+    fn py_dtypes() -> Vec<(String, String)> {
+        Self::field_dtypes("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_price_fields")]
+    fn py_price_fields() -> Vec<String> {
+        Self::price_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_timestamp_fields")]
+    fn py_timestamp_fields() -> Vec<String> {
+        Self::timestamp_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_hidden_fields")]
+    fn py_hidden_fields() -> Vec<String> {
+        Self::hidden_fields("")
+    }
+
+    #[classattr]
+    #[pyo3(name = "_ordered_fields")]
+    fn py_ordered_fields() -> Vec<String> {
+        Self::ordered_fields("")
+    }
+}
+
+#[pymethods]
+impl SymbolMappingMsgV1 {
+    #[new]
+    fn py_new(
+        publisher_id: u16,
+        instrument_id: u32,
+        ts_event: u64,
+        stype_in_symbol: &str,
+        stype_out_symbol: &str,
+        start_ts: u64,
+        end_ts: u64,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            hd: RecordHeader::new::<Self>(
+                rtype::SYMBOL_MAPPING,
+                publisher_id,
+                instrument_id,
+                ts_event,
+            ),
+            stype_in_symbol: str_to_c_chars(stype_in_symbol).map_err(to_val_err)?,
+            stype_out_symbol: str_to_c_chars(stype_out_symbol).map_err(to_val_err)?,
+            start_ts,
+            end_ts,
+            _dummy: Default::default(),
+        })
+    }
+
+    fn __bytes__(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+        match op {
+            CompareOp::Eq => self.eq(other).into_py(py),
+            CompareOp::Ne => self.ne(other).into_py(py),
+            _ => py.NotImplemented(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self:?}")
+    }
+
+    #[getter]
+    fn rtype(&self) -> u8 {
+        self.hd.rtype
+    }
+
+    #[getter]
+    fn publisher_id(&self) -> u16 {
+        self.hd.publisher_id
+    }
+
+    #[getter]
+    fn instrument_id(&self) -> u32 {
+        self.hd.instrument_id
+    }
+
+    #[getter]
+    fn ts_event(&self) -> u64 {
+        self.hd.ts_event
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_ts_event")]
+    fn py_pretty_ts_event(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.ts_event())
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_end_ts")]
+    fn py_pretty_end_ts(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.end_ts)
+    }
+
+    #[getter]
+    #[pyo3(name = "pretty_start_ts")]
+    fn py_pretty_start_ts(&self, py: Python<'_>) -> PyResult<PyObject> {
+        get_utc_nanosecond_timestamp(py, self.start_ts)
+    }
+
+    #[pyo3(name = "record_size")]
+    fn py_record_size(&self) -> usize {
+        self.record_size()
+    }
+
+    #[classattr]
+    fn size_hint() -> PyResult<usize> {
+        Ok(mem::size_of::<SymbolMappingMsg>())
+    }
+
+    #[getter]
+    #[pyo3(name = "stype_in_symbol")]
+    fn py_stype_in_symbol(&self) -> PyResult<&str> {
+        self.stype_in_symbol().map_err(to_val_err)
     }
 
     #[getter]


### PR DESCRIPTION
### Enhancements
- Added new trait `compat::SymbolMappingRec` for code reuse when working with
  both versions of `SymbolMappingMsg`
- Changed `PitSymbolMap::on_symbol_mapping` to accept either version of
  `SymbolMappingMsg`


### Bug fixes
- Fixed missing DBNv1 compatibility in `PitSymbolMap::on_record`
- Fixed missing Python export for `VersionUpgradePolicy`
- Fixed missing Python export and methods for `InstrumentDefMsgV1` and
  `SymbolMappingMsgV1`
- Fixed bug where Python `DbnDecoder` and `Transcoder` would throw exceptions
  when attempting to decode partial metadata
