### PR TITLE
VER: Release 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.18.2 - TBD
+
+### Enhancements
+- Added new `shutdown` method to async encoders to more easily ensure the end
+  of output is written and I/O cleaned up. Previously this required a call to
+  `.get_mut().shutdown().await`
+- Changed `AsyncDynWriter` and `AsyncDbnEncoder::with_zstd` to use a zstd checksum like
+  the sync equivalents
+
 ## 0.18.1 - 2024-06-04
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Changed `AsyncDynWriter` and `AsyncDbnEncoder::with_zstd` to use a zstd checksum like
   the sync equivalents
 
+### Bug fixes
+- Fixed bug where DBN metadata would still be upgraded after passing `AsIs` to
+  `DbnDecoder::set_upgrade_policy` and `AsyncDbnDecoder::set_upgrade_policy`
+
 ## 0.18.1 - 2024-06-04
 
 ### Enhancements
@@ -17,7 +21,7 @@
 - Added new off-market publisher values for `IFEU.IMPACT` and `NDEX.IMPACT`
 
 ### Bug fixes
-- Fix descriptions for `FINN` and `FINY` publishers
+- Fixed descriptions for `FINN` and `FINY` publishers
 
 ## 0.18.0 - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   `.get_mut().shutdown().await`
 - Changed `AsyncDynWriter` and `AsyncDbnEncoder::with_zstd` to use a zstd checksum like
   the sync equivalents
+- Added new publisher values for `XNAS.BASIC` and `XNAS.NLS`
 
 ### Bug fixes
 - Fixed bug where DBN metadata would still be upgraded after passing `AsIs` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added new off-market publisher values for `IFEU.IMPACT` and `NDEX.IMPACT`
 
 ### Bug fixes
-- Fix descriptions for `FINN` and `FINY` publishers.
+- Fix descriptions for `FINN` and `FINY` publishers
 
 ## 0.18.0 - 2024-05-21
 
@@ -451,7 +451,7 @@
 - Added new `OHLCV_EOD` rtype for future daily OHLCV schema based on the trading
   session
 - Added new `SType::Nasdaq` and `SType::Cms` to support querying US equities datasets
-  using either convention, regardless of the original convention of the dataset.
+  using either convention, regardless of the original convention of the dataset
 - Relaxed `pyo3`, `tokio`, and `zstd` dependency version requirements
 - Added `FIXED_PRICE_SCALE` constant to `databento_dbn` Python package
 - Added generated field metadata for each record type to aid in pandas DataFrame
@@ -466,7 +466,7 @@
 ## 0.8.0 - 2023-07-19
 ### Enhancements
 - Switched from `anyhow::Error` to custom `dbn::Error` for all public fallible functions
-  and methods. This should make it easier to disambiguate between error types.
+  and methods. This should make it easier to disambiguate between error types
 - `EncodeDbn::encode_record` and `EncodeDbn::record_record_ref` no longer treat a
   `BrokenPipe` error differently
 - Added `AsyncDbnDecoder`
@@ -474,7 +474,7 @@
   logic outside of CSV and JSON encoding
 - Added interning for Python strings
 - Added `rtype` to encoded JSON and CSV to aid differeniating between different record types.
-  This is particularly important when working with live data.
+  This is particularly important when working with live data
 - Added `pretty_` Python attributes for DBN price fields
 - Added `pretty_` Python attributes for DBN UTC timestamp fields
 
@@ -491,7 +491,7 @@
 - Updated `InstrumentDefMsg` serialization order to serialize `raw_symbol`,
   `security_update_action`, and `instrument_class` earlier given their importance
 - Removed `bool` return value from `EncodeDbn::encode_record` and
-  `EncodeDbn::record_record_ref`. These now return `dbn::Result<()>`.
+  `EncodeDbn::record_record_ref`. These now return `dbn::Result<()>`
 
 ### Bug fixes
 - Fixed handling of NUL byte when encoding DBN to CSV and JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.18.2 - TBD
+## 0.18.2 - 2024-06-18
 
 ### Enhancements
 - Added new `shutdown` method to async encoders to more easily ensure the end

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "dbn",
  "pyo3",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-compression",
  "csv",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.18.1"
+version = "0.18.2"
 documentation = "https://docs.databento.com"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.18.1"
+version = "0.18.2"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.18.1"
+version = "0.18.2"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.18.1", default-features = false }
+dbn = { path = "../dbn", version = "=0.18.2", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.18.1", path = "../dbn-macros" }
+dbn-macros = { version = "=0.18.2", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.11", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -102,7 +102,8 @@ where
 
     /// Sets the behavior for decoding DBN data of previous versions.
     pub fn set_upgrade_policy(&mut self, upgrade_policy: VersionUpgradePolicy) {
-        self.metadata.upgrade(upgrade_policy);
+        self.metadata
+            .set_version(self.decoder.version, upgrade_policy);
         self.decoder.set_upgrade_policy(upgrade_policy);
     }
 

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -85,7 +85,8 @@ where
 
     /// Sets the behavior for decoding DBN data of previous versions.
     pub fn set_upgrade_policy(&mut self, upgrade_policy: VersionUpgradePolicy) {
-        self.metadata.upgrade(upgrade_policy);
+        self.metadata
+            .set_version(self.decoder.version, upgrade_policy);
         self.decoder.set_upgrade_policy(upgrade_policy);
     }
 }

--- a/rust/dbn/src/encode.rs
+++ b/rust/dbn/src/encode.rs
@@ -211,6 +211,17 @@ fn zstd_encoder<'a, W: io::Write>(writer: W) -> Result<zstd::stream::AutoFinishE
     Ok(zstd_encoder.auto_finish())
 }
 
+#[cfg(feature = "async")]
+fn async_zstd_encoder<W: tokio::io::AsyncWriteExt + Unpin>(
+    writer: W,
+) -> async_compression::tokio::write::ZstdEncoder<W> {
+    async_compression::tokio::write::ZstdEncoder::with_quality_and_params(
+        writer,
+        async_compression::Level::Precise(ZSTD_COMPRESSION_LEVEL),
+        &[async_compression::zstd::CParameter::checksum_flag(true)],
+    )
+}
+
 #[cfg(test)]
 mod test_data {
     use fallible_streaming_iterator::FallibleStreamingIterator;

--- a/rust/dbn/src/encode/dyn_writer.rs
+++ b/rust/dbn/src/encode/dyn_writer.rs
@@ -94,7 +94,7 @@ mod r#async {
     use async_compression::tokio::write::ZstdEncoder;
     use tokio::io;
 
-    use crate::enums::Compression;
+    use crate::{encode::async_zstd_encoder, enums::Compression};
 
     /// An object that allows for abstracting over compressed and uncompressed output.
     pub struct DynWriter<W>(DynWriterImpl<W>)
@@ -118,7 +118,7 @@ mod r#async {
         pub fn new(writer: W, compression: Compression) -> Self {
             Self(match compression {
                 Compression::None => DynWriterImpl::Uncompressed(writer),
-                Compression::ZStd => DynWriterImpl::ZStd(ZstdEncoder::new(writer)),
+                Compression::ZStd => DynWriterImpl::ZStd(async_zstd_encoder(writer)),
             })
         }
 

--- a/rust/dbn/src/encode/json/async.rs
+++ b/rust/dbn/src/encode/json/async.rs
@@ -124,6 +124,17 @@ where
             .await
             .map_err(|e| Error::io(e, "flushing output"))
     }
+
+    /// Initiates or attempts to shut down the inner writer.
+    ///
+    /// # Errors
+    /// This function returns an error if the shut down did not complete successfully.
+    pub async fn shutdown(mut self) -> Result<()> {
+        self.writer
+            .shutdown()
+            .await
+            .map_err(|e| Error::io(e, "shutting down".to_owned()))
+    }
 }
 
 #[cfg(test)]

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -115,14 +115,14 @@ impl From<InstrumentClass> for char {
 impl InstrumentClass {
     /// Returns `true` if the instrument class is a type of option.
     ///
-    /// NOTE: excludes [`Self::MixedSpread`], which *may* include options.
+    /// Note: excludes [`Self::MixedSpread`], which *may* include options.
     pub fn is_option(&self) -> bool {
         matches!(self, Self::Call | Self::Put | Self::OptionSpread)
     }
 
     /// Returns `true` if the instrument class is a type of future.
     ///
-    /// NOTE: excludes [`Self::MixedSpread`], which *may* include futures.
+    /// Note: excludes [`Self::MixedSpread`], which *may* include futures.
     pub fn is_future(&self) -> bool {
         matches!(self, Self::Future | Self::FutureSpread)
     }

--- a/rust/dbn/src/metadata.rs
+++ b/rust/dbn/src/metadata.rs
@@ -125,6 +125,24 @@ impl Metadata {
             self.symbol_cstr_len = crate::SYMBOL_CSTR_LEN;
         }
     }
+
+    /// Allows upgrade policy to be configured from decoders after Metadata decoding.
+    /// Using [`upgrade()`] would leave metadata with the wrong `version` and
+    /// `symbol_cstr_len`.
+    pub(crate) fn set_version(&mut self, input_version: u8, upgrade_policy: VersionUpgradePolicy) {
+        if input_version < 2 {
+            match upgrade_policy {
+                VersionUpgradePolicy::AsIs => {
+                    self.version = input_version;
+                    self.symbol_cstr_len = crate::compat::SYMBOL_CSTR_LEN_V1;
+                }
+                VersionUpgradePolicy::Upgrade => {
+                    self.version = crate::DBN_VERSION;
+                    self.symbol_cstr_len = crate::SYMBOL_CSTR_LEN;
+                }
+            }
+        }
+    }
 }
 
 /// Helper for constructing [`Metadata`] structs with defaults.

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -563,10 +563,18 @@ pub enum Publisher {
     IfeuImpactXoff = 84,
     /// ICE Endex - Off-Market Trades
     NdexImpactXoff = 85,
+    /// Nasdaq NLS - Nasdaq BX
+    XnasNlsXbos = 86,
+    /// Nasdaq NLS - Nasdaq PSX
+    XnasNlsXpsx = 87,
+    /// Nasdaq Basic - Nasdaq BX
+    XnasBasicXbos = 88,
+    /// Nasdaq Basic - Nasdaq PSX
+    XnasBasicXpsx = 89,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 85;
+pub const PUBLISHER_COUNT: usize = 89;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -657,6 +665,10 @@ impl Publisher {
             Self::XnasBasicFinc => "XNAS.BASIC.FINC",
             Self::IfeuImpactXoff => "IFEU.IMPACT.XOFF",
             Self::NdexImpactXoff => "NDEX.IMPACT.XOFF",
+            Self::XnasNlsXbos => "XNAS.NLS.XBOS",
+            Self::XnasNlsXpsx => "XNAS.NLS.XPSX",
+            Self::XnasBasicXbos => "XNAS.BASIC.XBOS",
+            Self::XnasBasicXpsx => "XNAS.BASIC.XPSX",
         }
     }
 
@@ -748,6 +760,10 @@ impl Publisher {
             Self::XnasBasicFinc => Venue::Finc,
             Self::IfeuImpactXoff => Venue::Xoff,
             Self::NdexImpactXoff => Venue::Xoff,
+            Self::XnasNlsXbos => Venue::Xbos,
+            Self::XnasNlsXpsx => Venue::Xpsx,
+            Self::XnasBasicXbos => Venue::Xbos,
+            Self::XnasBasicXpsx => Venue::Xpsx,
         }
     }
 
@@ -839,6 +855,10 @@ impl Publisher {
             Self::XnasBasicFinc => Dataset::XnasBasic,
             Self::IfeuImpactXoff => Dataset::IfeuImpact,
             Self::NdexImpactXoff => Dataset::NdexImpact,
+            Self::XnasNlsXbos => Dataset::XnasNls,
+            Self::XnasNlsXpsx => Dataset::XnasNls,
+            Self::XnasBasicXbos => Dataset::XnasBasic,
+            Self::XnasBasicXpsx => Dataset::XnasBasic,
         }
     }
 
@@ -932,6 +952,10 @@ impl Publisher {
             (Dataset::XnasBasic, Venue::Finc) => Ok(Self::XnasBasicFinc),
             (Dataset::IfeuImpact, Venue::Xoff) => Ok(Self::IfeuImpactXoff),
             (Dataset::NdexImpact, Venue::Xoff) => Ok(Self::NdexImpactXoff),
+            (Dataset::XnasNls, Venue::Xbos) => Ok(Self::XnasNlsXbos),
+            (Dataset::XnasNls, Venue::Xpsx) => Ok(Self::XnasNlsXpsx),
+            (Dataset::XnasBasic, Venue::Xbos) => Ok(Self::XnasBasicXbos),
+            (Dataset::XnasBasic, Venue::Xpsx) => Ok(Self::XnasBasicXpsx),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1039,6 +1063,10 @@ impl std::str::FromStr for Publisher {
             "XNAS.BASIC.FINC" => Ok(Self::XnasBasicFinc),
             "IFEU.IMPACT.XOFF" => Ok(Self::IfeuImpactXoff),
             "NDEX.IMPACT.XOFF" => Ok(Self::NdexImpactXoff),
+            "XNAS.NLS.XBOS" => Ok(Self::XnasNlsXbos),
+            "XNAS.NLS.XPSX" => Ok(Self::XnasNlsXpsx),
+            "XNAS.BASIC.XBOS" => Ok(Self::XnasBasicXbos),
+            "XNAS.BASIC.XPSX" => Ok(Self::XnasBasicXpsx),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/record_enum.rs
+++ b/rust/dbn/src/record_enum.rs
@@ -4,7 +4,10 @@ use crate::{
     TradeMsg,
 };
 
-/// An owned DBN record type of flexible type.
+/// An owned DBN record type of flexible type. Unlike [`RecordRef`], this type allows
+/// `match`ing.
+///
+/// Note: this type does not support `ts_out`.
 #[derive(Debug, Clone)]
 pub enum RecordEnum {
     /// An market-by-order message.
@@ -37,6 +40,8 @@ pub enum RecordEnum {
 
 /// An immutable reference to a DBN record of flexible type. Unlike [`RecordRef`], this
 /// type allows `match`ing.
+///
+/// Note: this type does not support `ts_out`.
 #[derive(Debug, Copy, Clone)]
 pub enum RecordRefEnum<'a> {
     /// A reference to a market-by-order message.


### PR DESCRIPTION
### Enhancements
- Added new `shutdown` method to async encoders to more easily ensure the end
  of output is written and I/O cleaned up. Previously this required a call to
  `.get_mut().shutdown().await`
- Changed `AsyncDynWriter` and `AsyncDbnEncoder::with_zstd` to use a zstd checksum like
  the sync equivalents
- Added new publisher values for `XNAS.BASIC` and `XNAS.NLS`

### Bug fixes
- Fixed bug where DBN metadata would still be upgraded after passing `AsIs` to
  `DbnDecoder::set_upgrade_policy` and `AsyncDbnDecoder::set_upgrade_policy`
