### PR TITLE
VER: Release 0.16.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -30,7 +30,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -81,7 +81,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -114,11 +114,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -128,7 +128,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -34,7 +34,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -73,11 +73,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -87,7 +87,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -118,11 +118,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -132,7 +132,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -159,11 +159,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -173,7 +173,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -200,11 +200,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -214,7 +214,7 @@ jobs:
 
       # Python setup
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -277,11 +277,11 @@ jobs:
       ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cargo setup
       - name: Set up Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   it's not a price, it uses the same fixed-price decimal format as other prices
 - Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions
   without breaking changes
+- Renamed `_dummy` field in `ImbalanceMsg` and `StatMsg` to `_reserved`
 
 ### Bug fixes
 - Added missing `StatType::Vwap` variant used in the ICE datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Changed default for `VersionUpgradePolicy` to `Upgrade`
 - Changed default `upgrade_policy` for `DbnDecoder`, `AsyncDbnDecoder`, and Python
   `DBNDecoder` to `Upgrade` so by default the primary record types can always be used
+- Changed text serialization `unit_of_measure_qty` to be affected by `pretty_px`. While
+  it's not a price, it uses the same fixed-price decimal format as other prices
 - Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions
   without breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
 - Document cancellation safety for `AsyncRecordDecoder::decode_ref` (credit: @yongqli)
 - Added new publisher values for consolidated DBEQ.MAX
+- Upgraded `async-compression` to 0.4.6
+- Upgraded `strum` to 0.26
 
 ### Breaking changes
 - Changed default for `VersionUpgradePolicy` to `Upgrade`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
     to forget
 - Added `-s`/`--map-symbols` flag to CLI to create a `symbol` field in the output with
   the text symbol mapped from the instrument ID
-- Added `version` param to Python `Metadata` contructor choose between DBNv1 and DBNv2
+- Added `version` param to Python `Metadata` constructor choose between DBNv1 and DBNv2
 - Implemented `EncodeRecordTextExt` for `DynEncoder`
 - Implemented `Deserialize` and `Serialize` for all records and enums (with `serde`
   feature enabled). This allows serializing records with additional encodings not
@@ -125,7 +125,7 @@
   `dbn::AsyncRecordDecoder::decode`, and `dbn::AsyncRecordDecoder::decode_ref`
   cancellation safe. This makes them safe to use within a
   `tokio::select!`(https://docs.rs/tokio/latest/tokio/macro.select.html) statement
-- Added documention around cancellation safety for async APIs
+- Added documentation around cancellation safety for async APIs
 - Improved error messages for conversion errors
 - Added `TOB` flag to denote top-of-book messages
 - Added new publisher values in preparation for IFEU.IMPACT and NDEX.IMPACT datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.0 - TBD
+## 0.16.0 - 2024-03-01
 ### Enhancements
 - Updated `StatusMsg` and made it public in preparation for releasing a status schema
 - Added `StatusAction`, `StatusReason`, `TradingEvent`, and `TriState` enums for use in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## 0.16.0 - TBD
+### Enhancements
+- Added `-t` and `--tsv` flags to DBN CLI to encode tab-separated values (TSV)
+- Added `delimiter` method to builders for `DynEncoder` and `CsvEncoder` to customize the
+  field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
 
 ### Breaking changes
 - Changed default for `VersionUpgradePolicy` to `Upgrade`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
 - Document cancellation safety for `AsyncRecordDecoder::decode_ref` (credit: @yongqli)
 - Added new publisher values for consolidated DBEQ.MAX
+- Added C FFI conversion functions from `ErrorMsgV1` to `ErrorMsg` and `SystemMsgV1`
+  to `SystemMsg`
 - Upgraded `async-compression` to 0.4.6
 - Upgraded `strum` to 0.26
 
@@ -24,10 +26,14 @@
 - Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions
   without breaking changes
 - Renamed `_dummy` field in `ImbalanceMsg` and `StatMsg` to `_reserved`
+- Added `ts_out` parameter to `RecordDecoder` and `AsyncRecordDecoder`
+  `with_upgrade_policy` methods
 
 ### Bug fixes
+- Fixed handling of `ts_out` when upgrading DBNv1 records to version 2
 - Added missing `StatType::Vwap` variant used in the ICE datasets
 - Fixed an issue with Python stub file distribution
+- Fixed missing handling of `ErrorMsgV1` and `SystemMsgV1` in `rtype` dispatch macros
 
 ## 0.15.1 - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 - Added missing `StatType::Vwap` variant used in the ICE datasets
+- Fixed an issue with Python stub file distribution
 
 ## 0.15.1 - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.16.0 - TBD
 ### Enhancements
+- Updated `StatusMsg` and made it public in preparation for releasing a status schema
+- Added `StatusAction`, `StatusReason`, `TradingEvent`, and `TriState` enums for use in
+  the status schema
 - Added `-t` and `--tsv` flags to DBN CLI to encode tab-separated values (TSV)
 - Added `delimiter` method to builders for `DynEncoder` and `CsvEncoder` to customize the
   field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
@@ -11,6 +14,8 @@
 - Changed default for `VersionUpgradePolicy` to `Upgrade`
 - Changed default `upgrade_policy` for `DbnDecoder`, `AsyncDbnDecoder`, and Python
   `DBNDecoder` to `Upgrade` so by default the primary record types can always be used
+- Changed fields of previously-hidden `StatusMsg` record type
+- Updated text serialization order of status schema to match other schemas
 - Changed text serialization `unit_of_measure_qty` to be affected by `pretty_px`. While
   it's not a price, it uses the same fixed-price decimal format as other prices
 - Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Made `VersionUpgradePolicy` non-exhaustive to allow future additions without breaking
   changes
 
+### Bug fixes
+- Added missing `StatType::Vwap` variant used in the ICE datasets
+
 ## 0.15.1 - 2024-01-23
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `-t` and `--tsv` flags to DBN CLI to encode tab-separated values (TSV)
 - Added `delimiter` method to builders for `DynEncoder` and `CsvEncoder` to customize the
   field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
+- Document cancellation safety for `AsyncRecordDecoder::decode_ref` (credit: @yongqli)
 
 ### Breaking changes
 - Changed default for `VersionUpgradePolicy` to `Upgrade`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `delimiter` method to builders for `DynEncoder` and `CsvEncoder` to customize the
   field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
 - Document cancellation safety for `AsyncRecordDecoder::decode_ref` (credit: @yongqli)
+- Added new publisher values for consolidated DBEQ.MAX
 
 ### Breaking changes
 - Changed default for `VersionUpgradePolicy` to `Upgrade`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added new publisher values for consolidated DBEQ.MAX
 - Added C FFI conversion functions from `ErrorMsgV1` to `ErrorMsg` and `SystemMsgV1`
   to `SystemMsg`
+- Improved documentation for `side` field and `Side` enum
 - Upgraded `async-compression` to 0.4.6
 - Upgraded `strum` to 0.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Changed default for `VersionUpgradePolicy` to `Upgrade`
 - Changed default `upgrade_policy` for `DbnDecoder`, `AsyncDbnDecoder`, and Python
   `DBNDecoder` to `Upgrade` so by default the primary record types can always be used
-- Made `VersionUpgradePolicy` non-exhaustive to allow future additions without breaking
-  changes
+- Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions
+  without breaking changes
 
 ### Bug fixes
 - Added missing `StatType::Vwap` variant used in the ICE datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.16.0 - TBD
+
+### Breaking changes
+- Changed default for `VersionUpgradePolicy` to `Upgrade`
+- Changed default `upgrade_policy` for `DbnDecoder`, `AsyncDbnDecoder`, and Python
+  `DBNDecoder` to `Upgrade` so by default the primary record types can always be used
+- Made `VersionUpgradePolicy` non-exhaustive to allow future additions without breaking
+  changes
+
 ## 0.15.1 - 2024-01-23
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.7"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -76,15 +76,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
 dependencies = [
  "anstyle",
  "bstr",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
  "futures-core",
  "memchr",
@@ -147,15 +147,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -188,11 +188,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -204,9 +203,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.16"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -214,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.16"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -227,21 +226,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -337,7 +336,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
  "trybuild",
 ]
 
@@ -362,12 +361,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"
@@ -456,7 +449,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -473,9 +466,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -527,9 +520,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
 name = "indexmap"
@@ -543,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -558,28 +551,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "json-writer"
@@ -593,15 +568,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -645,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -659,10 +634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-traits"
-version = "0.2.17"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -695,7 +676,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -750,9 +731,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "powerfmt"
@@ -762,14 +749,13 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
  "float-cmp",
- "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -793,33 +779,34 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.0",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -828,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -838,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -848,26 +835,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -890,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -902,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -948,7 +936,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.48",
+ "syn 2.0.51",
  "unicode-ident",
 ]
 
@@ -969,11 +957,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.29"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1a81a2478639a14e68937903356dbac62cf52171148924f754bb8a8cd7a96c"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -988,9 +976,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -1000,35 +988,35 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1046,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "streaming-iterator"
@@ -1058,30 +1046,30 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1097,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1108,19 +1096,18 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1152,32 +1139,33 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -1192,18 +1180,19 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1220,7 +1209,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1240,20 +1229,20 @@ checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "trybuild"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76de4f783e610194f6c98bfd53f9fc52bb2e0d02c947621e8a0f4ecc799b2880"
+checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
 dependencies = [
  "basic-toml",
  "glob",
@@ -1358,7 +1347,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1378,17 +1367,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1399,9 +1388,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1411,9 +1400,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1423,9 +1412,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1435,9 +1424,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1447,9 +1436,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1459,9 +1448,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1471,15 +1460,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,11 @@ members = [
   "rust/dbn"
 ]
 resolver = "2"
+
+[workspace.package]
+authors = ["Databento <support@databento.com>"]
+edition = "2021"
+version = "0.15.1"
+documentation = "https://docs.databento.com"
+repository = "https://github.com/databento/dbn"
+license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.15.1"
+version = "0.16.0"
 documentation = "https://docs.databento.com"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -14,10 +14,10 @@ name = "dbn_c"
 crate-type = ["staticlib"]
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0.80"
 # DBN library
 dbn = { path = "../rust/dbn", features = [] }
-libc = "0.2.152"
+libc = "0.2.153"
 
 [build-dependencies]
 cbindgen = { version = "0.26.0", default-features = false }

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dbn-c"
-authors = ["Databento <support@databento.com>"]
-version = "0.15.0"
-edition = "2021"
 description = "C bindings for working with Databento Binary Encoding (DBN)"
-license = "Apache-2.0"
-repository = "https://github.com/databento/dbn"
 # This crate should not be published
 publish = false
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 name = "dbn_c"

--- a/c/src/compat.rs
+++ b/c/src/compat.rs
@@ -1,7 +1,13 @@
 use dbn::{
-    compat::{InstrumentDefMsgV1, SymbolMappingMsgV1},
-    InstrumentDefMsg, SymbolMappingMsg,
+    compat::{ErrorMsgV1, InstrumentDefMsgV1, SymbolMappingMsgV1, SystemMsgV1},
+    ErrorMsg, InstrumentDefMsg, SymbolMappingMsg, SystemMsg,
 };
+
+/// Converts an V1 ErrorMsg to V2.
+#[no_mangle]
+pub extern "C" fn from_error_v1_to_v2(def_v1: &ErrorMsgV1) -> ErrorMsg {
+    ErrorMsg::from(def_v1)
+}
 
 /// Converts an V1 InstrumentDefMsg to V2.
 #[no_mangle]
@@ -13,4 +19,10 @@ pub extern "C" fn from_instrument_def_v1_to_v2(def_v1: &InstrumentDefMsgV1) -> I
 #[no_mangle]
 pub extern "C" fn from_symbol_mapping_v1_to_v2(def_v1: &SymbolMappingMsgV1) -> SymbolMappingMsg {
     SymbolMappingMsg::from(def_v1)
+}
+
+/// Converts an V1 SystemMsg to V2.
+#[no_mangle]
+pub extern "C" fn from_system_v1_to_v2(def_v1: &SystemMsgV1) -> SystemMsg {
+    SystemMsg::from(def_v1)
 }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,7 +18,7 @@ dbn = { path = "../rust/dbn", features = ["python"] }
 # Python bindings for Rust
 pyo3 = "0.20"
 # Dates and datetimes
-time = "0.3.31"
+time = "0.3.34"
 
 [build-dependencies]
 pyo3-build-config = { version = "0.20" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "databento-dbn"
-authors = ["Databento <support@databento.com>"]
-version = "0.15.1"
-edition = "2021"
 description = "Python library written in Rust for working with Databento Binary Encoding (DBN)"
-license = "Apache-2.0"
-repository = "https://github.com/databento/dbn"
 # This crate should only be published as a Python package
 publish = false
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 name = "databento_dbn" # Python modules can't contain dashes

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.15.1"
+version = "0.16.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -5,7 +5,9 @@ import datetime as dt
 from collections.abc import Iterable
 from collections.abc import Sequence
 from enum import Enum
-from typing import BinaryIO, ClassVar, Protocol, SupportsBytes, TextIO, TypedDict, Union
+from typing import BinaryIO, ClassVar, SupportsBytes, TextIO, TypedDict, Union
+
+from databento_dbn import SymbolMapping
 
 
 FIXED_PRICE_SCALE: int
@@ -32,33 +34,6 @@ _DBNRecord = Union[
     SystemMsgV1,
     StatMsg,
 ]
-
-class MappingInterval(Protocol):
-    """
-    Represents a symbol mapping over a start and end date range interval.
-
-    Parameters
-    ----------
-    start_date : dt.date
-        The start of the mapping period.
-    end_date : dt.date
-        The end of the mapping period.
-    symbol : str
-        The symbol value.
-
-    """
-
-    start_date: dt.date
-    end_date: dt.date
-    symbol: str
-
-class SymbolMapping(Protocol):
-    """
-    Represents the mappings for one native symbol.
-    """
-
-    raw_symbol: str
-    intervals: Sequence[MappingInterval]
 
 class Compression(Enum):
     """

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -697,7 +697,9 @@ class _MBOBase:
     @property
     def side(self) -> str:
         """
-        The order side. Can be `A`sk, `B`id or `N`one.
+        The side that initiates the event. Can be `A`sk for a sell order (or sell
+        aggressor in a trade), `B`id for a buy order (or buy aggressor in a trade), or
+        `N`one where no side is specified by the original source.
 
         Returns
         -------
@@ -914,7 +916,9 @@ class _MBPBase:
     @property
     def side(self) -> str:
         """
-        The order side. Can be `A`sk, `B`id or `N`one.
+        The side that initiates the event. Can be `A`sk for a sell order (or sell
+        aggressor in a trade), `B`id for a buy order (or buy aggressor in a trade), or
+        `N`one where no side is specified by the original source.
 
         Returns
         -------

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -68,9 +68,13 @@ impl DbnDecoder {
             }
         }
         let mut read_position = self.buffer.position() as usize;
-        let mut decoder =
-            RecordDecoder::with_version(&mut self.buffer, self.input_version, self.upgrade_policy)
-                .map_err(to_val_err)?;
+        let mut decoder = RecordDecoder::with_version(
+            &mut self.buffer,
+            self.input_version,
+            self.upgrade_policy,
+            self.ts_out,
+        )
+        .map_err(to_val_err)?;
         Python::with_gil(|py| -> PyResult<()> {
             while let Some(rec) = decoder.decode_ref().map_err(to_val_err)? {
                 // Bug in clippy generates an error here. trivial_copy feature isn't enabled,

--- a/python/src/transcoder.rs
+++ b/python/src/transcoder.rs
@@ -214,6 +214,7 @@ impl<const OUTPUT_ENC: u8> Inner<OUTPUT_ENC> {
             &mut self.buffer,
             self.input_version,
             self.upgrade_policy,
+            self.ts_out,
         )
         .map_err(to_val_err)?;
         let mut encoder = DbnRecordEncoder::new(&mut self.output);
@@ -246,6 +247,7 @@ impl<const OUTPUT_ENC: u8> Inner<OUTPUT_ENC> {
             &mut self.buffer,
             self.input_version,
             self.upgrade_policy,
+            self.ts_out,
         )
         .map_err(to_val_err)?;
 
@@ -300,6 +302,7 @@ impl<const OUTPUT_ENC: u8> Inner<OUTPUT_ENC> {
             &mut self.buffer,
             self.input_version,
             self.upgrade_policy,
+            self.ts_out,
         )
         .map_err(to_val_err)?;
 

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "dbn-cli"
-authors = ["Databento <support@databento.com>"]
-version = "0.15.1"
-edition = "2021"
 description = "Command-line utility for converting Databento Binary Encoding (DBN) files to text-based formats"
 default-run = "dbn"
-license = "Apache-2.0"
-repository = "https://github.com/databento/dbn"
 keywords = ["market-data", "json", "csv", "conversion", "encoding"]
 # see https://crates.io/category_slugs
 categories = ["command-line-utilities", "encoding"]
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "dbn"
@@ -25,6 +25,7 @@ anyhow = "1.0"
 clap = { version = "4.4", features = ["derive", "wrap_help"] }
 # deserialization for CLI args
 serde = { version = "1.0", features = ["derive"] }
+# Compression
 zstd = "0.13"
 
 [dev-dependencies]

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -22,7 +22,7 @@ dbn = { path = "../dbn", version = "=0.15.1", default-features = false }
 # Error handling
 anyhow = "1.0"
 # CLI argument parsing
-clap = { version = "4.4", features = ["derive", "wrap_help"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 # deserialization for CLI args
 serde = { version = "1.0", features = ["derive"] }
 # Compression
@@ -30,9 +30,9 @@ zstd = "0.13"
 
 [dev-dependencies]
 # CLI integration tests
-assert_cmd = "2.0.13"
+assert_cmd = "2.0.14"
 # assert_cmd companion
-predicates = "3.0.4"
+predicates = "3.1.0"
 rstest = "0.18.2"
 # A library for managing temporary files and directories
-tempfile = "3.9.0"
+tempfile = "3.10.0"

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Databento common DBN library
-dbn = { path = "../dbn", version = "=0.15.1", default-features = false }
+dbn = { path = "../dbn", version = "=0.16.0", default-features = false }
 
 # Error handling
 anyhow = "1.0"

--- a/rust/dbn-cli/src/main.rs
+++ b/rust/dbn-cli/src/main.rs
@@ -14,9 +14,16 @@ use dbn_cli::{
 const STDIN_SENTINEL: &str = "-";
 
 fn wrap_frag(args: &Args, reader: impl io::Read) -> anyhow::Result<impl DecodeRecordRef> {
+    // assume no ts_out for fragments
+    const TS_OUT: bool = false;
     Ok(LimitFilter::new_no_metadata(
         SchemaFilter::new_no_metadata(
-            DbnRecordDecoder::with_version(reader, args.input_version(), args.upgrade_policy())?,
+            DbnRecordDecoder::with_version(
+                reader,
+                args.input_version(),
+                args.upgrade_policy(),
+                TS_OUT,
+            )?,
             args.schema_filter,
         ),
         args.limit,

--- a/rust/dbn-cli/tests/integration_tests.rs
+++ b/rust/dbn-cli/tests/integration_tests.rs
@@ -7,6 +7,7 @@ use std::{
 use assert_cmd::Command;
 use dbn::Schema;
 use predicates::{
+    boolean::PredicateBooleanExt,
     ord::eq,
     str::{contains, ends_with, is_empty, is_match, starts_with},
 };
@@ -245,8 +246,7 @@ fn metadata() {
         ])
         .assert()
         .success()
-        .stdout(starts_with("{"))
-        .stdout(ends_with("}\n"))
+        .stdout(starts_with("{").and(ends_with("}\n")))
         .stderr(is_empty());
 }
 
@@ -274,12 +274,14 @@ fn pretty_print_json_data() {
         ])
         .assert()
         .success()
-        .stdout(contains("    "))
-        .stdout(contains(",\n"))
-        .stdout(contains(": "))
-        .stdout(is_match(format!(".*\\s\"{PRETTY_TS_REGEX}\".*")).unwrap())
-        // prices should also be quoted
-        .stdout(is_match(format!(".*\\s\"{PRETTY_PX_REGEX}\".*")).unwrap())
+        .stdout(
+            contains("    ")
+                .and(contains(",\n"))
+                .and(contains(": "))
+                .and(is_match(format!(".*\\s\"{PRETTY_TS_REGEX}\".*")).unwrap())
+                // prices should also be quoted
+                .and(is_match(format!(".*\\s\"{PRETTY_PX_REGEX}\".*")).unwrap()),
+        )
         .stderr(is_empty());
 }
 
@@ -293,8 +295,11 @@ fn pretty_print_csv_data() {
         ])
         .assert()
         .success()
-        .stdout(is_match(format!(".*{PRETTY_TS_REGEX},.*")).unwrap())
-        .stdout(is_match(format!(".*,{PRETTY_PX_REGEX},.*")).unwrap())
+        .stdout(
+            is_match(format!(".*{PRETTY_TS_REGEX},.*"))
+                .unwrap()
+                .and(is_match(format!(".*,{PRETTY_PX_REGEX},.*")).unwrap()),
+        )
         .stderr(is_empty());
 }
 
@@ -366,8 +371,7 @@ fn limit_and_schema_filter_update_metadata() {
         ])
         .assert()
         .success()
-        .stdout(contains(r#""limit":"1""#))
-        .stdout(contains(r#""schema":"ohlcv-1d""#));
+        .stdout(contains(r#""limit":"1""#).and(contains(r#""schema":"ohlcv-1d""#)));
 }
 
 #[rstest]
@@ -602,8 +606,7 @@ fn writes_csv_header_for_0_records() {
         ])
         .assert()
         .success()
-        .stdout(starts_with("ts_event,"))
-        .stdout(contains('\n').count(1))
+        .stdout(starts_with("ts_event,").and(contains('\n').count(1)))
         .stderr(is_empty());
 }
 
@@ -640,8 +643,7 @@ fn map_symbols_fails_for_invalid_output(#[case] output_flag: &str) {
         .assert()
         .failure()
         .stdout(is_empty())
-        .stderr(contains(format!("'{output_flag}'")))
-        .stderr(contains("'--map-symbols'"));
+        .stderr(contains(format!("'{output_flag}'")).and(contains("'--map-symbols'")));
 }
 
 #[test]
@@ -671,8 +673,7 @@ fn passing_next_dbn_version_is_rejected() {
         ])
         .assert()
         .failure()
-        .stderr(contains("invalid value"))
-        .stderr(contains("--input-dbn-version"));
+        .stderr(contains("invalid value").and(contains("--input-dbn-version")));
 }
 
 #[rstest]

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "dbn-macros"
-authors = ["Databento <support@databento.com>"]
-version = "0.15.1"
-edition = "2021"
 description = "Proc macros for dbn crate"
-license = "Apache-2.0"
-repository = "https://github.com/databento/dbn"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -12,14 +12,14 @@ proc-macro = true
 
 [dependencies]
 # Get name of current crate in macros, like $crate in macro_rules macros
-proc-macro-crate = "3.0.0"
-proc-macro2 = "1.0.76"
+proc-macro-crate = "3.1.0"
+proc-macro2 = "1.0.78"
 # Convert code to token streams
 quote = "1.0.35"
 # Token parsing
-syn = { version = "2.0.48", features = ["full"] }
+syn = { version = "2.0.51", features = ["full"] }
 
 [dev-dependencies]
 csv = "1"
 dbn = { path = "../dbn" }
-trybuild = "1.0.88"
+trybuild = "1.0.89"

--- a/rust/dbn-macros/src/lib.rs
+++ b/rust/dbn-macros/src/lib.rs
@@ -34,8 +34,8 @@ pub fn dbn_attr(_item: TokenStream) -> TokenStream {
 /// - `unix_nanos`: serializes the field as a UNIX timestamp, with the output format
 ///   depending on `PRETTY_TS`
 ///
-/// Note: fields beginning with `_` will automatically be skipped, e.g. `_dummy` isn't
-/// serialized.
+/// Note: fields beginning with `_` will automatically be skipped, e.g. `_reserved`
+/// isn't serialized.
 #[proc_macro_derive(CsvSerialize, attributes(dbn))]
 pub fn derive_csv_serialize(input: TokenStream) -> TokenStream {
     serialize::derive_csv_macro_impl(input)
@@ -51,8 +51,8 @@ pub fn derive_csv_serialize(input: TokenStream) -> TokenStream {
 /// - `unix_nanos`: serializes the field as a UNIX timestamp, with the output format
 ///   depending on `PRETTY_TS`
 ///
-/// Note: fields beginning with `_` will automatically be skipped, e.g. `_dummy` isn't
-/// serialized.
+/// Note: fields beginning with `_` will automatically be skipped, e.g. `_reserved`
+/// isn't serialized.
 #[proc_macro_derive(JsonSerialize, attributes(dbn))]
 pub fn derive_json_serialize(input: TokenStream) -> TokenStream {
     serialize::derive_json_macro_impl(input)
@@ -106,8 +106,8 @@ pub fn dbn_record(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///   field. If the getter returns an error, the raw field value will be used
 /// - `skip`: won't be included in the `Debug` output
 ///
-/// Note: fields beginning with `_` will automatically be skipped, e.g. `_dummy` isn't
-/// included in the `Debug` output.
+/// Note: fields beginning with `_` will automatically be skipped, e.g. `_reserved`
+/// isn't included in the `Debug` output.
 #[proc_macro_derive(RecordDebug, attributes(dbn))]
 pub fn derive_record_debug(input: TokenStream) -> TokenStream {
     debug::derive_impl(input)

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "dbn"
-authors = ["Databento <support@databento.com>"]
-version = "0.15.1"
-edition = "2021"
 description = "Library for working with Databento Binary Encoding (DBN)"
-license = "Apache-2.0"
-repository = "https://github.com/databento/dbn"
 keywords = ["finance", "market-data", "conversion", "encoding", "trading"]
 # see https://crates.io/category_slugs
 categories = ["encoding"]
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [package.metadata.docs.rs]
 # Document all features on docs.rs

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -28,7 +28,7 @@ trivial_copy = []
 dbn-macros = { version = "=0.15.1", path = "../dbn-macros" }
 
 # async (de)compression
-async-compression = { version = "0.4.5", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "0.4.6", features = ["tokio", "zstd"], optional = true }
 # CSV serialization
 csv = "1.3"
 # Fast integer to string conversion
@@ -44,7 +44,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # zero-copy DBN decoding
 streaming-iterator = "0.1.9"
 # extra enum traits for Python
-strum = { version = "0.25", features = ["derive"], optional = true }
+strum = { version = "0.26", features = ["derive"], optional = true }
 # Custom error helper
 thiserror = "1.0"
 # date and datetime support
@@ -58,7 +58,7 @@ zstd = "0.13"
 # Parameterized testing
 rstest = "0.18.2"
 # Enum helpers
-strum = { version = "0.25", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
 # Async runtime
 tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 # Checking alignment and padding

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.15.1", path = "../dbn-macros" }
+dbn-macros = { version = "=0.16.0", path = "../dbn-macros" }
 
 # async (de)compression
 async-compression = { version = "0.4.6", features = ["tokio", "zstd"], optional = true }

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -44,7 +44,7 @@ where
     /// `reader` or the input is encoded in a newer version of DBN.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn new(mut reader: R) -> crate::Result<Self> {
@@ -67,7 +67,7 @@ where
     /// `reader` or the input is encoded in a newer version of DBN.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn with_upgrade_policy(
@@ -147,7 +147,7 @@ where
     /// This function will return an error if it is unable to parse the metadata in `reader`.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn with_zstd(reader: R) -> crate::Result<Self> {
@@ -165,7 +165,7 @@ where
     /// This function will return an error if it is unable to parse the metadata in `reader`.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn with_zstd_buffer(reader: R) -> crate::Result<Self> {
@@ -181,7 +181,7 @@ impl Decoder<BufReader<File>> {
     /// if it is unable to parse the metadata in the file.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn from_file(path: impl AsRef<Path>) -> crate::Result<Self> {
@@ -203,7 +203,7 @@ impl Decoder<ZstdDecoder<BufReader<File>>> {
     /// if it is unable to parse the metadata in the file.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn from_zstd_file(path: impl AsRef<Path>) -> crate::Result<Self> {
@@ -333,6 +333,10 @@ where
     /// This function returns an error if the underlying reader returns an
     /// error of a kind other than `io::ErrorKind::UnexpectedEof` upon reading.
     /// It will also return an error if it encounters an invalid record.
+    ///
+    /// # Cancel safety
+    /// This method is cancel safe. It can be used within a `tokio::select!` statement
+    /// without the potential for corrupting the input stream.
     pub async fn decode_ref(&mut self) -> Result<Option<RecordRef>> {
         let io_err = |e| crate::Error::io(e, "decoding record reference");
         loop {
@@ -450,7 +454,7 @@ where
     /// input is encoded in a newere version of DBN.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, the metadata
     /// may have been partially read, corrupting the stream.
     pub async fn decode(&mut self) -> Result<Metadata> {

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -36,8 +36,8 @@ impl<R> Decoder<R>
 where
     R: io::AsyncReadExt + Unpin,
 {
-    /// Creates a new async DBN [`Decoder`] from `reader`. Will decode records from
-    /// previous DBN versions as-is.
+    /// Creates a new async DBN [`Decoder`] from `reader`. Will upgrade records from
+    /// previous DBN version to the current version.
     ///
     /// # Errors
     /// This function will return an error if it is unable to parse the metadata in
@@ -53,7 +53,7 @@ where
             decoder: RecordDecoder::with_version(
                 reader,
                 metadata.version,
-                VersionUpgradePolicy::AsIs,
+                VersionUpgradePolicy::Upgrade,
             )?,
             metadata,
         })

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -42,6 +42,7 @@ where
                 reader,
                 metadata.version,
                 VersionUpgradePolicy::AsIs,
+                metadata.ts_out,
             )?,
             metadata,
         })
@@ -62,7 +63,7 @@ where
         let version = metadata.version;
         metadata.upgrade(upgrade_policy);
         Ok(Self {
-            decoder: RecordDecoder::with_version(reader, version, upgrade_policy)?,
+            decoder: RecordDecoder::with_version(reader, version, upgrade_policy, metadata.ts_out)?,
             metadata,
         })
     }
@@ -209,6 +210,7 @@ pub struct RecordDecoder<R> {
     /// For future use with reading different DBN versions.
     version: u8,
     upgrade_policy: VersionUpgradePolicy,
+    ts_out: bool,
     reader: R,
     read_buffer: Vec<u8>,
     compat_buffer: [u8; crate::MAX_RECORD_LEN],
@@ -224,7 +226,7 @@ where
     /// previous version, use [`RecordDecoder::with_version()`].
     pub fn new(reader: R) -> Self {
         // upgrade policy doesn't matter when decoding current DBN version
-        Self::with_version(reader, DBN_VERSION, VersionUpgradePolicy::AsIs).unwrap()
+        Self::with_version(reader, DBN_VERSION, VersionUpgradePolicy::AsIs, false).unwrap()
     }
 
     /// Creates a new `RecordDecoder` that will decode from `reader` with the specified
@@ -237,6 +239,7 @@ where
         reader: R,
         version: u8,
         upgrade_policy: VersionUpgradePolicy,
+        ts_out: bool,
     ) -> crate::Result<Self> {
         if version > DBN_VERSION {
             return Err(crate::Error::decode(format!("can't decode newer version of DBN. Decoder version is {DBN_VERSION}, input version is {version}")));
@@ -245,6 +248,7 @@ where
             version,
             upgrade_policy,
             reader,
+            ts_out,
             // `read_buffer` should have capacity for reading `length`
             read_buffer: vec![0],
             compat_buffer: [0; crate::MAX_RECORD_LEN],
@@ -268,6 +272,11 @@ where
     /// Sets the behavior for decoding DBN data of previous versions.
     pub fn set_upgrade_policy(&mut self, upgrade_policy: VersionUpgradePolicy) {
         self.upgrade_policy = upgrade_policy;
+    }
+
+    /// Sets whether to expect a send timestamp appended after every record.
+    pub fn set_ts_out(&mut self, ts_out: bool) {
+        self.ts_out = ts_out;
     }
 
     /// Returns a mutable reference to the inner reader.
@@ -340,6 +349,7 @@ where
             compat::decode_record_ref(
                 self.version,
                 self.upgrade_policy,
+                self.ts_out,
                 &mut self.compat_buffer,
                 &self.read_buffer,
             )
@@ -1032,6 +1042,7 @@ mod tests {
             .unwrap(),
             1,
             upgrade_policy,
+            false,
         )
         .unwrap();
         let mut count = 0;

--- a/rust/dbn/src/decode/dbz.rs
+++ b/rust/dbn/src/decode/dbz.rs
@@ -64,12 +64,13 @@ impl Decoder<BufReader<File>> {
 // `BufRead` instead of `Read` because the [zstd::Decoder] works with `BufRead` so accepting
 // a `Read` could result in redundant `BufReader`s being created.
 impl<R: io::BufRead> Decoder<R> {
-    /// Creates a new DBZ [`Decoder`] from `reader`.
+    /// Creates a new DBZ [`Decoder`] from `reader`. Will upgrade records from previous
+    /// versions to the current version.
     ///
     /// # Errors
     /// This function will return an error if it is unable to parse the metadata in `reader`.
     pub fn new(reader: R) -> crate::Result<Self> {
-        Self::with_upgrade_policy(reader, VersionUpgradePolicy::AsIs)
+        Self::with_upgrade_policy(reader, VersionUpgradePolicy::Upgrade)
     }
 
     /// Creates a new DBZ [`Decoder`] from `reader`. It will decode records from

--- a/rust/dbn/src/decode/dbz.rs
+++ b/rust/dbn/src/decode/dbz.rs
@@ -121,6 +121,7 @@ impl<R: io::BufRead> DecodeRecordRef for Decoder<R> {
             compat::decode_record_ref(
                 1,
                 self.upgrade_policy,
+                self.metadata.ts_out,
                 &mut self.compat_buffer,
                 &self.read_buffer,
             )

--- a/rust/dbn/src/encode/csv/sync.rs
+++ b/rust/dbn/src/encode/csv/sync.rs
@@ -794,7 +794,7 @@ mod tests {
             num_extensions: 16,
             unpaired_side: 'A' as c_char,
             significant_imbalance: 'N' as c_char,
-            _dummy: [0],
+            _reserved: [0],
         }];
         let mut buffer = Vec::new();
         let writer = BufWriter::new(&mut buffer);
@@ -833,7 +833,7 @@ mod tests {
             channel_id: 7,
             update_action: StatUpdateAction::New as u8,
             stat_flags: 0,
-            _dummy: Default::default(),
+            _reserved: Default::default(),
         }];
         let mut buffer = Vec::new();
         let writer = BufWriter::new(&mut buffer);

--- a/rust/dbn/src/encode/csv/sync.rs
+++ b/rust/dbn/src/encode/csv/sync.rs
@@ -612,10 +612,13 @@ mod tests {
         let data = vec![StatusMsg {
             hd: RECORD_HEADER,
             ts_recv: 1658441891000000000,
-            group,
-            trading_status: 3,
-            halt_reason: 4,
-            trading_event: 6,
+            action: 1,
+            reason: 2,
+            trading_event: 3,
+            is_trading: b'Y' as c_char,
+            is_quoting: b'Y' as c_char,
+            is_short_sell_restricted: b'~' as c_char,
+            _reserved: Default::default(),
         }];
         let mut buffer = Vec::new();
         let writer = BufWriter::new(&mut buffer);
@@ -631,7 +634,7 @@ mod tests {
         assert_eq!(
             line,
             format!(
-                "{}{sep}1658441891000000000{sep}group{sep}3{sep}4{sep}6",
+                "1658441891000000000{sep}{}{sep}1{sep}2{sep}3{sep}Y{sep}Y{sep}~",
                 header(sep)
             )
         );

--- a/rust/dbn/src/encode/dbn/async.rs
+++ b/rust/dbn/src/encode/dbn/async.rs
@@ -27,7 +27,7 @@ where
     /// `writer`.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// metadata may have been partially written, but future calls will begin writing
     /// the encoded metadata from the beginning.
@@ -54,7 +54,7 @@ where
     /// writer.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// record may have been partially written, but future calls will begin writing the
     /// encoded record from the beginning.
@@ -69,7 +69,7 @@ where
     /// or there's a serialization error.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// record may have been partially written, but future calls will begin writing the
     /// encoded record from the beginning.
@@ -98,7 +98,7 @@ where
     /// `writer`.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// metadata may have been partially written, but future calls will begin writing
     /// the encoded metadata from the beginning.
@@ -132,7 +132,7 @@ where
     /// writer.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// record may have been partially written, but future calls will begin writing the
     /// encoded record from the beginning.
@@ -149,7 +149,7 @@ where
     /// This function returns an error if it's unable to write to the underlying writer.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// record may have been partially written, but future calls will begin writing the
     /// encoded record from the beginning.
@@ -220,7 +220,7 @@ where
     /// writer.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// metadata may have been partially written, but future calls will begin writing
     /// the encoded metadata from the beginning.

--- a/rust/dbn/src/encode/dyn_encoder.rs
+++ b/rust/dbn/src/encode/dyn_encoder.rs
@@ -41,6 +41,7 @@ where
     use_pretty_px: bool,
     use_pretty_ts: bool,
     with_symbol: bool,
+    delimiter: u8,
 }
 
 impl<'m, W> DynEncoderBuilder<'m, W>
@@ -65,6 +66,7 @@ where
             use_pretty_px: false,
             use_pretty_ts: false,
             with_symbol: false,
+            delimiter: b',',
         }
     }
 
@@ -113,6 +115,12 @@ where
         self
     }
 
+    /// Sets the field delimiter. Defaults to `b','` for comma-separated values (CSV).
+    pub fn delimiter(mut self, delimiter: u8) -> Self {
+        self.delimiter = delimiter;
+        self
+    }
+
     /// Creates the new encoder with the previously specified settings and if
     /// `write_header` is `true`, encodes the header row.
     ///
@@ -127,6 +135,7 @@ where
                 let builder = CsvEncoder::builder(writer)
                     .use_pretty_px(self.use_pretty_px)
                     .use_pretty_ts(self.use_pretty_ts)
+                    .delimiter(self.delimiter)
                     .write_header(self.write_header)
                     .ts_out(self.metadata.ts_out)
                     .with_symbol(self.with_symbol);

--- a/rust/dbn/src/encode/json/async.rs
+++ b/rust/dbn/src/encode/json/async.rs
@@ -44,7 +44,7 @@ where
     /// This function returns an error if there's an error writing to `writer`.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// metadata JSON may have been partially written, but future calls will begin writing
     /// the metadata JSON from the beginning.
@@ -81,7 +81,7 @@ where
     /// writer.
     ///
     /// # Cancel safety
-    /// This method is not cancellation safe. If the method is used in
+    /// This method is not cancellation safe. If this method is used in a
     /// `tokio::select!` statement and another branch completes first, then the
     /// record may have been partially written, but future calls will begin writing the
     /// encoded record from the beginning.

--- a/rust/dbn/src/encode/json/sync.rs
+++ b/rust/dbn/src/encode/json/sync.rs
@@ -451,7 +451,7 @@ mod tests {
             low_limit_price: -1_000_000,
             max_price_variation: 0,
             trading_reference_price: 500_000,
-            unit_of_measure_qty: 5,
+            unit_of_measure_qty: 5_000_000_000,
             min_price_increment_amount: 5,
             price_ratio: 10,
             inst_attrib_value: 10,
@@ -516,7 +516,7 @@ mod tests {
                 r#""hd":{"ts_event":"2022-07-21T22:17:31.000000000Z","rtype":4,"publisher_id":1,"instrument_id":323}"#,
                 concat!(
                     r#""raw_symbol":"ESZ4 C4100","security_update_action":"A","instrument_class":"C","min_price_increment":"0.000000100","display_factor":"1000","expiration":"2023-10-27T23:40:00.000000000Z","activation":"2023-10-15T06:06:40.000000000Z","#,
-                    r#""high_limit_price":"0.001000000","low_limit_price":"-0.001000000","max_price_variation":"0.000000000","trading_reference_price":"0.000500000","unit_of_measure_qty":"5","#,
+                    r#""high_limit_price":"0.001000000","low_limit_price":"-0.001000000","max_price_variation":"0.000000000","trading_reference_price":"0.000500000","unit_of_measure_qty":"5.000000000","#,
                     r#""min_price_increment_amount":"0.000000005","price_ratio":"0.000000010","inst_attrib_value":10,"underlying_id":256785,"raw_instrument_id":323,"market_depth_implied":0,"#,
                     r#""market_depth":13,"market_segment_id":0,"max_trade_vol":10000,"min_lot_size":1,"min_lot_size_block":1000,"min_lot_size_round_lot":100,"min_trade_vol":1,"#,
                     r#""contract_multiplier":0,"decay_quantity":0,"original_contract_size":0,"trading_reference_date":0,"appl_id":0,"#,

--- a/rust/dbn/src/encode/json/sync.rs
+++ b/rust/dbn/src/encode/json/sync.rs
@@ -419,10 +419,13 @@ mod tests {
         let data = vec![StatusMsg {
             hd: RECORD_HEADER,
             ts_recv: 1658441891000000000,
-            group: str_to_c_chars("group").unwrap(),
-            trading_status: 3,
-            halt_reason: 4,
-            trading_event: 6,
+            action: 1,
+            reason: 2,
+            trading_event: 3,
+            is_trading: b'Y' as c_char,
+            is_quoting: b'Y' as c_char,
+            is_short_sell_restricted: b'~' as c_char,
+            _reserved: Default::default(),
         }];
         let slice_res = write_json_to_string(data.as_slice(), false, false, true);
         let stream_res = write_json_stream_to_string(data, false, false, true);
@@ -431,9 +434,10 @@ mod tests {
         assert_eq!(
             slice_res,
             format!(
-                "{{{},{}}}\n",
+                "{{{},{},{}}}\n",
+                r#""ts_recv":"2022-07-21T22:18:11.000000000Z""#,
                 r#""hd":{"ts_event":"2022-07-21T22:17:31.000000000Z","rtype":4,"publisher_id":1,"instrument_id":323}"#,
-                r#""ts_recv":"2022-07-21T22:18:11.000000000Z","group":"group","trading_status":3,"halt_reason":4,"trading_event":6"#,
+                r#""action":1,"reason":2,"trading_event":3,"is_trading":"Y","is_quoting":"Y","is_short_sell_restricted":"~""#,
             )
         );
     }

--- a/rust/dbn/src/encode/json/sync.rs
+++ b/rust/dbn/src/encode/json/sync.rs
@@ -557,7 +557,7 @@ mod tests {
             num_extensions: 16,
             unpaired_side: 'A' as c_char,
             significant_imbalance: 'N' as c_char,
-            _dummy: [0],
+            _reserved: [0],
         }];
         let slice_res = write_json_to_string(data.as_slice(), false, false, false);
         let stream_res = write_json_stream_to_string(data, false, false, false);
@@ -592,7 +592,7 @@ mod tests {
             channel_id: 7,
             update_action: StatUpdateAction::New as u8,
             stat_flags: 0,
-            _dummy: Default::default(),
+            _reserved: Default::default(),
         }];
         let slice_res = write_json_to_string(data.as_slice(), false, true, false);
         let stream_res = write_json_stream_to_string(data, false, true, false);

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -17,11 +17,11 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum Side {
-    /// A sell order.
+    /// A sell order or sell aggressor in a trade.
     Ask = b'A',
-    /// A buy order.
+    /// A buy order or a buy aggressor in a trade.
     Bid = b'B',
-    /// None or unknown.
+    /// No side specified by the original source.
     None = b'N',
 }
 

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -785,41 +785,63 @@ pub enum StatusReason {
     InstrumentExpiration = 5,
     /// Recovery in progress.
     RecoveryInProcess = 6,
-    /// The status change was caused by regulatory action.
-    Regulatory = 7,
-    /// The status change was caused by administrative action.
-    Administrative = 8,
+    /// The status change was caused by a regulatory action.
+    Regulatory = 10,
+    /// The status change was caused by an administrative action.
+    Administrative = 11,
+    /// The status change was caused by the issuer not being compliance with regulatory
+    /// requirements.
+    NonCompliance = 12,
+    /// Trading halted because the issuer's filings are not current.
+    FilingsNotCurrent = 13,
+    /// Trading halted due to an SEC trading suspension.
+    SecTradingSuspension = 14,
+    /// The status changed because a new issue is available.
+    NewIssue = 15,
+    /// The status changed because an issue is available.
+    IssueAvailable = 16,
+    /// The status changed because the issue was reviewed.
+    IssuesReviewed = 17,
+    /// The status changed because the filing requirements were satisfied.
+    FilingReqsSatisfied = 18,
     /// Relevant news is pending.
-    NewsPending = 9,
+    NewsPending = 30,
     /// Relevant news was released.
-    NewsReleased = 10,
+    NewsReleased = 31,
+    /// The news has been fully disseminated and times are available for the resumption
+    /// in quoting and trading.
+    NewsAndResumptionTimes = 32,
+    /// The relevants news was not forthcoming.
+    NewsNotForthcoming = 33,
     /// Halted for order imbalance.
-    OrderImbalance = 11,
+    OrderImbalance = 40,
     /// The instrument hit limit up or limit down.
-    LuldPause = 12,
+    LuldPause = 50,
     /// An operational issue occurred with the venue.
-    Operational = 13,
+    Operational = 60,
     /// The status changed until the exchange receives additional information.
-    AdditionalInformationRequested = 14,
+    AdditionalInformationRequested = 70,
     /// Trading halted due to merger becoming effective.
-    MergerEffective = 15,
+    MergerEffective = 80,
     /// Trading is halted in an ETF due to conditions with the component securities.
-    Etf = 16,
+    Etf = 90,
     /// Trading is halted for a corporate action.
-    CorporateAction = 17,
+    CorporateAction = 100,
     /// Trading is halted because the instrument is a new offering.
-    NewSecurityOffering = 18,
+    NewSecurityOffering = 110,
     /// Halted due to the market-wide circuit breaker level 1.
-    MarketWideHaltLevel1 = 19,
+    MarketWideHaltLevel1 = 120,
     /// Halted due to the market-wide circuit breaker level 2.
-    MarketWideHaltLevel2 = 20,
+    MarketWideHaltLevel2 = 121,
     /// Halted due to the market-wide circuit breaker level 3.
-    MarketWideHaltLevel3 = 21,
+    MarketWideHaltLevel3 = 122,
     /// Halted due to the carryover of a market-wide circuit breaker from the previous
     /// trading day.
-    MarketWideHaltCarryover = 22,
+    MarketWideHaltCarryover = 123,
+    /// Resumption due to the end of the a market-wide circuit breaker halt.
+    MarketWideHaltResumption = 124,
     /// Halted because quotation is not available.
-    QuotationNotAvailable = 23,
+    QuotationNotAvailable = 130,
 }
 
 /// Further information about a status update.

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -455,8 +455,7 @@ pub enum Schema {
     /// Additional data disseminated by publishers.
     #[pyo3(name = "STATISTICS")]
     Statistics = 10,
-    /// Exchange status.
-    #[doc(hidden)]
+    /// Trading status events.
     #[pyo3(name = "STATUS")]
     Status = 11,
     /// Auction imbalance events.
@@ -722,6 +721,157 @@ pub enum StatUpdateAction {
     New = 1,
     /// A removal of a statistic.
     Delete = 2,
+}
+
+/// The primary enum for the type of [`StatusMsg`](crate::record::StatusMsg) update.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[non_exhaustive]
+pub enum StatusAction {
+    /// No change.
+    #[default]
+    None = 0,
+    /// The instrument is in a pre-open period.
+    PreOpen = 1,
+    /// The instrument is in a pre-cross period.
+    PreCross = 2,
+    /// The instrument is quoting but not trading.
+    Quoting = 3,
+    /// The instrument is in a cross/auction.
+    Cross = 4,
+    /// The instrument is being opened through a trading rotation.
+    Rotation = 5,
+    /// A new price indication is available for the instrument.
+    NewPriceIndication = 6,
+    /// The instrument is trading.
+    Trading = 7,
+    /// Trading in the instrument has been halted.
+    Halt = 8,
+    /// Trading in the instrument has been paused.
+    Pause = 9,
+    /// Trading in the instrument has been suspended.
+    Suspend = 10,
+    /// The instrument is in a pre-close period.
+    PreClose = 11,
+    /// Trading in the instrument has closed.
+    Close = 12,
+    /// The instrument is in a post-close period.
+    PostClose = 13,
+    /// A change in short-selling restrictions.
+    SsrChange = 14,
+    /// The instrument is not available for trading, either trading has closed or been
+    /// halted.
+    NotAvailableForTrading = 15,
+}
+
+/// The secondary enum for a [`StatusMsg`](crate::record::StatusMsg) update, explains
+/// the cause of a halt or other change in `action`.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[non_exhaustive]
+pub enum StatusReason {
+    /// No reason is given.
+    #[default]
+    None = 0,
+    /// The change in status occurred as scheduled.
+    Scheduled = 1,
+    /// The instrument stopped due to a market surveillance intervention.
+    SurveillanceIntervention = 2,
+    /// The status changed due to activity in the market.
+    MarketEvent = 3,
+    /// The derivative instrument began trading.
+    InstrumentActivation = 4,
+    /// The derivative instrument expired.
+    InstrumentExpiration = 5,
+    /// Recovery in progress.
+    RecoveryInProcess = 6,
+    /// The status change was caused by regulatory action.
+    Regulatory = 7,
+    /// The status change was caused by administrative action.
+    Administrative = 8,
+    /// Relevant news is pending.
+    NewsPending = 9,
+    /// Relevant news was released.
+    NewsReleased = 10,
+    /// Halted for order imbalance.
+    OrderImbalance = 11,
+    /// The instrument hit limit up or limit down.
+    LuldPause = 12,
+    /// An operational issue occurred with the venue.
+    Operational = 13,
+    /// The status changed until the exchange receives additional information.
+    AdditionalInformationRequested = 14,
+    /// Trading halted due to merger becoming effective.
+    MergerEffective = 15,
+    /// Trading is halted in an ETF due to conditions with the component securities.
+    Etf = 16,
+    /// Trading is halted for a corporate action.
+    CorporateAction = 17,
+    /// Trading is halted because the instrument is a new offering.
+    NewSecurityOffering = 18,
+    /// Halted due to the market-wide circuit breaker level 1.
+    MarketWideHaltLevel1 = 19,
+    /// Halted due to the market-wide circuit breaker level 2.
+    MarketWideHaltLevel2 = 20,
+    /// Halted due to the market-wide circuit breaker level 3.
+    MarketWideHaltLevel3 = 21,
+    /// Halted due to the carryover of a market-wide circuit breaker from the previous
+    /// trading day.
+    MarketWideHaltCarryover = 22,
+    /// Halted because quotation is not available.
+    QuotationNotAvailable = 23,
+}
+
+/// Further information about a status update.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[non_exhaustive]
+pub enum TradingEvent {
+    /// No additional information given.
+    #[default]
+    None = 0,
+    /// Order entry and modification are not allowed.
+    NoCancel = 1,
+    /// A change of trading session occurred. Daily statistics are reset.
+    ChangeTradingSession = 2,
+    /// Implied matching is available.
+    ImpliedMatchingOn = 3,
+    /// Implied matching is not available.
+    ImpliedMatchingOff = 4,
+}
+
+/// An enum for representing unknown, true, or false values. Equivalent to
+/// `Option<bool>` but with a human-readable repr.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+pub enum TriState {
+    /// The value is not applicable or not known.
+    #[default]
+    NotAvailable = b'~',
+    /// False
+    No = b'N',
+    /// True
+    Yes = b'Y',
+}
+
+impl From<TriState> for Option<bool> {
+    fn from(value: TriState) -> Self {
+        match value {
+            TriState::NotAvailable => None,
+            TriState::No => Some(false),
+            TriState::Yes => Some(true),
+        }
+    }
+}
+
+impl From<Option<bool>> for TriState {
+    fn from(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => Self::Yes,
+            Some(false) => Self::No,
+            None => Self::NotAvailable,
+        }
+    }
 }
 
 /// How to handle decoding DBN data from a prior version.

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -654,6 +654,7 @@ pub mod flags {
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[allow(clippy::manual_non_exhaustive)] // false positive
 pub enum SecurityUpdateAction {
     /// A new instrument definition.
     Add = b'A',

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -669,6 +669,7 @@ pub enum SecurityUpdateAction {
 /// The type of statistic contained in a [`StatMsg`](crate::record::StatMsg).
 #[repr(u16)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[non_exhaustive]
 pub enum StatType {
     /// The price of the first trade of an instrument. `price` will be set.
     OpeningPrice = 1,

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -706,6 +706,10 @@ pub enum StatType {
     /// The change in price from the close price of the previous trading session to the
     /// most recent trading session. `price` will be set.
     NetChange = 12,
+    /// The volume-weighted average price (VWAP) during the trading session.
+    /// `price` will be set to the VWAP while `quantity` will be the traded
+    /// volume.
+    Vwap = 13,
 }
 
 /// The type of [`StatMsg`](crate::record::StatMsg) update.

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -725,13 +725,14 @@ pub enum StatUpdateAction {
     pyo3::pyclass(module = "databento_dbn", rename_all = "SCREAMING_SNAKE_CASE")
 )]
 #[cfg_attr(feature = "python", derive(strum::EnumIter))]
+#[non_exhaustive]
 pub enum VersionUpgradePolicy {
-    /// Decode data from previous versions as-is. Currently the default.
-    #[default]
+    /// Decode data from previous versions as-is.
     AsIs,
     /// Decode data from previous versions converting it to the latest version. This
     /// breaks zero-copy decoding for structs that need updating, but makes usage
     /// simpler.
+    #[default]
     Upgrade,
 }
 

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -98,7 +98,7 @@ pub const UNDEF_STAT_QUANTITY: i32 = i32::MAX;
 /// The sentinel value for an unset or null timestamp.
 pub const UNDEF_TIMESTAMP: u64 = u64::MAX;
 /// The length in bytes of the largest record type.
-pub const MAX_RECORD_LEN: usize = std::mem::size_of::<InstrumentDefMsg>();
+pub const MAX_RECORD_LEN: usize = std::mem::size_of::<WithTsOut<InstrumentDefMsg>>();
 
 /// Contains dataset code constants.
 pub mod datasets {

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -57,8 +57,8 @@ pub mod symbol_map;
 pub use crate::{
     enums::{
         flags, rtype, Action, Compression, Encoding, InstrumentClass, MatchAlgorithm, RType, SType,
-        Schema, SecurityUpdateAction, Side, StatType, StatUpdateAction, UserDefinedInstrument,
-        VersionUpgradePolicy,
+        Schema, SecurityUpdateAction, Side, StatType, StatUpdateAction, StatusAction, StatusReason,
+        TradingEvent, TriState, UserDefinedInstrument, VersionUpgradePolicy,
     },
     error::{Error, Result},
     metadata::{MappingInterval, Metadata, MetadataBuilder, SymbolMapping},

--- a/rust/dbn/src/macros.rs
+++ b/rust/dbn/src/macros.rs
@@ -44,8 +44,20 @@ macro_rules! rtype_dispatch_base {
                         $handler!(SymbolMappingMsg)
                     }
                 }
-                RType::Error => $handler!(ErrorMsg),
-                RType::System => $handler!(SystemMsg),
+                RType::Error => {
+                    if $rec_ref.record_size() < std::mem::size_of::<ErrorMsg>() {
+                        $handler!($crate::compat::ErrorMsgV1)
+                    } else {
+                        $handler!(ErrorMsg)
+                    }
+                }
+                RType::System => {
+                    if $rec_ref.record_size() < std::mem::size_of::<SystemMsg>() {
+                        $handler!($crate::compat::SystemMsgV1)
+                    } else {
+                        $handler!(SystemMsg)
+                    }
+                }
                 RType::Statistics => $handler!(StatMsg),
                 RType::Mbo => $handler!(MboMsg),
             }),

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -92,10 +92,12 @@ pub enum Venue {
     Dbeq = 40,
     /// MIAX Sapphire
     Sphr = 41,
+    /// Long-Term Stock Exchange, Inc.
+    Ltse = 42,
 }
 
 /// The number of Venue variants.
-pub const VENUE_COUNT: usize = 41;
+pub const VENUE_COUNT: usize = 42;
 
 impl Venue {
     /// Convert a Venue to its `str` representation.
@@ -142,6 +144,7 @@ impl Venue {
             Self::Ndex => "NDEX",
             Self::Dbeq => "DBEQ",
             Self::Sphr => "SPHR",
+            Self::Ltse => "LTSE",
         }
     }
 }
@@ -204,6 +207,7 @@ impl std::str::FromStr for Venue {
             "NDEX" => Ok(Self::Ndex),
             "DBEQ" => Ok(Self::Dbeq),
             "SPHR" => Ok(Self::Sphr),
+            "LTSE" => Ok(Self::Ltse),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -271,10 +275,12 @@ pub enum Dataset {
     IfeuImpact = 28,
     /// ICE Endex iMpact
     NdexImpact = 29,
+    /// Databento Equities Max
+    DbeqMax = 30,
 }
 
 /// The number of Dataset variants.
-pub const DATASET_COUNT: usize = 29;
+pub const DATASET_COUNT: usize = 30;
 
 impl Dataset {
     /// Convert a Dataset to its `str` representation.
@@ -309,6 +315,7 @@ impl Dataset {
             Self::XnasNls => "XNAS.NLS",
             Self::IfeuImpact => "IFEU.IMPACT",
             Self::NdexImpact => "NDEX.IMPACT",
+            Self::DbeqMax => "DBEQ.MAX",
         }
     }
 }
@@ -359,6 +366,7 @@ impl std::str::FromStr for Dataset {
             "XNAS.NLS" => Ok(Self::XnasNls),
             "IFEU.IMPACT" => Ok(Self::IfeuImpact),
             "NDEX.IMPACT" => Ok(Self::NdexImpact),
+            "DBEQ.MAX" => Ok(Self::DbeqMax),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -490,10 +498,48 @@ pub enum Publisher {
     DbeqPlusDbeq = 60,
     /// OPRA - MIAX Sapphire
     OpraPillarSphr = 61,
+    /// DBEQ Max - NYSE Chicago
+    DbeqMaxXchi = 62,
+    /// DBEQ Max - NYSE National
+    DbeqMaxXcis = 63,
+    /// DBEQ Max - IEX
+    DbeqMaxIexg = 64,
+    /// DBEQ Max - MIAX Pearl
+    DbeqMaxEprl = 65,
+    /// DBEQ Max - Nasdaq
+    DbeqMaxXnas = 66,
+    /// DBEQ Max - NYSE
+    DbeqMaxXnys = 67,
+    /// DBEQ Max - FINRA/NYSE TRF
+    DbeqMaxFinn = 68,
+    /// DBEQ Max - FINRA/Nasdaq TRF Carteret
+    DbeqMaxFiny = 69,
+    /// DBEQ Max - FINRA/Nasdaq TRF Chicago
+    DbeqMaxFinc = 70,
+    /// DBEQ Max - CBOE BZX
+    DbeqMaxBats = 71,
+    /// DBEQ Max - CBOE BYX
+    DbeqMaxBaty = 72,
+    /// DBEQ Max - CBOE EDGA
+    DbeqMaxEdga = 73,
+    /// DBEQ Max - CBOE EDGX
+    DbeqMaxEdgx = 74,
+    /// DBEQ Max - Nasdaq BX
+    DbeqMaxXbos = 75,
+    /// DBEQ Max - Nasdaq PSX
+    DbeqMaxXpsx = 76,
+    /// DBEQ Max - MEMX
+    DbeqMaxMemx = 77,
+    /// DBEQ Max - NYSE American
+    DbeqMaxXase = 78,
+    /// DBEQ Max - NYSE Arca
+    DbeqMaxArcx = 79,
+    /// DBEQ Max - Long-Term Stock Exchange
+    DbeqMaxLtse = 80,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 61;
+pub const PUBLISHER_COUNT: usize = 80;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -560,6 +606,25 @@ impl Publisher {
             Self::DbeqBasicDbeq => "DBEQ.BASIC.DBEQ",
             Self::DbeqPlusDbeq => "DBEQ.PLUS.DBEQ",
             Self::OpraPillarSphr => "OPRA.PILLAR.SPHR",
+            Self::DbeqMaxXchi => "DBEQ.MAX.XCHI",
+            Self::DbeqMaxXcis => "DBEQ.MAX.XCIS",
+            Self::DbeqMaxIexg => "DBEQ.MAX.IEXG",
+            Self::DbeqMaxEprl => "DBEQ.MAX.EPRL",
+            Self::DbeqMaxXnas => "DBEQ.MAX.XNAS",
+            Self::DbeqMaxXnys => "DBEQ.MAX.XNYS",
+            Self::DbeqMaxFinn => "DBEQ.MAX.FINN",
+            Self::DbeqMaxFiny => "DBEQ.MAX.FINY",
+            Self::DbeqMaxFinc => "DBEQ.MAX.FINC",
+            Self::DbeqMaxBats => "DBEQ.MAX.BATS",
+            Self::DbeqMaxBaty => "DBEQ.MAX.BATY",
+            Self::DbeqMaxEdga => "DBEQ.MAX.EDGA",
+            Self::DbeqMaxEdgx => "DBEQ.MAX.EDGX",
+            Self::DbeqMaxXbos => "DBEQ.MAX.XBOS",
+            Self::DbeqMaxXpsx => "DBEQ.MAX.XPSX",
+            Self::DbeqMaxMemx => "DBEQ.MAX.MEMX",
+            Self::DbeqMaxXase => "DBEQ.MAX.XASE",
+            Self::DbeqMaxArcx => "DBEQ.MAX.ARCX",
+            Self::DbeqMaxLtse => "DBEQ.MAX.LTSE",
         }
     }
 
@@ -627,6 +692,25 @@ impl Publisher {
             Self::DbeqBasicDbeq => Venue::Dbeq,
             Self::DbeqPlusDbeq => Venue::Dbeq,
             Self::OpraPillarSphr => Venue::Sphr,
+            Self::DbeqMaxXchi => Venue::Xchi,
+            Self::DbeqMaxXcis => Venue::Xcis,
+            Self::DbeqMaxIexg => Venue::Iexg,
+            Self::DbeqMaxEprl => Venue::Eprl,
+            Self::DbeqMaxXnas => Venue::Xnas,
+            Self::DbeqMaxXnys => Venue::Xnys,
+            Self::DbeqMaxFinn => Venue::Finn,
+            Self::DbeqMaxFiny => Venue::Finy,
+            Self::DbeqMaxFinc => Venue::Finc,
+            Self::DbeqMaxBats => Venue::Bats,
+            Self::DbeqMaxBaty => Venue::Baty,
+            Self::DbeqMaxEdga => Venue::Edga,
+            Self::DbeqMaxEdgx => Venue::Edgx,
+            Self::DbeqMaxXbos => Venue::Xbos,
+            Self::DbeqMaxXpsx => Venue::Xpsx,
+            Self::DbeqMaxMemx => Venue::Memx,
+            Self::DbeqMaxXase => Venue::Xase,
+            Self::DbeqMaxArcx => Venue::Arcx,
+            Self::DbeqMaxLtse => Venue::Ltse,
         }
     }
 
@@ -694,6 +778,25 @@ impl Publisher {
             Self::DbeqBasicDbeq => Dataset::DbeqBasic,
             Self::DbeqPlusDbeq => Dataset::DbeqPlus,
             Self::OpraPillarSphr => Dataset::OpraPillar,
+            Self::DbeqMaxXchi => Dataset::DbeqMax,
+            Self::DbeqMaxXcis => Dataset::DbeqMax,
+            Self::DbeqMaxIexg => Dataset::DbeqMax,
+            Self::DbeqMaxEprl => Dataset::DbeqMax,
+            Self::DbeqMaxXnas => Dataset::DbeqMax,
+            Self::DbeqMaxXnys => Dataset::DbeqMax,
+            Self::DbeqMaxFinn => Dataset::DbeqMax,
+            Self::DbeqMaxFiny => Dataset::DbeqMax,
+            Self::DbeqMaxFinc => Dataset::DbeqMax,
+            Self::DbeqMaxBats => Dataset::DbeqMax,
+            Self::DbeqMaxBaty => Dataset::DbeqMax,
+            Self::DbeqMaxEdga => Dataset::DbeqMax,
+            Self::DbeqMaxEdgx => Dataset::DbeqMax,
+            Self::DbeqMaxXbos => Dataset::DbeqMax,
+            Self::DbeqMaxXpsx => Dataset::DbeqMax,
+            Self::DbeqMaxMemx => Dataset::DbeqMax,
+            Self::DbeqMaxXase => Dataset::DbeqMax,
+            Self::DbeqMaxArcx => Dataset::DbeqMax,
+            Self::DbeqMaxLtse => Dataset::DbeqMax,
         }
     }
 
@@ -763,6 +866,25 @@ impl Publisher {
             (Dataset::DbeqBasic, Venue::Dbeq) => Ok(Self::DbeqBasicDbeq),
             (Dataset::DbeqPlus, Venue::Dbeq) => Ok(Self::DbeqPlusDbeq),
             (Dataset::OpraPillar, Venue::Sphr) => Ok(Self::OpraPillarSphr),
+            (Dataset::DbeqMax, Venue::Xchi) => Ok(Self::DbeqMaxXchi),
+            (Dataset::DbeqMax, Venue::Xcis) => Ok(Self::DbeqMaxXcis),
+            (Dataset::DbeqMax, Venue::Iexg) => Ok(Self::DbeqMaxIexg),
+            (Dataset::DbeqMax, Venue::Eprl) => Ok(Self::DbeqMaxEprl),
+            (Dataset::DbeqMax, Venue::Xnas) => Ok(Self::DbeqMaxXnas),
+            (Dataset::DbeqMax, Venue::Xnys) => Ok(Self::DbeqMaxXnys),
+            (Dataset::DbeqMax, Venue::Finn) => Ok(Self::DbeqMaxFinn),
+            (Dataset::DbeqMax, Venue::Finy) => Ok(Self::DbeqMaxFiny),
+            (Dataset::DbeqMax, Venue::Finc) => Ok(Self::DbeqMaxFinc),
+            (Dataset::DbeqMax, Venue::Bats) => Ok(Self::DbeqMaxBats),
+            (Dataset::DbeqMax, Venue::Baty) => Ok(Self::DbeqMaxBaty),
+            (Dataset::DbeqMax, Venue::Edga) => Ok(Self::DbeqMaxEdga),
+            (Dataset::DbeqMax, Venue::Edgx) => Ok(Self::DbeqMaxEdgx),
+            (Dataset::DbeqMax, Venue::Xbos) => Ok(Self::DbeqMaxXbos),
+            (Dataset::DbeqMax, Venue::Xpsx) => Ok(Self::DbeqMaxXpsx),
+            (Dataset::DbeqMax, Venue::Memx) => Ok(Self::DbeqMaxMemx),
+            (Dataset::DbeqMax, Venue::Xase) => Ok(Self::DbeqMaxXase),
+            (Dataset::DbeqMax, Venue::Arcx) => Ok(Self::DbeqMaxArcx),
+            (Dataset::DbeqMax, Venue::Ltse) => Ok(Self::DbeqMaxLtse),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -846,6 +968,25 @@ impl std::str::FromStr for Publisher {
             "DBEQ.BASIC.DBEQ" => Ok(Self::DbeqBasicDbeq),
             "DBEQ.PLUS.DBEQ" => Ok(Self::DbeqPlusDbeq),
             "OPRA.PILLAR.SPHR" => Ok(Self::OpraPillarSphr),
+            "DBEQ.MAX.XCHI" => Ok(Self::DbeqMaxXchi),
+            "DBEQ.MAX.XCIS" => Ok(Self::DbeqMaxXcis),
+            "DBEQ.MAX.IEXG" => Ok(Self::DbeqMaxIexg),
+            "DBEQ.MAX.EPRL" => Ok(Self::DbeqMaxEprl),
+            "DBEQ.MAX.XNAS" => Ok(Self::DbeqMaxXnas),
+            "DBEQ.MAX.XNYS" => Ok(Self::DbeqMaxXnys),
+            "DBEQ.MAX.FINN" => Ok(Self::DbeqMaxFinn),
+            "DBEQ.MAX.FINY" => Ok(Self::DbeqMaxFiny),
+            "DBEQ.MAX.FINC" => Ok(Self::DbeqMaxFinc),
+            "DBEQ.MAX.BATS" => Ok(Self::DbeqMaxBats),
+            "DBEQ.MAX.BATY" => Ok(Self::DbeqMaxBaty),
+            "DBEQ.MAX.EDGA" => Ok(Self::DbeqMaxEdga),
+            "DBEQ.MAX.EDGX" => Ok(Self::DbeqMaxEdgx),
+            "DBEQ.MAX.XBOS" => Ok(Self::DbeqMaxXbos),
+            "DBEQ.MAX.XPSX" => Ok(Self::DbeqMaxXpsx),
+            "DBEQ.MAX.MEMX" => Ok(Self::DbeqMaxMemx),
+            "DBEQ.MAX.XASE" => Ok(Self::DbeqMaxXase),
+            "DBEQ.MAX.ARCX" => Ok(Self::DbeqMaxArcx),
+            "DBEQ.MAX.LTSE" => Ok(Self::DbeqMaxLtse),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/python.rs
+++ b/rust/dbn/src/python.rs
@@ -359,6 +359,7 @@ mod tests {
                 "low_limit_price".to_owned(),
                 "max_price_variation".to_owned(),
                 "trading_reference_price".to_owned(),
+                "unit_of_measure_qty".to_owned(),
                 "min_price_increment_amount".to_owned(),
                 "price_ratio".to_owned(),
                 "strike_price".to_owned(),

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -1748,7 +1748,7 @@ impl ImbalanceMsg {
             num_extensions: 0,
             unpaired_side: 0,
             significant_imbalance,
-            _dummy: [0],
+            _reserved: [0],
         }
     }
 
@@ -1913,7 +1913,7 @@ impl StatMsg {
             channel_id,
             update_action: update_action.unwrap_or(StatUpdateAction::New as u8),
             stat_flags: stat_flags.unwrap_or_default(),
-            _dummy: Default::default(),
+            _reserved: Default::default(),
         }
     }
 

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -12,8 +12,9 @@ use crate::{
     record::str_to_c_chars,
     rtype, BidAskPair, ErrorMsg, HasRType, ImbalanceMsg, InstrumentDefMsg, MboMsg, Mbp10Msg,
     Mbp1Msg, OhlcvMsg, Record, RecordHeader, SType, SecurityUpdateAction, StatMsg,
-    StatUpdateAction, StatusMsg, SymbolMappingMsg, SystemMsg, TradeMsg, UserDefinedInstrument,
-    WithTsOut, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
+    StatUpdateAction, StatusAction, StatusMsg, StatusReason, SymbolMappingMsg, SystemMsg, TradeMsg,
+    TradingEvent, TriState, UserDefinedInstrument, WithTsOut, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE,
+    UNDEF_PRICE, UNDEF_TIMESTAMP,
 };
 
 use super::{to_val_err, PyFieldDesc};
@@ -779,18 +780,23 @@ impl StatusMsg {
         instrument_id: u32,
         ts_event: u64,
         ts_recv: u64,
-        group: &str,
-        trading_status: u8,
-        halt_reason: u8,
-        trading_event: u8,
+        action: Option<u16>,
+        reason: Option<u16>,
+        trading_event: Option<u16>,
+        is_trading: Option<bool>,
+        is_quoting: Option<bool>,
+        is_short_sell_restricted: Option<bool>,
     ) -> PyResult<Self> {
         Ok(Self {
             hd: RecordHeader::new::<Self>(rtype::STATUS, publisher_id, instrument_id, ts_event),
             ts_recv,
-            group: str_to_c_chars(group).map_err(to_val_err)?,
-            trading_status,
-            halt_reason,
-            trading_event,
+            action: action.unwrap_or_else(|| StatusAction::default() as u16),
+            reason: reason.unwrap_or_else(|| StatusReason::default() as u16),
+            trading_event: trading_event.unwrap_or_else(|| TradingEvent::default() as u16),
+            is_trading: TriState::from(is_trading) as u8 as c_char,
+            is_quoting: TriState::from(is_quoting) as u8 as c_char,
+            is_short_sell_restricted: TriState::from(is_short_sell_restricted) as u8 as c_char,
+            _reserved: Default::default(),
         })
     }
 
@@ -850,12 +856,6 @@ impl StatusMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<StatMsg>())
-    }
-
-    #[getter]
-    #[pyo3(name = "group")]
-    fn py_group(&self) -> PyResult<&str> {
-        self.group().map_err(to_val_err)
     }
 
     #[classattr]

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -752,7 +752,7 @@ pub struct ImbalanceMsg {
     // Filler for alignment.
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub _dummy: [u8; 1],
+    pub _reserved: [u8; 1],
 }
 
 /// A statistics message. A catchall for various data disseminated by publishers.
@@ -809,7 +809,7 @@ pub struct StatMsg {
     // Filler for alignment
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub _dummy: [u8; 6],
+    pub _reserved: [u8; 6],
 }
 
 /// An error message from the Databento Live Subscription Gateway (LSG).

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -459,7 +459,9 @@ pub struct InstrumentDefMsg {
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub trading_reference_price: i64,
-    /// The contract size for each instrument, in combination with `unit_of_measure`.
+    /// The contract size for each instrument, in combination with `unit_of_measure`, in units
+    /// of 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub unit_of_measure_qty: i64,
     /// The value currently under development by the venue. Converted to units of 1e-9, i.e.

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -104,7 +104,9 @@ pub struct MboMsg {
     /// **T**rade, or **F**ill.
     #[dbn(c_char, encode_order(2))]
     pub action: c_char,
-    /// The order side. Can be **A**sk, **B**id or **N**one.
+    /// The side that initiates the event. Can be **A**sk for a sell order (or sell
+    /// aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
+    /// **N**one where no side is specified by the original source.
     #[dbn(c_char, encode_order(3))]
     pub side: c_char,
     /// The capture-server-received timestamp expressed as number of nanoseconds since
@@ -177,7 +179,9 @@ pub struct TradeMsg {
     /// The event action. Always **T**rade in the trades schema.
     #[dbn(c_char, encode_order(2))]
     pub action: c_char,
-    /// The aggressing order's side in the trade. Can be **A**sk, **B**id or **N**one.
+    /// The side that initiates the trade. Can be **A**sk for a sell aggressor in a
+    /// trade, **B**id for a buy aggressor in a trade, or **N**one where no side is
+    /// specified by the original source.
     #[dbn(c_char, encode_order(3))]
     pub side: c_char,
     /// A combination of packet end with matching engine status. See
@@ -232,7 +236,9 @@ pub struct Mbp1Msg {
     /// **T**rade.
     #[dbn(c_char, encode_order(2))]
     pub action: c_char,
-    /// The order side. Can be **A**sk, **B**id or **N**one.
+    /// The side that initiates the event. Can be **A**sk for a sell order (or sell
+    /// aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
+    /// **N**one where no side is specified by the original source.
     #[dbn(c_char, encode_order(3))]
     pub side: c_char,
     /// A combination of packet end with matching engine status. See
@@ -290,7 +296,9 @@ pub struct Mbp10Msg {
     /// **T**rade.
     #[dbn(c_char, encode_order(2))]
     pub action: c_char,
-    /// The order side. Can be **A**sk, **B**id or **N**one.
+    /// The side that initiates the event. Can be **A**sk for a sell order (or sell
+    /// aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
+    /// **N**one where no side is specified by the original source.
     #[dbn(c_char, encode_order(3))]
     pub side: c_char,
     /// A combination of packet end with matching engine status. See

--- a/rust/dbn/src/record/impl_default.rs
+++ b/rust/dbn/src/record/impl_default.rs
@@ -1,5 +1,8 @@
+use std::ffi::c_char;
+
 use crate::{
     compat::{ErrorMsgV1, InstrumentDefMsgV1, SymbolMappingMsgV1, SystemMsgV1, SYMBOL_CSTR_LEN_V1},
+    enums::{StatusAction, StatusReason, TradingEvent, TriState},
     SType, Schema, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_STAT_QUANTITY, UNDEF_TIMESTAMP,
 };
 
@@ -116,10 +119,13 @@ impl Default for StatusMsg {
         Self {
             hd: RecordHeader::default::<Self>(rtype::STATUS),
             ts_recv: UNDEF_TIMESTAMP,
-            group: Default::default(),
-            trading_status: 0,
-            halt_reason: 0,
-            trading_event: 0,
+            action: StatusAction::default() as u16,
+            reason: StatusReason::default() as u16,
+            trading_event: TradingEvent::default() as u16,
+            is_trading: TriState::default() as u8 as c_char,
+            is_quoting: TriState::default() as u8 as c_char,
+            is_short_sell_restricted: TriState::default() as u8 as c_char,
+            _reserved: Default::default(),
         }
     }
 }

--- a/rust/dbn/src/record/impl_default.rs
+++ b/rust/dbn/src/record/impl_default.rs
@@ -296,7 +296,7 @@ impl Default for ImbalanceMsg {
             num_extensions: 0,
             unpaired_side: 0,
             significant_imbalance: b'~' as c_char,
-            _dummy: Default::default(),
+            _reserved: Default::default(),
         }
     }
 }
@@ -315,7 +315,7 @@ impl Default for StatMsg {
             channel_id: 0,
             update_action: StatUpdateAction::New as u8,
             stat_flags: 0,
-            _dummy: Default::default(),
+            _reserved: Default::default(),
         }
     }
 }

--- a/rust/dbn/src/record/methods.rs
+++ b/rust/dbn/src/record/methods.rs
@@ -1,8 +1,11 @@
 use std::fmt::Debug;
 
+use num_enum::TryFromPrimitive;
+
 use crate::{
     compat::{ErrorMsgV1, InstrumentDefMsgV1, SymbolMappingMsgV1, SystemMsgV1},
-    SType,
+    enums::{StatusAction, StatusReason},
+    SType, TradingEvent, TriState,
 };
 
 use super::*;
@@ -217,13 +220,34 @@ impl Mbp10Msg {
     }
 }
 
+#[doc(hidden)]
 impl StatusMsg {
-    /// Returns `group` as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `group` contains invalid UTF-8.
-    pub fn group(&self) -> Result<&str> {
-        c_chars_to_str(&self.group)
+    pub fn action(&self) -> Result<StatusAction> {
+        StatusAction::try_from(self.action)
+            .map_err(|_| Error::conversion::<StatusAction>(format!("{:#06X}", self.action)))
+    }
+    pub fn reason(&self) -> Result<StatusReason> {
+        StatusReason::try_from(self.reason)
+            .map_err(|_| Error::conversion::<StatusReason>(format!("{:#06X}", self.reason)))
+    }
+    pub fn trading_event(&self) -> Result<TradingEvent> {
+        TradingEvent::try_from(self.trading_event)
+            .map_err(|_| Error::conversion::<TradingEvent>(format!("{:#06X}", self.trading_event)))
+    }
+    pub fn is_trading(&self) -> Option<bool> {
+        TriState::try_from_primitive(self.is_trading as c_char as u8)
+            .map(Option::<bool>::from)
+            .unwrap_or_default()
+    }
+    pub fn is_quoting(&self) -> Option<bool> {
+        TriState::try_from_primitive(self.is_quoting as c_char as u8)
+            .map(Option::<bool>::from)
+            .unwrap_or_default()
+    }
+    pub fn is_short_sell_restricted(&self) -> Option<bool> {
+        TriState::try_from_primitive(self.is_short_sell_restricted as c_char as u8)
+            .map(Option::<bool>::from)
+            .unwrap_or_default()
     }
 }
 

--- a/rust/dbn/src/record/methods.rs
+++ b/rust/dbn/src/record/methods.rs
@@ -220,30 +220,55 @@ impl Mbp10Msg {
     }
 }
 
-#[doc(hidden)]
 impl StatusMsg {
+    /// Tries to convert the raw status action to an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `action` field does not contain a valid
+    /// [`StatusAction`].
     pub fn action(&self) -> Result<StatusAction> {
         StatusAction::try_from(self.action)
             .map_err(|_| Error::conversion::<StatusAction>(format!("{:#06X}", self.action)))
     }
+
+    /// Tries to convert the raw status reason to an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `reason` field does not contain a valid
+    /// [`StatusReason`].
     pub fn reason(&self) -> Result<StatusReason> {
         StatusReason::try_from(self.reason)
             .map_err(|_| Error::conversion::<StatusReason>(format!("{:#06X}", self.reason)))
     }
+
+    /// Tries to convert the raw status trading event to an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `trading_event` field does not contain a
+    /// valid [`TradingEvent`].
     pub fn trading_event(&self) -> Result<TradingEvent> {
         TradingEvent::try_from(self.trading_event)
             .map_err(|_| Error::conversion::<TradingEvent>(format!("{:#06X}", self.trading_event)))
     }
+
+    /// Converts the raw `is_trading` state to an `Option<bool>` where `None` indicates
+    /// a value is not applicable or available.
     pub fn is_trading(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_trading as c_char as u8)
             .map(Option::<bool>::from)
             .unwrap_or_default()
     }
+
+    /// Converts the raw `is_quoting` state to an `Option<bool>` where `None` indicates
+    /// a value is not applicable or available.
     pub fn is_quoting(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_quoting as c_char as u8)
             .map(Option::<bool>::from)
             .unwrap_or_default()
     }
+
+    /// Converts the raw `is_short_sell_restricted` state to an `Option<bool>` where
+    /// `None` indicates a value is not applicable or available.
     pub fn is_short_sell_restricted(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_short_sell_restricted as c_char as u8)
             .map(Option::<bool>::from)

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 
 source "$(dirname "$0")/config.sh"
-grep -E '^version =' "${PROJECT_ROOT_DIR}/rust/dbn/Cargo.toml" | cut -d'"' -f 2
+grep -E '^version =' "${PROJECT_ROOT_DIR}/Cargo.toml" | cut -d'"' -f 2


### PR DESCRIPTION
### Enhancements
- Updated `StatusMsg` and made it public in preparation for releasing a status schema
- Added `StatusAction`, `StatusReason`, `TradingEvent`, and `TriState` enums for use in
  the status schema
- Added `-t` and `--tsv` flags to DBN CLI to encode tab-separated values (TSV)
- Added `delimiter` method to builders for `DynEncoder` and `CsvEncoder` to customize the
  field delimiter character, allowing DBN to be encoded as tab-separated values (TSV)
- Document cancellation safety for `AsyncRecordDecoder::decode_ref` (credit: @yongqli)
- Added new publisher values for consolidated DBEQ.MAX
- Added C FFI conversion functions from `ErrorMsgV1` to `ErrorMsg` and `SystemMsgV1`
  to `SystemMsg`
- Improved documentation for `side` field and `Side` enum
- Upgraded `async-compression` to 0.4.6
- Upgraded `strum` to 0.26

### Breaking changes
- Changed default for `VersionUpgradePolicy` to `Upgrade`
- Changed default `upgrade_policy` for `DbnDecoder`, `AsyncDbnDecoder`, and Python
  `DBNDecoder` to `Upgrade` so by default the primary record types can always be used
- Changed fields of previously-hidden `StatusMsg` record type
- Updated text serialization order of status schema to match other schemas
- Changed text serialization `unit_of_measure_qty` to be affected by `pretty_px`. While
  it's not a price, it uses the same fixed-price decimal format as other prices
- Made `StatType` and  `VersionUpgradePolicy` non-exhaustive to allow future additions
  without breaking changes
- Renamed `_dummy` field in `ImbalanceMsg` and `StatMsg` to `_reserved`
- Added `ts_out` parameter to `RecordDecoder` and `AsyncRecordDecoder`
  `with_upgrade_policy` methods

### Bug fixes
- Fixed handling of `ts_out` when upgrading DBNv1 records to version 2
- Added missing `StatType::Vwap` variant used in the ICE datasets
- Fixed an issue with Python stub file distribution
- Fixed missing handling of `ErrorMsgV1` and `SystemMsgV1` in `rtype` dispatch macros
