### PR TITLE
Add serde arrow

### DIFF
--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -53,6 +53,9 @@ time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 # (de)compression
 zstd = "0.13"
+serde_arrow = { version = "0.8.0", features = ["arrow-45"]}
+polars = { version = "0.35.4", features = ["parquet", "dtype-struct", "dtype-u8", "dtype-i8", "dtype-u16", "lazy", "streaming"] }
+polars-core = { version = "0.35.4", features = ["arrow_rs"] }
 
 [dev-dependencies]
 # Parameterized testing

--- a/rust/dbn/examples/serde-example.rs
+++ b/rust/dbn/examples/serde-example.rs
@@ -1,0 +1,83 @@
+use dbn::decode::DecodeDbn;
+use dbn::{decode::dbn::Decoder, record::MboMsg};
+use polars::io::parquet::ZstdLevel;
+use polars::prelude::IntoLazy;
+use streaming_iterator::StreamingIterator;
+
+fn main() -> Result<(), dbn::Error> {
+    let dbn_stream = Decoder::from_zstd_file("../../tests/data/test_data.mbo.dbn.zst")?;
+    let mut iter = dbn_stream.decode_stream::<MboMsg>();
+
+    let mut stack = vec![];
+    while let Some(mbo_msg) = iter.next() {
+        println!("{mbo_msg:#?}");
+        stack.push(mbo_msg.clone());
+    }
+
+    let fields = serde_arrow::arrow::serialize_into_fields(
+        &stack,
+        serde_arrow::schema::TracingOptions {
+            allow_null_fields: true,
+            map_as_struct: false,
+            string_dictionary_encoding: false,
+            coerce_numbers: false,
+            try_parse_dates: true,
+        },
+    )
+    .unwrap();
+    println!("{fields:#?}");
+    let arrays = serde_arrow::arrow::serialize_into_arrays(&fields, &stack).unwrap();
+    let columns_func = |arrays| {
+        fields
+            .iter()
+            .zip(arrays)
+            .map(|(f, arr)| polars::series::Series::from_arrow_rs(f.name(), &arr).unwrap())
+    };
+
+    let df = polars::frame::DataFrame::new(columns_func(arrays.clone()).collect()).unwrap();
+    println!("{df}");
+    df.lazy()
+        .sink_parquet(
+            "./df.parquet".into(),
+            polars::prelude::ParquetWriteOptions {
+                compression: polars::io::parquet::ParquetCompression::Zstd(Some(ZstdLevel::try_new(15).unwrap())),
+                statistics: true,
+                row_group_size: None,
+                data_pagesize_limit: None,
+                maintain_order: false
+            },
+        )
+        .unwrap();
+
+    // flatten df
+
+    let func = |i: polars::series::Series| match i.struct_() {
+        Ok(i) => i
+            .clone()
+            .unnest()
+            .iter()
+            .map(|i| i.clone())
+            .collect::<Vec<_>>(),
+        _ => vec![i],
+    };
+
+    let df2 =
+        polars::frame::DataFrame::new(columns_func(arrays.clone()).map(func).flatten().collect())
+            .unwrap();
+    println!("{df2}");
+
+    df2.lazy()
+        .sink_parquet(
+            "./df2.parquet".into(),
+            polars::prelude::ParquetWriteOptions {
+                compression: polars::io::parquet::ParquetCompression::Zstd(Some(ZstdLevel::try_new(15).unwrap())),
+                statistics: true,
+                row_group_size: None,
+                data_pagesize_limit: None,
+                maintain_order: false
+            },
+        )
+        .unwrap();
+
+    Ok(())
+}

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -38,6 +38,7 @@ pub use conv::{
     pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(test, derive(type_layout::TypeLayout))]
 pub struct RecordHeader {
     /// The length of the record in 32-bit words.
@@ -62,6 +63,7 @@ pub struct RecordHeader {
 /// [`Mbo`](crate::enums::Schema::Mbo) schema.
 #[repr(C)]
 #[derive(Clone, Debug, CsvSerialize, JsonSerialize, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "trivial_copy", derive(Copy))]
 #[cfg_attr(
     feature = "python",


### PR DESCRIPTION
# Pull Request

This adds `serde` support to `MBO` and `RecordHeader` data types, and an example that shows the example usage of this implementation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested?

No tests, just an example.

