### PR TITLE
Main

### DIFF
--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -32,6 +32,11 @@ impl From<Side> for char {
 }
 
 /// A tick action.
+/// 
+/// This is used to indicate order life cycle, such as order cancelation and addition.  
+/// You can find examples here.  
+/// - https://databento.com/docs/examples/order-book/order-tracking  
+/// - https://databento.com/docs/examples/order-book/order-actions  
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum Action {


### PR DESCRIPTION
# Pull Request

I suggest adding links to official documentation in code docs to improve use experience.

For example, you can add links to the official documentation's order tracking/order actions page on `enum Actions`, which allows users to quickly navigate themselves to the web page to understand what it's all about.

## Type of change

- [x] This change requires a documentation update

## How has this change been tested?

Just a suggestion. Not tested.