### PR TITLE
VER: Release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.20.1 - TBD
+
+### Bug fixes
+- Added missing Python type stub for `pretty_ts_ref` in `StatMsg`
+
 ## 0.20.0 - 2024-07-30
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.20.1 - TBD
+## 0.20.1 - 2024-08-26
 
 ### Enhancements
 - Added `DynAsyncBufWriter` for buffering compressed or uncompressed async output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - Added `DynAsyncBufWriter` for buffering compressed or uncompressed async output
+- Added new publisher values for `XCIS.BBOTRADES` and `XNYS.BBOTRADES`
 
 ### Bug fixes
 - Added missing Python type stub for `pretty_ts_ref` in `StatMsg`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.20.1 - TBD
 
+### Enhancements
+- Added `DynAsyncBufWriter` for buffering compressed or uncompressed async output
+
 ### Bug fixes
 - Added missing Python type stub for `pretty_ts_ref` in `StatMsg`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "dbn",
  "pyo3",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-compression",
  "csv",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.20.0"
+version = "0.20.1"
 documentation = "https://docs.databento.com"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.20.0"
+version = "0.20.1"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.20.0"
+version = "0.20.1"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -4259,6 +4259,18 @@ class StatMsg(Record):
         """
 
     @property
+    def pretty_ts_ref(self) -> dt.datetime:
+        """
+        Reference timestamp expressed as the number of nanoseconds since the
+        UNIX epoch as a datetime or `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
     def ts_ref(self) -> int:
         """
         Reference timestamp expressed as the number of nanoseconds since the

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.20.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.20.1", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.20.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.20.1", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.11", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/encode.rs
+++ b/rust/dbn/src/encode.rs
@@ -27,7 +27,7 @@ pub use self::{
         AsyncEncoder as AsyncDbnEncoder, AsyncMetadataEncoder as AsyncDbnMetadataEncoder,
         AsyncRecordEncoder as AsyncDbnRecordEncoder,
     },
-    dyn_writer::DynAsyncWriter,
+    dyn_writer::{DynAsyncBufWriter, DynAsyncWriter},
     json::AsyncEncoder as AsyncJsonEncoder,
 };
 

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -285,14 +285,18 @@ pub enum Dataset {
     NdexImpact = 29,
     /// Databento Equities Max
     DbeqMax = 30,
-    /// Nasdaq Basic (NLS+QBBO)
+    /// Nasdaq Basic (NLS and QBBO)
     XnasBasic = 31,
     /// Databento Equities Summary
     DbeqSummary = 32,
+    /// NYSE National BBO and Trades
+    XcisBbotrades = 33,
+    /// NYSE BBO and Trades
+    XnysBbotrades = 34,
 }
 
 /// The number of Dataset variants.
-pub const DATASET_COUNT: usize = 32;
+pub const DATASET_COUNT: usize = 34;
 
 impl Dataset {
     /// Convert a Dataset to its `str` representation.
@@ -332,6 +336,8 @@ impl Dataset {
             Self::DbeqMax => "DBEQ.MAX",
             Self::XnasBasic => "XNAS.BASIC",
             Self::DbeqSummary => "DBEQ.SUMMARY",
+            Self::XcisBbotrades => "XCIS.BBOTRADES",
+            Self::XnysBbotrades => "XNYS.BBOTRADES",
         }
     }
 }
@@ -387,6 +393,8 @@ impl std::str::FromStr for Dataset {
             "DBEQ.MAX" => Ok(Self::DbeqMax),
             "XNAS.BASIC" => Ok(Self::XnasBasic),
             "DBEQ.SUMMARY" => Ok(Self::DbeqSummary),
+            "XCIS.BBOTRADES" => Ok(Self::XcisBbotrades),
+            "XNYS.BBOTRADES" => Ok(Self::XnysBbotrades),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -577,10 +585,14 @@ pub enum Publisher {
     XnasBasicXpsx = 89,
     /// Databento Equities Summary
     DbeqSummaryDbeq = 90,
+    /// NYSE National BBO and Trades
+    XcisBbotradesXcis = 91,
+    /// NYSE BBO and Trades
+    XnysBbotradesXnys = 92,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 90;
+pub const PUBLISHER_COUNT: usize = 92;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -676,6 +688,8 @@ impl Publisher {
             Self::XnasBasicXbos => "XNAS.BASIC.XBOS",
             Self::XnasBasicXpsx => "XNAS.BASIC.XPSX",
             Self::DbeqSummaryDbeq => "DBEQ.SUMMARY.DBEQ",
+            Self::XcisBbotradesXcis => "XCIS.BBOTRADES.XCIS",
+            Self::XnysBbotradesXnys => "XNYS.BBOTRADES.XNYS",
         }
     }
 
@@ -772,6 +786,8 @@ impl Publisher {
             Self::XnasBasicXbos => Venue::Xbos,
             Self::XnasBasicXpsx => Venue::Xpsx,
             Self::DbeqSummaryDbeq => Venue::Dbeq,
+            Self::XcisBbotradesXcis => Venue::Xcis,
+            Self::XnysBbotradesXnys => Venue::Xnys,
         }
     }
 
@@ -868,6 +884,8 @@ impl Publisher {
             Self::XnasBasicXbos => Dataset::XnasBasic,
             Self::XnasBasicXpsx => Dataset::XnasBasic,
             Self::DbeqSummaryDbeq => Dataset::DbeqSummary,
+            Self::XcisBbotradesXcis => Dataset::XcisBbotrades,
+            Self::XnysBbotradesXnys => Dataset::XnysBbotrades,
         }
     }
 
@@ -966,6 +984,8 @@ impl Publisher {
             (Dataset::XnasBasic, Venue::Xbos) => Ok(Self::XnasBasicXbos),
             (Dataset::XnasBasic, Venue::Xpsx) => Ok(Self::XnasBasicXpsx),
             (Dataset::DbeqSummary, Venue::Dbeq) => Ok(Self::DbeqSummaryDbeq),
+            (Dataset::XcisBbotrades, Venue::Xcis) => Ok(Self::XcisBbotradesXcis),
+            (Dataset::XnysBbotrades, Venue::Xnys) => Ok(Self::XnysBbotradesXnys),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1078,6 +1098,8 @@ impl std::str::FromStr for Publisher {
             "XNAS.BASIC.XBOS" => Ok(Self::XnasBasicXbos),
             "XNAS.BASIC.XPSX" => Ok(Self::XnasBasicXpsx),
             "DBEQ.SUMMARY.DBEQ" => Ok(Self::DbeqSummaryDbeq),
+            "XCIS.BBOTRADES.XCIS" => Ok(Self::XcisBbotradesXcis),
+            "XNYS.BBOTRADES.XNYS" => Ok(Self::XnysBbotradesXnys),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }


### PR DESCRIPTION
### Enhancements
- Added `DynAsyncBufWriter` for buffering compressed or uncompressed async output
- Added new publisher values for `XCIS.BBOTRADES` and `XNYS.BBOTRADES`

### Bug fixes
- Added missing Python type stub for `pretty_ts_ref` in `StatMsg`

