### PR TITLE
VER: Release 0.22.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,9 +84,9 @@ jobs:
           args: --release --target universal2-apple-darwin --out dist --manifest-path python/Cargo.toml --interpreter python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-macos-${{ matrix.python-version }}
           path: dist
 
   windows-release:
@@ -127,9 +127,9 @@ jobs:
           args: --release --out dist --manifest-path python/Cargo.toml --interpreter python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-windows-${{ matrix.python-version }}
           path: dist
 
   linux-release:
@@ -171,9 +171,9 @@ jobs:
           args: --release --out dist --manifest-path python/Cargo.toml --interpreter python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-linux-${{ matrix.python-version }}
           path: dist
 
   linux-musl-release:
@@ -215,9 +215,9 @@ jobs:
           args: --release --out dist --manifest-path python/Cargo.toml --interpreter python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-linux-musl-${{ matrix.python-version }}
           path: dist
 
   publish-py:
@@ -231,9 +231,9 @@ jobs:
         linux-musl-release,
       ]
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
+      - uses: actions/download-artifact@v4
+        pattern: wheel-*
+        merge-multiple: true
       # Install publish dependencies
       - name: Install publish dependencies
         run: python -m pip install --upgrade twine
@@ -244,15 +244,6 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: twine upload *
-
-      - name: Upload to release
-        uses: actions/upload-artifact@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: wheels
-          path: "*"
-          upload_url: ${{ needs.tag-release.outputs.upload_url }}
 
   publish-rs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.21.1 - TBD
+
+### Bug fixes
+- Added missing Python type stub for `CMBP_1` variant in `Schema`
+
 ## 0.21.0 - 2024-09-24
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 0.21.1 - TBD
+## 0.22.0 - TBD
+
+### Enhancements
+- Added Python type stubs for Record `__init__` methods
+
+### Breaking changes
+- Combine `_reserved3` and `_reserved4` fields in `CbboMsg`
+- Changed setters for `char` Record fields to accept a single-character strings
+- Changed `rtype` and `length` to no longer be settable from Python. Users should
+  use the Record type `__init__` methods to initialize records
 
 ### Bug fixes
 - Added missing Python type stub for `CMBP_1` variant in `Schema`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.22.0 - TBD
+## 0.22.0 - 2024-10-01
 
 ### Enhancements
 - Added Python type stubs for Record `__init__` methods

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.21.0"
+version = "0.22.0"
 documentation = "https://docs.databento.com"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.21.0"
+version = "0.22.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.21.0"
+version = "0.22.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -358,7 +358,7 @@ class Schema(Enum):
         Exchange status.
     IMBALANCE
         Auction imbalance events.
-    CBBO
+    CMBP_1
         Consolidated best bid and offer.
     CBBO_1S
         Consolidated best bid and offer record.
@@ -387,7 +387,7 @@ class Schema(Enum):
     STATISTICS: str
     STATUS: str
     IMBALANCE: str
-    CBBO: str
+    CMBP_1: str
     CBBO_1S: str
     CBBO_1M: str
     TCBBO: str

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: UP007 PYI021 PYI053
+# ruff: noqa: UP007 PYI021 PYI053 PYI011
 from __future__ import annotations
 
 import datetime as dt
@@ -1329,11 +1329,37 @@ class MBOMsg(Record, _MBOBase):
     A market-by-order (MBO) tick message.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        order_id: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        ts_recv: int,
+        flags: int | None = None,
+        channel_id: int | None = None,
+        ts_in_delta: int | None = None,
+        sequence: int | None = None,
+    ) -> None: ...
+
 class BidAskPair:
     """
     A book level.
     """
 
+    def __init__(
+        self,
+        bid_px: int = UNDEF_PRICE,
+        ask_px: int = UNDEF_PRICE,
+        bid_sz: int = 0,
+        ask_sz: int = 0,
+        bid_ct: int = 0,
+        ask_ct: int = 0,
+    ) -> None: ...
     @property
     def pretty_bid_px(self) -> float:
         """
@@ -1445,6 +1471,15 @@ class ConsolidatedBidAskPair:
     A consolidated book level.
     """
 
+    def __init__(
+        self,
+        bid_px: int = UNDEF_PRICE,
+        ask_px: int = UNDEF_PRICE,
+        bid_sz: int = 0,
+        ask_sz: int = 0,
+        bid_pb: int = 0,
+        ask_pb: int = 0,
+    ) -> None: ...
     @property
     def pretty_bid_px(self) -> float:
         """
@@ -1721,11 +1756,43 @@ class TradeMsg(Record, _MBPBase):
 
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        depth: int,
+        ts_recv: int,
+        flags: int | None = None,
+        ts_in_delta: int | None = None,
+        sequence: int | None = None,
+    ) -> None: ...
+
 class MBP1Msg(Record, _MBPBase):
     """
     Market by price implementation with a known book depth of 1.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        depth: int,
+        ts_recv: int,
+        flags: int | None = None,
+        ts_in_delta: int | None = None,
+        sequence: int | None = None,
+        levels: BidAskPair | None = None,
+    ) -> None: ...
     @property
     def levels(self) -> list[BidAskPair]:
         """
@@ -1746,6 +1813,21 @@ class BBOMsg(Record):
     Subsampled market by price with a known book depth of 1.
     """
 
+    def __init__(
+        self,
+        rtype: int,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        ts_recv: int,
+        flags: int | None = None,
+        sequence: int | None = None,
+        levels: BidAskPair | None = None,
+    ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
@@ -1867,6 +1949,21 @@ class CMBP1Msg(Record):
     Consolidated best bid and offer implementation.
     """
 
+    def __init__(
+        self,
+        rtype: int,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        ts_recv: int,
+        flags: int | None = None,
+        ts_in_delta: int | None = None,
+        levels: ConsolidatedBidAskPair | None = None,
+    ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
@@ -2018,6 +2115,19 @@ class CBBOMsg(Record):
     Subsampled consolidated best bid and offer.
     """
 
+    def __init__(
+        self,
+        rtype: int,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        side: str,
+        ts_recv: int,
+        flags: int | None = None,
+        levels: ConsolidatedBidAskPair | None = None,
+    ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
@@ -2139,6 +2249,22 @@ class MBP10Msg(Record, _MBPBase):
     Market by price implementation with a known book depth of 10.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        price: int,
+        size: int,
+        action: str,
+        side: str,
+        depth: int,
+        ts_recv: int,
+        flags: int | None = None,
+        ts_in_delta: int | None = None,
+        sequence: int | None = None,
+        levels: list[BidAskPair] | None = None,
+    ) -> None: ...
     @property
     def levels(self) -> list[BidAskPair]:
         """
@@ -2159,6 +2285,18 @@ class OHLCVMsg(Record):
     Open, high, low, close, and volume message.
     """
 
+    def __init__(
+        self,
+        rtype: int,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        open: int,
+        high: int,
+        low: int,
+        close: int,
+        volume: int,
+    ) -> None: ...
     @property
     def pretty_open(self) -> float:
         """
@@ -2299,6 +2437,72 @@ class InstrumentDefMsg(Record):
     Definition of an instrument.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        ts_recv: int,
+        min_price_increment: int,
+        display_factor: int,
+        min_lot_size_round_lot: int,
+        raw_symbol: str,
+        group: str,
+        exchange: str,
+        instrument_class: str,
+        match_algorithm: str,
+        md_security_trading_status: str,
+        security_update_action: str,
+        expiration: int = UNDEF_TIMESTAMP,
+        activation: int = UNDEF_TIMESTAMP,
+        high_limit_price: int = UNDEF_PRICE,
+        low_limit_price: int = UNDEF_PRICE,
+        max_price_variation: int = UNDEF_PRICE,
+        trading_reference_price: int = UNDEF_PRICE,
+        unit_of_measure_qty: int = UNDEF_PRICE,
+        min_price_increment_amount: int = UNDEF_PRICE,
+        price_ratio: int = UNDEF_PRICE,
+        inst_attrib_value: int | None = None,
+        underlying_id: int | None = None,
+        raw_instrument_id: int | None = None,
+        market_depth_implied: int | None = None,
+        market_depth: int | None = None,
+        market_segment_id: int | None = None,
+        max_trade_vol: int | None = None,
+        min_lot_size: int | None = None,
+        min_lot_size_block: int | None = None,
+        min_trade_vol: int | None = None,
+        contract_multiplier: int | None = None,
+        decay_quantity: int | None = None,
+        original_contract_size: int | None = None,
+        trading_reference_date: int | None = None,
+        appl_id: int | None = None,
+        maturity_year: int | None = None,
+        decay_start_date: int | None = None,
+        channel_id: int | None = None,
+        currency: str = "",
+        settl_currency: str = "",
+        secsubtype: str = "",
+        asset: str = "",
+        cfi: str = "",
+        security_type: str = "",
+        unit_of_measure: str = "",
+        underlying: str = "",
+        strike_price_currency: str = "",
+        strike_price: int = UNDEF_PRICE,
+        main_fraction: int | None = None,
+        price_display_format: int | None = None,
+        settl_price_type: int | None = None,
+        sub_fraction: int | None = None,
+        underlying_product: int | None = None,
+        maturity_month: int | None = None,
+        maturity_day: int | None = None,
+        maturity_week: int | None = None,
+        user_defined_instrument: str | None = None,
+        contract_multiplier_unit: int | None = None,
+        flow_schedule_type: int | None = None,
+        tick_rule: int | None = None,
+    ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime:
         """
@@ -3174,6 +3378,72 @@ class InstrumentDefMsgV1(Record):
     A DBN version 1 definition of an instrument.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        ts_recv: int,
+        min_price_increment: int,
+        display_factor: int,
+        min_lot_size_round_lot: int,
+        raw_symbol: str,
+        group: str,
+        exchange: str,
+        instrument_class: str,
+        match_algorithm: str,
+        md_security_trading_status: str,
+        security_update_action: str,
+        expiration: int = UNDEF_TIMESTAMP,
+        activation: int = UNDEF_TIMESTAMP,
+        high_limit_price: int = UNDEF_PRICE,
+        low_limit_price: int = UNDEF_PRICE,
+        max_price_variation: int = UNDEF_PRICE,
+        trading_reference_price: int = UNDEF_PRICE,
+        unit_of_measure_qty: int = UNDEF_PRICE,
+        min_price_increment_amount: int = UNDEF_PRICE,
+        price_ratio: int = UNDEF_PRICE,
+        inst_attrib_value: int | None = None,
+        underlying_id: int | None = None,
+        raw_instrument_id: int | None = None,
+        market_depth_implied: int | None = None,
+        market_depth: int | None = None,
+        market_segment_id: int | None = None,
+        max_trade_vol: int | None = None,
+        min_lot_size: int | None = None,
+        min_lot_size_block: int | None = None,
+        min_trade_vol: int | None = None,
+        contract_multiplier: int | None = None,
+        decay_quantity: int | None = None,
+        original_contract_size: int | None = None,
+        trading_reference_date: int | None = None,
+        appl_id: int | None = None,
+        maturity_year: int | None = None,
+        decay_start_date: int | None = None,
+        channel_id: int | None = None,
+        currency: str = "",
+        settl_currency: str = "",
+        secsubtype: str = "",
+        asset: str = "",
+        cfi: str = "",
+        security_type: str = "",
+        unit_of_measure: str = "",
+        underlying: str = "",
+        strike_price_currency: str = "",
+        strike_price: int = UNDEF_PRICE,
+        main_fraction: int | None = None,
+        price_display_format: int | None = None,
+        settl_price_type: int | None = None,
+        sub_fraction: int | None = None,
+        underlying_product: int | None = None,
+        maturity_month: int | None = None,
+        maturity_day: int | None = None,
+        maturity_week: int | None = None,
+        user_defined_instrument: str | None = None,
+        contract_multiplier_unit: int | None = None,
+        flow_schedule_type: int | None = None,
+        tick_rule: int | None = None,
+    ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime:
         """
@@ -4049,6 +4319,21 @@ class ImbalanceMsg(Record):
     An auction imbalance message.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        ts_recv: int,
+        ref_price: int,
+        cont_book_clr_price: int,
+        auct_interest_clr_price: int,
+        paired_qty: int,
+        total_imbalance_qty: int,
+        auction_type: str,
+        side: str,
+        significant_imbalance: str,
+    ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime:
         """
@@ -4356,6 +4641,22 @@ class StatMsg(Record):
 
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        ts_recv: int,
+        ts_ref: int,
+        price: int,
+        quantity: int,
+        stat_type: int,
+        sequence: int | None = None,
+        ts_in_delta: int | None = None,
+        channel_id: int | None = None,
+        update_action: int | None = None,
+        stat_flags: int = 0,
+    ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime:
         """
@@ -4609,21 +4910,10 @@ class StatusMsg(Record):
 
         """
 
-class ErrorMsg(Record):
+class ErrorMsg(ErrorMsgV1):
     """
     An error message from the Databento Live Subscription Gateway (LSG).
     """
-
-    @property
-    def err(self) -> str:
-        """
-        The error message.
-
-        Returns
-        -------
-        str
-
-        """
 
     @property
     def is_last(self) -> int:
@@ -4641,6 +4931,7 @@ class ErrorMsgV1(Record):
     A DBN version 1 error message from the Databento Live Subscription Gateway (LSG).
     """
 
+    def __init__(self, ts_event: int, err: str, is_last: bool = True) -> None: ...
     @property
     def err(self) -> str:
         """
@@ -4657,6 +4948,18 @@ class SymbolMappingMsg(Record):
     another.
     """
 
+    def __init__(
+        self,
+        publisher_id: int,
+        instrument_id: int,
+        ts_event: int,
+        stype_in: SType,
+        stype_in_symbol: str,
+        stype_out: SType,
+        stype_out_symbol: str,
+        start_ts: int,
+        end_ts: int,
+    ) -> None: ...
     @property
     def stype_in(self) -> SType:
         """
@@ -4749,82 +5052,12 @@ class SymbolMappingMsg(Record):
 
         """
 
-class SymbolMappingMsgV1(Record):
+class SymbolMappingMsgV1(SymbolMappingMsg):
     """A DBN version 1 symbol mapping message which maps a symbol of one `SType`
     to another.
     """
 
-    @property
-    def stype_in_symbol(self) -> str:
-        """
-        The input symbol.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def stype_out_symbol(self) -> str:
-        """
-        The output symbol.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def pretty_start_ts(self) -> dt.datetime:
-        """
-        The start of the mapping interval expressed as a datetime
-        or `pandas.Timestamp`, if available.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def start_ts(self) -> int:
-        """
-        The start of the mapping interval expressed as the number of
-        nanoseconds since the UNIX epoch.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_end_ts(self) -> dt.datetime:
-        """
-        The end of the mapping interval expressed as a datetime
-        or `pandas.Timestamp`, if available.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def end_ts(self) -> int:
-        """
-        The end of the mapping interval expressed as the number of nanoseconds
-        since the UNIX epoch.
-
-        Returns
-        -------
-        int
-
-        """
-
-class SystemMsg(Record):
+class SystemMsg(SystemMsgV1):
     """
     A non-error message from the Databento Live Subscription Gateway (LSG).
 
@@ -4833,26 +5066,13 @@ class SystemMsg(Record):
     """
 
     @property
-    def msg(self) -> str:
+    def code(self) -> int:
         """
-        The message from the Databento Live Subscription Gateway (LSG).
+        Type of system message, currently unused.
 
         Returns
         -------
-        str
-
-        """
-
-    @property
-    def is_heartbeat(self) -> bool:
-        """
-        `true` if this message is a heartbeat, used to indicate the connection
-        with the gateway is still open.
-
-        Returns
-        -------
-        bool
-
+        int
         """
 
 class SystemMsgV1(Record):
@@ -4864,6 +5084,7 @@ class SystemMsgV1(Record):
 
     """
 
+    def __init__(self, ts_event: int, msg: str) -> None: ...
     @property
     def msg(self) -> str:
         """

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.21.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.22.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.21.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.22.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.11", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -149,10 +149,20 @@ impl MboMsg {
     fn get_action(&self) -> char {
         self.action as u8 as char
     }
+    #[setter]
+    fn set_action(&mut self, action: char) -> PyResult<()> {
+        self.action = char_to_c_char(action)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[classattr]
@@ -471,7 +481,6 @@ impl Cmbp1Msg {
     fn ts_event(&self) -> u64 {
         self.hd.ts_event
     }
-
     #[setter]
     fn set_ts_event(&mut self, ts_event: u64) {
         self.hd.ts_event = ts_event;
@@ -506,10 +515,20 @@ impl Cmbp1Msg {
     fn get_action(&self) -> char {
         self.action as u8 as char
     }
+    #[setter]
+    fn set_action(&mut self, action: char) -> PyResult<()> {
+        self.action = char_to_c_char(action)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[classattr]
@@ -581,7 +600,6 @@ impl CbboMsg {
             _reserved1: Default::default(),
             _reserved2: Default::default(),
             _reserved3: Default::default(),
-            _reserved4: Default::default(),
         })
     }
 
@@ -620,7 +638,6 @@ impl CbboMsg {
     fn ts_event(&self) -> u64 {
         self.hd.ts_event
     }
-
     #[setter]
     fn set_ts_event(&mut self, ts_event: u64) {
         self.hd.ts_event = ts_event;
@@ -876,10 +893,20 @@ impl TradeMsg {
     fn get_action(&self) -> char {
         self.action as u8 as char
     }
+    #[setter]
+    fn set_action(&mut self, action: char) -> PyResult<()> {
+        self.action = char_to_c_char(action)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[classattr]
@@ -1031,10 +1058,20 @@ impl Mbp1Msg {
     fn get_action(&self) -> char {
         self.action as u8 as char
     }
+    #[setter]
+    fn set_action(&mut self, action: char) -> PyResult<()> {
+        self.action = char_to_c_char(action)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[classattr]
@@ -1198,10 +1235,20 @@ impl Mbp10Msg {
     fn get_action(&self) -> char {
         self.action as u8 as char
     }
+    #[setter]
+    fn set_action(&mut self, action: char) -> PyResult<()> {
+        self.action = char_to_c_char(action)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[classattr]
@@ -1580,7 +1627,7 @@ impl InstrumentDefMsg {
         contract_multiplier_unit = None,
         flow_schedule_type = None,
         tick_rule = None,
-    ))]
+  ))]
     fn py_new(
         publisher_id: u16,
         instrument_id: u32,
@@ -1913,15 +1960,30 @@ impl InstrumentDefMsg {
     fn get_instrument_class(&self) -> char {
         self.instrument_class as u8 as char
     }
+    #[setter]
+    fn set_instrument_class(&mut self, instrument_class: char) -> PyResult<()> {
+        self.instrument_class = char_to_c_char(instrument_class)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_match_algorithm(&self) -> char {
         self.match_algorithm as u8 as char
     }
+    #[setter]
+    fn set_match_algorithm(&mut self, match_algorithm: char) -> PyResult<()> {
+        self.match_algorithm = char_to_c_char(match_algorithm)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_security_update_action(&self) -> char {
         self.security_update_action as u8 as char
+    }
+    #[setter]
+    fn set_security_update_action(&mut self, security_update_action: char) -> PyResult<()> {
+        self.security_update_action = char_to_c_char(security_update_action)?;
+        Ok(())
     }
 
     #[getter]
@@ -2364,10 +2426,20 @@ impl InstrumentDefMsgV1 {
     fn get_instrument_class(&self) -> char {
         self.instrument_class as u8 as char
     }
+    #[setter]
+    fn set_instrument_class(&mut self, instrument_class: char) -> PyResult<()> {
+        self.instrument_class = char_to_c_char(instrument_class)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_match_algorithm(&self) -> char {
         self.match_algorithm as u8 as char
+    }
+    #[setter]
+    fn set_match_algorithm(&mut self, match_algorithm: char) -> PyResult<()> {
+        self.match_algorithm = char_to_c_char(match_algorithm)?;
+        Ok(())
     }
 
     #[getter]
@@ -2534,20 +2606,40 @@ impl ImbalanceMsg {
     fn get_auction_type(&self) -> char {
         self.auction_type as u8 as char
     }
+    #[setter]
+    fn set_auction_type(&mut self, auction_type: char) -> PyResult<()> {
+        self.auction_type = char_to_c_char(auction_type)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_side(&self) -> char {
         self.side as u8 as char
+    }
+    #[setter]
+    fn set_side(&mut self, side: char) -> PyResult<()> {
+        self.side = char_to_c_char(side)?;
+        Ok(())
     }
 
     #[getter]
     fn get_unpaired_side(&self) -> char {
         self.unpaired_side as u8 as char
     }
+    #[setter]
+    fn set_unpaired_side(&mut self, unpaired_side: char) -> PyResult<()> {
+        self.unpaired_side = char_to_c_char(unpaired_side)?;
+        Ok(())
+    }
 
     #[getter]
     fn get_significant_imbalance(&self) -> char {
         self.significant_imbalance as u8 as char
+    }
+    #[setter]
+    fn set_significant_imbalance(&mut self, significant_imbalance: char) -> PyResult<()> {
+        self.significant_imbalance = char_to_c_char(significant_imbalance)?;
+        Ok(())
     }
 
     #[classattr]

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -34,9 +34,10 @@ pub use conv::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(get_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
+#[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
 #[cfg_attr(test, derive(type_layout::TypeLayout))]
 pub struct RecordHeader {
     /// The length of the record in 32-bit words.
@@ -48,12 +49,15 @@ pub struct RecordHeader {
     /// a given rtype. The set of possible values is defined in [`rtype`].
     pub rtype: u8,
     /// The publisher ID assigned by Databento, which denotes the dataset and venue.
+    #[pyo3(set)]
     pub publisher_id: u16,
     /// The numeric ID assigned to the instrument.
+    #[pyo3(set)]
     pub instrument_id: u32,
     /// The matching-engine-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), unix_nanos)]
+    #[pyo3(set)]
     pub ts_event: u64,
 }
 
@@ -65,7 +69,7 @@ pub struct RecordHeader {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "MBOMsg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "MBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -76,24 +80,24 @@ pub struct MboMsg {
     #[pyo3(get)]
     pub hd: RecordHeader,
     /// The order ID assigned at the venue.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub order_id: u64,
     /// The order price expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(encode_order(4), fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The order quantity.
     #[dbn(encode_order(5))]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     /// A channel ID within the venue.
     #[dbn(encode_order(6))]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub channel_id: u8,
     /// The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R**,
     /// **T**rade, or **F**ill.
@@ -107,13 +111,13 @@ pub struct MboMsg {
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_in_delta: i32,
     /// The message sequence number assigned at the venue.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub sequence: u32,
 }
 
@@ -191,7 +195,7 @@ pub struct ConsolidatedBidAskPair {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -204,10 +208,10 @@ pub struct TradeMsg {
     /// The order price expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The order quantity.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     /// The event action. Always **T**rade in the trades schema.
     #[dbn(c_char, encode_order(2))]
@@ -219,22 +223,22 @@ pub struct TradeMsg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     /// The depth of actual book change.
     #[dbn(encode_order(4))]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub depth: u8,
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_in_delta: i32,
     /// The message sequence number assigned at the venue.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub sequence: u32,
 }
 
@@ -246,7 +250,7 @@ pub struct TradeMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "MBP1Msg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "MBP1Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -259,10 +263,10 @@ pub struct Mbp1Msg {
     /// The order price expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The order quantity.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     /// The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R**, or
     /// **T**rade.
@@ -275,25 +279,25 @@ pub struct Mbp1Msg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     /// The depth of actual book change.
     #[dbn(encode_order(4))]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub depth: u8,
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_in_delta: i32,
     /// The message sequence number assigned at the venue.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub sequence: u32,
     /// The top of the order book.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub levels: [BidAskPair; 1],
 }
 
@@ -305,7 +309,7 @@ pub struct Mbp1Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "MBP10Msg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "MBP10Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -318,10 +322,10 @@ pub struct Mbp10Msg {
     /// The order price expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The order quantity.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     /// The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R**, or
     /// **T**rade.
@@ -334,25 +338,25 @@ pub struct Mbp10Msg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     /// The depth of actual book change.
     #[dbn(encode_order(4))]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub depth: u8,
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_in_delta: i32,
     /// The message sequence number assigned at the venue.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub sequence: u32,
     /// The top 10 levels of the order book.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub levels: [BidAskPair; 10],
 }
 
@@ -364,7 +368,7 @@ pub struct Mbp10Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "BBOMsg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "BBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -377,10 +381,10 @@ pub struct BboMsg {
     /// The price of the last trade expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The quantity of the last trade.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     // Reserved for later usage.
     #[doc(hidden)]
@@ -393,7 +397,7 @@ pub struct BboMsg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     // Reserved for later usage.
     #[doc(hidden)]
@@ -401,17 +405,17 @@ pub struct BboMsg {
     pub _reserved2: u8,
     /// The interval timestamp expressed as number of nanoseconds since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     // Reserved for later usage.
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _reserved3: [u8; 4],
     /// The sequence number assigned at the venue of the last update.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub sequence: u32,
     /// The top of the order book.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub levels: [BidAskPair; 1],
 }
 
@@ -423,7 +427,7 @@ pub struct BboMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "CMBP1Msg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "CMBP1Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -436,10 +440,10 @@ pub struct Cmbp1Msg {
     /// The order price expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The order quantity.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     /// The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R**, or
     /// **T**rade.
@@ -452,7 +456,7 @@ pub struct Cmbp1Msg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     // Reserved for future usage.
     #[doc(hidden)]
@@ -461,16 +465,16 @@ pub struct Cmbp1Msg {
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_in_delta: i32,
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _reserved2: [c_char; 4],
     /// The top of the order book.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub levels: [ConsolidatedBidAskPair; 1],
 }
 
@@ -482,7 +486,7 @@ pub struct Cmbp1Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn", name = "CBBOMsg"),
+    pyo3::pyclass(dict, module = "databento_dbn", name = "CBBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -495,10 +499,10 @@ pub struct CbboMsg {
     /// The price of the last trade expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub price: i64,
     /// The quantity of the last trade.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub size: u32,
     // Reserved for later usage.
     #[doc(hidden)]
@@ -511,7 +515,7 @@ pub struct CbboMsg {
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
     /// [`enums::flags`](crate::enums::flags) for possible values.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub flags: FlagSet,
     // Reserved for later usage.
     #[doc(hidden)]
@@ -519,18 +523,14 @@ pub struct CbboMsg {
     pub _reserved2: u8,
     /// The interval timestamp expressed as number of nanoseconds since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     // Reserved for later usage.
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub _reserved3: [u8; 4],
-    /// Reserved for later usage.
-    #[doc(hidden)]
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub _reserved4: [u8; 4],
+    pub _reserved3: [u8; 8],
     /// The top of the order book.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub levels: [ConsolidatedBidAskPair; 1],
 }
 
@@ -560,9 +560,10 @@ pub type Cbbo1MMsg = CbboMsg;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn", name = "OHLCVMsg"),
+    pyo3::pyclass(get_all, dict, module = "databento_dbn", name = "OHLCVMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
+#[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
 #[cfg_attr(test, derive(type_layout::TypeLayout))]
 #[dbn_record(
     rtype::OHLCV_1S,
@@ -577,17 +578,22 @@ pub struct OhlcvMsg {
     pub hd: RecordHeader,
     /// The open price for the bar.
     #[dbn(fixed_price)]
+    #[pyo3(set)]
     pub open: i64,
     /// The high price for the bar.
     #[dbn(fixed_price)]
+    #[pyo3(set)]
     pub high: i64,
     /// The low price for the bar.
     #[dbn(fixed_price)]
+    #[pyo3(set)]
     pub low: i64,
     /// The close price for the bar.
     #[dbn(fixed_price)]
+    #[pyo3(set)]
     pub close: i64,
     /// The total volume traded during the aggregation period.
+    #[pyo3(set)]
     pub volume: u64,
 }
 
@@ -607,7 +613,7 @@ pub struct OhlcvMsg {
 #[dbn_record(rtype::STATUS)]
 pub struct StatusMsg {
     /// The common header.
-    #[pyo3(get, set)]
+    #[pyo3(get)]
     pub hd: RecordHeader,
     /// The capture-server-received timestamp expressed as number of nanoseconds since
     /// the UNIX epoch.
@@ -899,7 +905,7 @@ pub struct InstrumentDefMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -912,51 +918,51 @@ pub struct ImbalanceMsg {
     /// The capture-server-received timestamp expressed as the number of nanoseconds
     /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The price at which the imbalance shares are calculated, where every 1 unit corresponds to
     /// 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ref_price: i64,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub auction_time: u64,
     /// The hypothetical auction-clearing price for both cross and continuous orders.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub cont_book_clr_price: i64,
     /// The hypothetical auction-clearing price for cross orders only.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub auct_interest_clr_price: i64,
     /// Reserved for future use.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ssr_filling_price: i64,
     /// Reserved for future use.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub ind_match_price: i64,
     /// Reserved for future use.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub upper_collar: i64,
     /// Reserved for future use.
     #[dbn(fixed_price)]
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub lower_collar: i64,
     /// The quantity of shares that are eligible to be matched at `ref_price`.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub paired_qty: u32,
     /// The quantity of shares that are not paired at `ref_price`.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub total_imbalance_qty: u32,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub market_imbalance_qty: u32,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub unpaired_qty: u32,
     /// Venue-specific character code indicating the auction type.
     #[dbn(c_char)]
@@ -965,13 +971,13 @@ pub struct ImbalanceMsg {
     #[dbn(c_char)]
     pub side: c_char,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub auction_status: u8,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub freeze_status: u8,
     /// Reserved for future use.
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub num_extensions: u8,
     /// Reserved for future use.
     #[dbn(c_char)]
@@ -993,7 +999,7 @@ pub struct ImbalanceMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(get_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -1005,36 +1011,46 @@ pub struct StatMsg {
     /// The capture-server-received timestamp expressed as the number of nanoseconds
     /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
+    #[pyo3(set)]
     pub ts_recv: u64,
     /// The reference timestamp of the statistic value expressed as the number of
     /// nanoseconds since the UNIX epoch. Will be [`crate::UNDEF_TIMESTAMP`] when
     /// unused.
     #[dbn(unix_nanos)]
+    #[pyo3(set)]
     pub ts_ref: u64,
     /// The value for price statistics expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be
     /// [`crate::UNDEF_PRICE`] when unused.
     #[dbn(fixed_price)]
+    #[pyo3(set)]
     pub price: i64,
     /// The value for non-price statistics. Will be [`crate::UNDEF_STAT_QUANTITY`] when
     /// unused.
+    #[pyo3(set)]
     pub quantity: i32,
     /// The message sequence number assigned at the venue.
+    #[pyo3(set)]
     pub sequence: u32,
     /// The delta of `ts_recv - ts_exchange_send`, max 2 seconds.
+    #[pyo3(set)]
     pub ts_in_delta: i32,
     /// The type of statistic value contained in the message. Refer to the
     /// [`StatType`](crate::enums::StatType) for variants.
     #[dbn(fmt_method)]
+    #[pyo3(set)]
     pub stat_type: u16,
     /// A channel ID within the venue.
+    #[pyo3(set)]
     pub channel_id: u16,
     /// Indicates if the statistic is newly added (1) or deleted (2). (Deleted is only used with
     /// some stat types)
     #[dbn(fmt_method)]
+    #[pyo3(set)]
     pub update_action: u8,
     /// Additional flags associate with certain stat types.
     #[dbn(fmt_binary)]
+    #[pyo3(set)]
     pub stat_flags: u8,
     // Filler for alignment
     #[doc(hidden)]
@@ -1057,7 +1073,7 @@ pub struct StatMsg {
 #[dbn_record(rtype::ERROR)]
 pub struct ErrorMsg {
     /// The common header.
-    #[pyo3(get, set)]
+    #[pyo3(get)]
     pub hd: RecordHeader,
     /// The error message.
     #[dbn(fmt_method)]

--- a/rust/dbn/src/record/impl_default.rs
+++ b/rust/dbn/src/record/impl_default.rs
@@ -128,8 +128,7 @@ impl CbboMsg {
             ts_recv: UNDEF_TIMESTAMP,
             _reserved1: 0,
             _reserved2: 0,
-            _reserved3: [0; 4],
-            _reserved4: [0; 4],
+            _reserved3: Default::default(),
             levels: Default::default(),
         }
     }


### PR DESCRIPTION
## 0.22.0 - 2024-10-01

### Enhancements
- Added Python type stubs for Record `__init__` methods

### Breaking changes
- Combine `_reserved3` and `_reserved4` fields in `CbboMsg`
- Changed setters for `char` Record fields to accept a single-character strings
- Changed `rtype` and `length` to no longer be settable from Python. Users should
  use the Record type `__init__` methods to initialize records

### Bug fixes
- Added missing Python type stub for `CMBP_1` variant in `Schema`
