### PR TITLE
VER: Release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-### 0.27.0 - TBD (coming soon)
+## 0.27.0 - TBD
 
 ### Breaking changes
 - Updated enumerations for unreleased datasets and publishers.
 
 ### Enhancements
 - Added new dataset `EQUS.MINI` and new publisher `EQUS.MINI.EQUS`
+
+### Bug fixes
+- Fixed export of `InstrumentDefMsgV3` to Python
 
 ## 0.26.0 - 2025-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Enhancements
 - Added new dataset `EQUS.MINI` and new publisher `EQUS.MINI.EQUS`
+- Upgraded `pyo3` version to 0.23.4 with improved support for Python 3.13
 
 ### Bug fixes
 - Fixed export of `InstrumentDefMsgV3` to Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 0.27.0 - TBD
+## 0.27.0 - 2025-01-21
 
 ### Breaking changes
-- Updated enumerations for unreleased datasets and publishers.
+- Updated enumerations for unreleased US equities datasets and publishers
 
 ### Enhancements
-- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS`, `XNYS.TRADES.EQUS`
+- Added new venue `EQUS` for consolidated US equities
+- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and `XNYS.TRADES.EQUS`
 - Upgraded `pyo3` version to 0.23.4 with improved support for Python 3.13
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Updated enumerations for unreleased datasets and publishers.
 
 ### Enhancements
-- Added new dataset `EQUS.MINI` and new publisher `EQUS.MINI.EQUS`
+- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS`, `XNYS.TRADES.EQUS`
 - Upgraded `pyo3` version to 0.23.4 with improved support for Python 3.13
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.27.0 - TBD (coming soon)
+
+### Breaking changes
+- Updated enumerations for unreleased datasets and publishers.
+
+### Enhancements
+- Added new dataset `EQUS.MINI` and new publisher `EQUS.MINI.EQUS`
+
 ## 0.26.0 - 2025-01-07
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,19 +67,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "assert_cmd"
@@ -134,15 +135,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -168,16 +169,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.90",
+ "syn 2.0.96",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",
@@ -192,9 +193,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -202,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -215,14 +216,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -325,7 +326,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "trybuild",
 ]
 
@@ -381,9 +382,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -444,7 +445,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -484,6 +485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,9 +503,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -562,21 +574,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -604,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -650,14 +662,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -670,9 +682,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -700,9 +712,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -714,15 +726,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -739,18 +751,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -766,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -776,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -786,34 +798,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -879,7 +891,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.90",
+ "syn 2.0.96",
  "unicode-ident",
 ]
 
@@ -900,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
@@ -913,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -925,35 +937,35 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1010,7 +1022,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1026,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1049,12 +1061,13 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1081,28 +1094,28 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1138,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1150,13 +1163,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1257,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,9 +1359,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.26.0"
+version = "0.27.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ license = "Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.94"
 csv = "1.3"
-pyo3 = "0.22.6"
-pyo3-build-config = "0.22.6"
+pyo3 = "0.23.4"
+pyo3-build-config = "0.23.4"
 rstest = "0.23.0"
 serde = { version = "1.0", features = ["derive"] }
 time = ">=0.3.35"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.26.0"
+version = "0.27.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.26.0"
+version = "0.27.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -30,7 +30,7 @@ fn databento_dbn(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     }
     // all functions exposed to Python need to be added here
     m.add_wrapped(wrap_pyfunction!(encode::update_encoded_metadata))?;
-    m.add("DBNError", m.py().get_type_bound::<DBNError>())?;
+    m.add("DBNError", m.py().get_type::<DBNError>())?;
     checked_add_class::<EnumIterator>(m)?;
     checked_add_class::<Metadata>(m)?;
     checked_add_class::<dbn_decoder::DbnDecoder>(m)?;
@@ -99,6 +99,7 @@ mod tests {
     use std::sync::Once;
 
     use dbn::enums::SType;
+    use pyo3::ffi::c_str;
 
     use super::*;
 
@@ -157,8 +158,9 @@ assert metadata.ts_out is False"#
     fn test_dbn_decoder_metadata_error() {
         setup();
         Python::with_gil(|py| {
-            py.run_bound(
-                r#"from _lib import DBNDecoder
+            py.run(
+                c_str!(
+                    r#"from _lib import DBNDecoder
 
 decoder = DBNDecoder()
 try:
@@ -167,7 +169,8 @@ try:
     assert False
 except Exception:
     pass
-"#,
+"#
+                ),
                 None,
                 None,
             )

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3,7 +3,7 @@
 use pyo3::{prelude::*, wrap_pyfunction, PyClass};
 
 use dbn::{
-    compat::{ErrorMsgV1, InstrumentDefMsgV1, SymbolMappingMsgV1, SystemMsgV1},
+    compat::{ErrorMsgV1, InstrumentDefMsgV1, InstrumentDefMsgV3, SymbolMappingMsgV1, SystemMsgV1},
     flags,
     python::{DBNError, EnumIterator},
     Action, BboMsg, BidAskPair, CbboMsg, Cmbp1Msg, Compression, ConsolidatedBidAskPair, Encoding,
@@ -48,6 +48,7 @@ fn databento_dbn(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     checked_add_class::<StatusMsg>(m)?;
     checked_add_class::<InstrumentDefMsg>(m)?;
     checked_add_class::<InstrumentDefMsgV1>(m)?;
+    checked_add_class::<InstrumentDefMsgV3>(m)?;
     checked_add_class::<ErrorMsg>(m)?;
     checked_add_class::<ErrorMsgV1>(m)?;
     checked_add_class::<SymbolMappingMsg>(m)?;

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.26.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.27.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.26.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.27.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.18", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/metadata.rs
+++ b/rust/dbn/src/metadata.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Information about the data contained in a DBN file or stream. DBN requires the
 /// Metadata to be included at the start of the encoded data.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "python", pyo3::pyclass(module = "databento_dbn"))]
+#[cfg_attr(feature = "python", pyo3::pyclass(eq, module = "databento_dbn"))]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
 pub struct Metadata {
     /// The DBN schema version number. Newly-encoded DBN files will use

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -89,7 +89,7 @@ pub enum Venue {
     Ifeu = 38,
     /// ICE Endex
     Ndex = 39,
-    /// Databento Equities - Consolidated
+    /// Databento US Equities - Consolidated
     Dbeq = 40,
     /// MIAX Sapphire
     Sphr = 41,
@@ -103,10 +103,12 @@ pub enum Venue {
     Asmt = 45,
     /// IntelligentCross ASPEN Inverted
     Aspi = 46,
+    /// Databento US Equities - Consolidated
+    Equs = 47,
 }
 
 /// The number of Venue variants.
-pub const VENUE_COUNT: usize = 46;
+pub const VENUE_COUNT: usize = 47;
 
 impl Venue {
     /// Convert a Venue to its `str` representation.
@@ -158,6 +160,7 @@ impl Venue {
             Self::Aspn => "ASPN",
             Self::Asmt => "ASMT",
             Self::Aspi => "ASPI",
+            Self::Equs => "EQUS",
         }
     }
 }
@@ -225,6 +228,7 @@ impl std::str::FromStr for Venue {
             "ASPN" => Ok(Self::Aspn),
             "ASMT" => Ok(Self::Asmt),
             "ASPI" => Ok(Self::Aspi),
+            "EQUS" => Ok(Self::Equs),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -275,14 +279,14 @@ pub enum Dataset {
     FinyTrades = 18,
     /// OPRA Binary
     OpraPillar = 19,
-    /// Databento Equities Basic
+    /// Databento US Equities Basic
     DbeqBasic = 20,
     /// NYSE Arca Integrated
     ArcxPillar = 21,
     /// IEX TOPS
     IexgTops = 22,
-    /// Databento Equities Plus
-    DbeqPlus = 23,
+    /// Databento US Equities Plus
+    EqusPlus = 23,
     /// NYSE BBO
     XnysBbo = 24,
     /// NYSE Trades
@@ -295,16 +299,16 @@ pub enum Dataset {
     IfeuImpact = 28,
     /// ICE Endex iMpact
     NdexImpact = 29,
-    /// Databento Equities Max
-    DbeqMax = 30,
+    /// Databento US Equities (All Feeds)
+    EqusAll = 30,
     /// Nasdaq Basic (NLS and QBBO)
     XnasBasic = 31,
-    /// Databento Equities Summary
-    DbeqSummary = 32,
-    /// NYSE National BBO and Trades
-    XcisBbotrades = 33,
-    /// NYSE BBO and Trades
-    XnysBbotrades = 34,
+    /// Databento US Equities Summary
+    EqusSummary = 32,
+    /// NYSE National Trades and BBO
+    XcisTradesbbo = 33,
+    /// NYSE Trades and BBO
+    XnysTradesbbo = 34,
 }
 
 /// The number of Dataset variants.
@@ -338,18 +342,18 @@ impl Dataset {
             Self::DbeqBasic => "DBEQ.BASIC",
             Self::ArcxPillar => "ARCX.PILLAR",
             Self::IexgTops => "IEXG.TOPS",
-            Self::DbeqPlus => "DBEQ.PLUS",
+            Self::EqusPlus => "EQUS.PLUS",
             Self::XnysBbo => "XNYS.BBO",
             Self::XnysTrades => "XNYS.TRADES",
             Self::XnasQbbo => "XNAS.QBBO",
             Self::XnasNls => "XNAS.NLS",
             Self::IfeuImpact => "IFEU.IMPACT",
             Self::NdexImpact => "NDEX.IMPACT",
-            Self::DbeqMax => "DBEQ.MAX",
+            Self::EqusAll => "EQUS.ALL",
             Self::XnasBasic => "XNAS.BASIC",
-            Self::DbeqSummary => "DBEQ.SUMMARY",
-            Self::XcisBbotrades => "XCIS.BBOTRADES",
-            Self::XnysBbotrades => "XNYS.BBOTRADES",
+            Self::EqusSummary => "EQUS.SUMMARY",
+            Self::XcisTradesbbo => "XCIS.TRADESBBO",
+            Self::XnysTradesbbo => "XNYS.TRADESBBO",
         }
     }
 }
@@ -395,18 +399,18 @@ impl std::str::FromStr for Dataset {
             "DBEQ.BASIC" => Ok(Self::DbeqBasic),
             "ARCX.PILLAR" => Ok(Self::ArcxPillar),
             "IEXG.TOPS" => Ok(Self::IexgTops),
-            "DBEQ.PLUS" => Ok(Self::DbeqPlus),
+            "EQUS.PLUS" => Ok(Self::EqusPlus),
             "XNYS.BBO" => Ok(Self::XnysBbo),
             "XNYS.TRADES" => Ok(Self::XnysTrades),
             "XNAS.QBBO" => Ok(Self::XnasQbbo),
             "XNAS.NLS" => Ok(Self::XnasNls),
             "IFEU.IMPACT" => Ok(Self::IfeuImpact),
             "NDEX.IMPACT" => Ok(Self::NdexImpact),
-            "DBEQ.MAX" => Ok(Self::DbeqMax),
+            "EQUS.ALL" => Ok(Self::EqusAll),
             "XNAS.BASIC" => Ok(Self::XnasBasic),
-            "DBEQ.SUMMARY" => Ok(Self::DbeqSummary),
-            "XCIS.BBOTRADES" => Ok(Self::XcisBbotrades),
-            "XNYS.BBOTRADES" => Ok(Self::XnysBbotrades),
+            "EQUS.SUMMARY" => Ok(Self::EqusSummary),
+            "XCIS.TRADESBBO" => Ok(Self::XcisTradesbbo),
+            "XNYS.TRADESBBO" => Ok(Self::XnysTradesbbo),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -511,72 +515,72 @@ pub enum Publisher {
     XnasQbboXnas = 46,
     /// Nasdaq Trades
     XnasNlsXnas = 47,
-    /// DBEQ Plus - NYSE Chicago
-    DbeqPlusXchi = 48,
-    /// DBEQ Plus - NYSE National
-    DbeqPlusXcis = 49,
-    /// DBEQ Plus - IEX
-    DbeqPlusIexg = 50,
-    /// DBEQ Plus - MIAX Pearl
-    DbeqPlusEprl = 51,
-    /// DBEQ Plus - Nasdaq
-    DbeqPlusXnas = 52,
-    /// DBEQ Plus - NYSE
-    DbeqPlusXnys = 53,
-    /// DBEQ Plus - FINRA/Nasdaq TRF Carteret
-    DbeqPlusFinn = 54,
-    /// DBEQ Plus - FINRA/NYSE TRF
-    DbeqPlusFiny = 55,
-    /// DBEQ Plus - FINRA/Nasdaq TRF Chicago
-    DbeqPlusFinc = 56,
+    /// Databento US Equities Plus - NYSE Chicago
+    EqusPlusXchi = 48,
+    /// Databento US Equities Plus - NYSE National
+    EqusPlusXcis = 49,
+    /// Databento US Equities Plus - IEX
+    EqusPlusIexg = 50,
+    /// Databento US Equities Plus - MIAX Pearl
+    EqusPlusEprl = 51,
+    /// Databento US Equities Plus - Nasdaq
+    EqusPlusXnas = 52,
+    /// Databento US Equities Plus - NYSE
+    EqusPlusXnys = 53,
+    /// Databento US Equities Plus - FINRA/Nasdaq TRF Carteret
+    EqusPlusFinn = 54,
+    /// Databento US Equities Plus - FINRA/NYSE TRF
+    EqusPlusFiny = 55,
+    /// Databento US Equities Plus - FINRA/Nasdaq TRF Chicago
+    EqusPlusFinc = 56,
     /// ICE Futures Europe (Commodities)
     IfeuImpactIfeu = 57,
     /// ICE Endex
     NdexImpactNdex = 58,
-    /// DBEQ Basic - Consolidated
+    /// Databento US Equities Basic - Consolidated
     DbeqBasicDbeq = 59,
-    /// DBEQ Plus - Consolidated
-    DbeqPlusDbeq = 60,
+    /// EQUS Plus - Consolidated
+    EqusPlusEqus = 60,
     /// OPRA - MIAX Sapphire
     OpraPillarSphr = 61,
-    /// DBEQ Max - NYSE Chicago
-    DbeqMaxXchi = 62,
-    /// DBEQ Max - NYSE National
-    DbeqMaxXcis = 63,
-    /// DBEQ Max - IEX
-    DbeqMaxIexg = 64,
-    /// DBEQ Max - MIAX Pearl
-    DbeqMaxEprl = 65,
-    /// DBEQ Max - Nasdaq
-    DbeqMaxXnas = 66,
-    /// DBEQ Max - NYSE
-    DbeqMaxXnys = 67,
-    /// DBEQ Max - FINRA/Nasdaq TRF Carteret
-    DbeqMaxFinn = 68,
-    /// DBEQ Max - FINRA/NYSE TRF
-    DbeqMaxFiny = 69,
-    /// DBEQ Max - FINRA/Nasdaq TRF Chicago
-    DbeqMaxFinc = 70,
-    /// DBEQ Max - CBOE BZX
-    DbeqMaxBats = 71,
-    /// DBEQ Max - CBOE BYX
-    DbeqMaxBaty = 72,
-    /// DBEQ Max - CBOE EDGA
-    DbeqMaxEdga = 73,
-    /// DBEQ Max - CBOE EDGX
-    DbeqMaxEdgx = 74,
-    /// DBEQ Max - Nasdaq BX
-    DbeqMaxXbos = 75,
-    /// DBEQ Max - Nasdaq PSX
-    DbeqMaxXpsx = 76,
-    /// DBEQ Max - MEMX
-    DbeqMaxMemx = 77,
-    /// DBEQ Max - NYSE American
-    DbeqMaxXase = 78,
-    /// DBEQ Max - NYSE Arca
-    DbeqMaxArcx = 79,
-    /// DBEQ Max - Long-Term Stock Exchange
-    DbeqMaxLtse = 80,
+    /// Databento US Equities (All Feeds) - NYSE Chicago
+    EqusAllXchi = 62,
+    /// Databento US Equities (All Feeds) - NYSE National
+    EqusAllXcis = 63,
+    /// Databento US Equities (All Feeds) - IEX
+    EqusAllIexg = 64,
+    /// Databento US Equities (All Feeds) - MIAX Pearl
+    EqusAllEprl = 65,
+    /// Databento US Equities (All Feeds) - Nasdaq
+    EqusAllXnas = 66,
+    /// Databento US Equities (All Feeds) - NYSE
+    EqusAllXnys = 67,
+    /// Databento US Equities (All Feeds) - FINRA/Nasdaq TRF Carteret
+    EqusAllFinn = 68,
+    /// Databento US Equities (All Feeds) - FINRA/NYSE TRF
+    EqusAllFiny = 69,
+    /// Databento US Equities (All Feeds) - FINRA/Nasdaq TRF Chicago
+    EqusAllFinc = 70,
+    /// Databento US Equities (All Feeds) - CBOE BZX
+    EqusAllBats = 71,
+    /// Databento US Equities (All Feeds) - CBOE BYX
+    EqusAllBaty = 72,
+    /// Databento US Equities (All Feeds) - CBOE EDGA
+    EqusAllEdga = 73,
+    /// Databento US Equities (All Feeds) - CBOE EDGX
+    EqusAllEdgx = 74,
+    /// Databento US Equities (All Feeds) - Nasdaq BX
+    EqusAllXbos = 75,
+    /// Databento US Equities (All Feeds) - Nasdaq PSX
+    EqusAllXpsx = 76,
+    /// Databento US Equities (All Feeds) - MEMX
+    EqusAllMemx = 77,
+    /// Databento US Equities (All Feeds) - NYSE American
+    EqusAllXase = 78,
+    /// Databento US Equities (All Feeds) - NYSE Arca
+    EqusAllArcx = 79,
+    /// Databento US Equities (All Feeds) - Long-Term Stock Exchange
+    EqusAllLtse = 80,
     /// Nasdaq Basic - Nasdaq
     XnasBasicXnas = 81,
     /// Nasdaq Basic - FINRA/Nasdaq TRF Carteret
@@ -596,15 +600,15 @@ pub enum Publisher {
     /// Nasdaq Basic - Nasdaq PSX
     XnasBasicXpsx = 89,
     /// Databento Equities Summary
-    DbeqSummaryDbeq = 90,
-    /// NYSE National BBO and Trades
-    XcisBbotradesXcis = 91,
-    /// NYSE BBO and Trades
-    XnysBbotradesXnys = 92,
+    EqusSummaryEqus = 90,
+    /// NYSE National Trades and BBO
+    XcisTradesbboXcis = 91,
+    /// NYSE Trades and BBO
+    XnysTradesbboXnys = 92,
     /// Nasdaq Basic - Consolidated
-    XnasBasicDbeq = 93,
-    /// DBEQ Max - Consolidated
-    DbeqMaxDbeq = 94,
+    XnasBasicEqus = 93,
+    /// Databento US Equities (All Feeds) - Consolidated
+    EqusAllEqus = 94,
 }
 
 /// The number of Publisher variants.
@@ -661,39 +665,39 @@ impl Publisher {
             Self::XnysTradesXnys => "XNYS.TRADES.XNYS",
             Self::XnasQbboXnas => "XNAS.QBBO.XNAS",
             Self::XnasNlsXnas => "XNAS.NLS.XNAS",
-            Self::DbeqPlusXchi => "DBEQ.PLUS.XCHI",
-            Self::DbeqPlusXcis => "DBEQ.PLUS.XCIS",
-            Self::DbeqPlusIexg => "DBEQ.PLUS.IEXG",
-            Self::DbeqPlusEprl => "DBEQ.PLUS.EPRL",
-            Self::DbeqPlusXnas => "DBEQ.PLUS.XNAS",
-            Self::DbeqPlusXnys => "DBEQ.PLUS.XNYS",
-            Self::DbeqPlusFinn => "DBEQ.PLUS.FINN",
-            Self::DbeqPlusFiny => "DBEQ.PLUS.FINY",
-            Self::DbeqPlusFinc => "DBEQ.PLUS.FINC",
+            Self::EqusPlusXchi => "EQUS.PLUS.XCHI",
+            Self::EqusPlusXcis => "EQUS.PLUS.XCIS",
+            Self::EqusPlusIexg => "EQUS.PLUS.IEXG",
+            Self::EqusPlusEprl => "EQUS.PLUS.EPRL",
+            Self::EqusPlusXnas => "EQUS.PLUS.XNAS",
+            Self::EqusPlusXnys => "EQUS.PLUS.XNYS",
+            Self::EqusPlusFinn => "EQUS.PLUS.FINN",
+            Self::EqusPlusFiny => "EQUS.PLUS.FINY",
+            Self::EqusPlusFinc => "EQUS.PLUS.FINC",
             Self::IfeuImpactIfeu => "IFEU.IMPACT.IFEU",
             Self::NdexImpactNdex => "NDEX.IMPACT.NDEX",
             Self::DbeqBasicDbeq => "DBEQ.BASIC.DBEQ",
-            Self::DbeqPlusDbeq => "DBEQ.PLUS.DBEQ",
+            Self::EqusPlusEqus => "EQUS.PLUS.EQUS",
             Self::OpraPillarSphr => "OPRA.PILLAR.SPHR",
-            Self::DbeqMaxXchi => "DBEQ.MAX.XCHI",
-            Self::DbeqMaxXcis => "DBEQ.MAX.XCIS",
-            Self::DbeqMaxIexg => "DBEQ.MAX.IEXG",
-            Self::DbeqMaxEprl => "DBEQ.MAX.EPRL",
-            Self::DbeqMaxXnas => "DBEQ.MAX.XNAS",
-            Self::DbeqMaxXnys => "DBEQ.MAX.XNYS",
-            Self::DbeqMaxFinn => "DBEQ.MAX.FINN",
-            Self::DbeqMaxFiny => "DBEQ.MAX.FINY",
-            Self::DbeqMaxFinc => "DBEQ.MAX.FINC",
-            Self::DbeqMaxBats => "DBEQ.MAX.BATS",
-            Self::DbeqMaxBaty => "DBEQ.MAX.BATY",
-            Self::DbeqMaxEdga => "DBEQ.MAX.EDGA",
-            Self::DbeqMaxEdgx => "DBEQ.MAX.EDGX",
-            Self::DbeqMaxXbos => "DBEQ.MAX.XBOS",
-            Self::DbeqMaxXpsx => "DBEQ.MAX.XPSX",
-            Self::DbeqMaxMemx => "DBEQ.MAX.MEMX",
-            Self::DbeqMaxXase => "DBEQ.MAX.XASE",
-            Self::DbeqMaxArcx => "DBEQ.MAX.ARCX",
-            Self::DbeqMaxLtse => "DBEQ.MAX.LTSE",
+            Self::EqusAllXchi => "EQUS.ALL.XCHI",
+            Self::EqusAllXcis => "EQUS.ALL.XCIS",
+            Self::EqusAllIexg => "EQUS.ALL.IEXG",
+            Self::EqusAllEprl => "EQUS.ALL.EPRL",
+            Self::EqusAllXnas => "EQUS.ALL.XNAS",
+            Self::EqusAllXnys => "EQUS.ALL.XNYS",
+            Self::EqusAllFinn => "EQUS.ALL.FINN",
+            Self::EqusAllFiny => "EQUS.ALL.FINY",
+            Self::EqusAllFinc => "EQUS.ALL.FINC",
+            Self::EqusAllBats => "EQUS.ALL.BATS",
+            Self::EqusAllBaty => "EQUS.ALL.BATY",
+            Self::EqusAllEdga => "EQUS.ALL.EDGA",
+            Self::EqusAllEdgx => "EQUS.ALL.EDGX",
+            Self::EqusAllXbos => "EQUS.ALL.XBOS",
+            Self::EqusAllXpsx => "EQUS.ALL.XPSX",
+            Self::EqusAllMemx => "EQUS.ALL.MEMX",
+            Self::EqusAllXase => "EQUS.ALL.XASE",
+            Self::EqusAllArcx => "EQUS.ALL.ARCX",
+            Self::EqusAllLtse => "EQUS.ALL.LTSE",
             Self::XnasBasicXnas => "XNAS.BASIC.XNAS",
             Self::XnasBasicFinn => "XNAS.BASIC.FINN",
             Self::XnasBasicFinc => "XNAS.BASIC.FINC",
@@ -703,11 +707,11 @@ impl Publisher {
             Self::XnasNlsXpsx => "XNAS.NLS.XPSX",
             Self::XnasBasicXbos => "XNAS.BASIC.XBOS",
             Self::XnasBasicXpsx => "XNAS.BASIC.XPSX",
-            Self::DbeqSummaryDbeq => "DBEQ.SUMMARY.DBEQ",
-            Self::XcisBbotradesXcis => "XCIS.BBOTRADES.XCIS",
-            Self::XnysBbotradesXnys => "XNYS.BBOTRADES.XNYS",
-            Self::XnasBasicDbeq => "XNAS.BASIC.DBEQ",
-            Self::DbeqMaxDbeq => "DBEQ.MAX.DBEQ",
+            Self::EqusSummaryEqus => "EQUS.SUMMARY.EQUS",
+            Self::XcisTradesbboXcis => "XCIS.TRADESBBO.XCIS",
+            Self::XnysTradesbboXnys => "XNYS.TRADESBBO.XNYS",
+            Self::XnasBasicEqus => "XNAS.BASIC.EQUS",
+            Self::EqusAllEqus => "EQUS.ALL.EQUS",
         }
     }
 
@@ -761,39 +765,39 @@ impl Publisher {
             Self::XnysTradesXnys => Venue::Xnys,
             Self::XnasQbboXnas => Venue::Xnas,
             Self::XnasNlsXnas => Venue::Xnas,
-            Self::DbeqPlusXchi => Venue::Xchi,
-            Self::DbeqPlusXcis => Venue::Xcis,
-            Self::DbeqPlusIexg => Venue::Iexg,
-            Self::DbeqPlusEprl => Venue::Eprl,
-            Self::DbeqPlusXnas => Venue::Xnas,
-            Self::DbeqPlusXnys => Venue::Xnys,
-            Self::DbeqPlusFinn => Venue::Finn,
-            Self::DbeqPlusFiny => Venue::Finy,
-            Self::DbeqPlusFinc => Venue::Finc,
+            Self::EqusPlusXchi => Venue::Xchi,
+            Self::EqusPlusXcis => Venue::Xcis,
+            Self::EqusPlusIexg => Venue::Iexg,
+            Self::EqusPlusEprl => Venue::Eprl,
+            Self::EqusPlusXnas => Venue::Xnas,
+            Self::EqusPlusXnys => Venue::Xnys,
+            Self::EqusPlusFinn => Venue::Finn,
+            Self::EqusPlusFiny => Venue::Finy,
+            Self::EqusPlusFinc => Venue::Finc,
             Self::IfeuImpactIfeu => Venue::Ifeu,
             Self::NdexImpactNdex => Venue::Ndex,
             Self::DbeqBasicDbeq => Venue::Dbeq,
-            Self::DbeqPlusDbeq => Venue::Dbeq,
+            Self::EqusPlusEqus => Venue::Equs,
             Self::OpraPillarSphr => Venue::Sphr,
-            Self::DbeqMaxXchi => Venue::Xchi,
-            Self::DbeqMaxXcis => Venue::Xcis,
-            Self::DbeqMaxIexg => Venue::Iexg,
-            Self::DbeqMaxEprl => Venue::Eprl,
-            Self::DbeqMaxXnas => Venue::Xnas,
-            Self::DbeqMaxXnys => Venue::Xnys,
-            Self::DbeqMaxFinn => Venue::Finn,
-            Self::DbeqMaxFiny => Venue::Finy,
-            Self::DbeqMaxFinc => Venue::Finc,
-            Self::DbeqMaxBats => Venue::Bats,
-            Self::DbeqMaxBaty => Venue::Baty,
-            Self::DbeqMaxEdga => Venue::Edga,
-            Self::DbeqMaxEdgx => Venue::Edgx,
-            Self::DbeqMaxXbos => Venue::Xbos,
-            Self::DbeqMaxXpsx => Venue::Xpsx,
-            Self::DbeqMaxMemx => Venue::Memx,
-            Self::DbeqMaxXase => Venue::Xase,
-            Self::DbeqMaxArcx => Venue::Arcx,
-            Self::DbeqMaxLtse => Venue::Ltse,
+            Self::EqusAllXchi => Venue::Xchi,
+            Self::EqusAllXcis => Venue::Xcis,
+            Self::EqusAllIexg => Venue::Iexg,
+            Self::EqusAllEprl => Venue::Eprl,
+            Self::EqusAllXnas => Venue::Xnas,
+            Self::EqusAllXnys => Venue::Xnys,
+            Self::EqusAllFinn => Venue::Finn,
+            Self::EqusAllFiny => Venue::Finy,
+            Self::EqusAllFinc => Venue::Finc,
+            Self::EqusAllBats => Venue::Bats,
+            Self::EqusAllBaty => Venue::Baty,
+            Self::EqusAllEdga => Venue::Edga,
+            Self::EqusAllEdgx => Venue::Edgx,
+            Self::EqusAllXbos => Venue::Xbos,
+            Self::EqusAllXpsx => Venue::Xpsx,
+            Self::EqusAllMemx => Venue::Memx,
+            Self::EqusAllXase => Venue::Xase,
+            Self::EqusAllArcx => Venue::Arcx,
+            Self::EqusAllLtse => Venue::Ltse,
             Self::XnasBasicXnas => Venue::Xnas,
             Self::XnasBasicFinn => Venue::Finn,
             Self::XnasBasicFinc => Venue::Finc,
@@ -803,11 +807,11 @@ impl Publisher {
             Self::XnasNlsXpsx => Venue::Xpsx,
             Self::XnasBasicXbos => Venue::Xbos,
             Self::XnasBasicXpsx => Venue::Xpsx,
-            Self::DbeqSummaryDbeq => Venue::Dbeq,
-            Self::XcisBbotradesXcis => Venue::Xcis,
-            Self::XnysBbotradesXnys => Venue::Xnys,
-            Self::XnasBasicDbeq => Venue::Dbeq,
-            Self::DbeqMaxDbeq => Venue::Dbeq,
+            Self::EqusSummaryEqus => Venue::Equs,
+            Self::XcisTradesbboXcis => Venue::Xcis,
+            Self::XnysTradesbboXnys => Venue::Xnys,
+            Self::XnasBasicEqus => Venue::Equs,
+            Self::EqusAllEqus => Venue::Equs,
         }
     }
 
@@ -861,39 +865,39 @@ impl Publisher {
             Self::XnysTradesXnys => Dataset::XnysTrades,
             Self::XnasQbboXnas => Dataset::XnasQbbo,
             Self::XnasNlsXnas => Dataset::XnasNls,
-            Self::DbeqPlusXchi => Dataset::DbeqPlus,
-            Self::DbeqPlusXcis => Dataset::DbeqPlus,
-            Self::DbeqPlusIexg => Dataset::DbeqPlus,
-            Self::DbeqPlusEprl => Dataset::DbeqPlus,
-            Self::DbeqPlusXnas => Dataset::DbeqPlus,
-            Self::DbeqPlusXnys => Dataset::DbeqPlus,
-            Self::DbeqPlusFinn => Dataset::DbeqPlus,
-            Self::DbeqPlusFiny => Dataset::DbeqPlus,
-            Self::DbeqPlusFinc => Dataset::DbeqPlus,
+            Self::EqusPlusXchi => Dataset::EqusPlus,
+            Self::EqusPlusXcis => Dataset::EqusPlus,
+            Self::EqusPlusIexg => Dataset::EqusPlus,
+            Self::EqusPlusEprl => Dataset::EqusPlus,
+            Self::EqusPlusXnas => Dataset::EqusPlus,
+            Self::EqusPlusXnys => Dataset::EqusPlus,
+            Self::EqusPlusFinn => Dataset::EqusPlus,
+            Self::EqusPlusFiny => Dataset::EqusPlus,
+            Self::EqusPlusFinc => Dataset::EqusPlus,
             Self::IfeuImpactIfeu => Dataset::IfeuImpact,
             Self::NdexImpactNdex => Dataset::NdexImpact,
             Self::DbeqBasicDbeq => Dataset::DbeqBasic,
-            Self::DbeqPlusDbeq => Dataset::DbeqPlus,
+            Self::EqusPlusEqus => Dataset::EqusPlus,
             Self::OpraPillarSphr => Dataset::OpraPillar,
-            Self::DbeqMaxXchi => Dataset::DbeqMax,
-            Self::DbeqMaxXcis => Dataset::DbeqMax,
-            Self::DbeqMaxIexg => Dataset::DbeqMax,
-            Self::DbeqMaxEprl => Dataset::DbeqMax,
-            Self::DbeqMaxXnas => Dataset::DbeqMax,
-            Self::DbeqMaxXnys => Dataset::DbeqMax,
-            Self::DbeqMaxFinn => Dataset::DbeqMax,
-            Self::DbeqMaxFiny => Dataset::DbeqMax,
-            Self::DbeqMaxFinc => Dataset::DbeqMax,
-            Self::DbeqMaxBats => Dataset::DbeqMax,
-            Self::DbeqMaxBaty => Dataset::DbeqMax,
-            Self::DbeqMaxEdga => Dataset::DbeqMax,
-            Self::DbeqMaxEdgx => Dataset::DbeqMax,
-            Self::DbeqMaxXbos => Dataset::DbeqMax,
-            Self::DbeqMaxXpsx => Dataset::DbeqMax,
-            Self::DbeqMaxMemx => Dataset::DbeqMax,
-            Self::DbeqMaxXase => Dataset::DbeqMax,
-            Self::DbeqMaxArcx => Dataset::DbeqMax,
-            Self::DbeqMaxLtse => Dataset::DbeqMax,
+            Self::EqusAllXchi => Dataset::EqusAll,
+            Self::EqusAllXcis => Dataset::EqusAll,
+            Self::EqusAllIexg => Dataset::EqusAll,
+            Self::EqusAllEprl => Dataset::EqusAll,
+            Self::EqusAllXnas => Dataset::EqusAll,
+            Self::EqusAllXnys => Dataset::EqusAll,
+            Self::EqusAllFinn => Dataset::EqusAll,
+            Self::EqusAllFiny => Dataset::EqusAll,
+            Self::EqusAllFinc => Dataset::EqusAll,
+            Self::EqusAllBats => Dataset::EqusAll,
+            Self::EqusAllBaty => Dataset::EqusAll,
+            Self::EqusAllEdga => Dataset::EqusAll,
+            Self::EqusAllEdgx => Dataset::EqusAll,
+            Self::EqusAllXbos => Dataset::EqusAll,
+            Self::EqusAllXpsx => Dataset::EqusAll,
+            Self::EqusAllMemx => Dataset::EqusAll,
+            Self::EqusAllXase => Dataset::EqusAll,
+            Self::EqusAllArcx => Dataset::EqusAll,
+            Self::EqusAllLtse => Dataset::EqusAll,
             Self::XnasBasicXnas => Dataset::XnasBasic,
             Self::XnasBasicFinn => Dataset::XnasBasic,
             Self::XnasBasicFinc => Dataset::XnasBasic,
@@ -903,11 +907,11 @@ impl Publisher {
             Self::XnasNlsXpsx => Dataset::XnasNls,
             Self::XnasBasicXbos => Dataset::XnasBasic,
             Self::XnasBasicXpsx => Dataset::XnasBasic,
-            Self::DbeqSummaryDbeq => Dataset::DbeqSummary,
-            Self::XcisBbotradesXcis => Dataset::XcisBbotrades,
-            Self::XnysBbotradesXnys => Dataset::XnysBbotrades,
-            Self::XnasBasicDbeq => Dataset::XnasBasic,
-            Self::DbeqMaxDbeq => Dataset::DbeqMax,
+            Self::EqusSummaryEqus => Dataset::EqusSummary,
+            Self::XcisTradesbboXcis => Dataset::XcisTradesbbo,
+            Self::XnysTradesbboXnys => Dataset::XnysTradesbbo,
+            Self::XnasBasicEqus => Dataset::XnasBasic,
+            Self::EqusAllEqus => Dataset::EqusAll,
         }
     }
 
@@ -963,39 +967,39 @@ impl Publisher {
             (Dataset::XnysTrades, Venue::Xnys) => Ok(Self::XnysTradesXnys),
             (Dataset::XnasQbbo, Venue::Xnas) => Ok(Self::XnasQbboXnas),
             (Dataset::XnasNls, Venue::Xnas) => Ok(Self::XnasNlsXnas),
-            (Dataset::DbeqPlus, Venue::Xchi) => Ok(Self::DbeqPlusXchi),
-            (Dataset::DbeqPlus, Venue::Xcis) => Ok(Self::DbeqPlusXcis),
-            (Dataset::DbeqPlus, Venue::Iexg) => Ok(Self::DbeqPlusIexg),
-            (Dataset::DbeqPlus, Venue::Eprl) => Ok(Self::DbeqPlusEprl),
-            (Dataset::DbeqPlus, Venue::Xnas) => Ok(Self::DbeqPlusXnas),
-            (Dataset::DbeqPlus, Venue::Xnys) => Ok(Self::DbeqPlusXnys),
-            (Dataset::DbeqPlus, Venue::Finn) => Ok(Self::DbeqPlusFinn),
-            (Dataset::DbeqPlus, Venue::Finy) => Ok(Self::DbeqPlusFiny),
-            (Dataset::DbeqPlus, Venue::Finc) => Ok(Self::DbeqPlusFinc),
+            (Dataset::EqusPlus, Venue::Xchi) => Ok(Self::EqusPlusXchi),
+            (Dataset::EqusPlus, Venue::Xcis) => Ok(Self::EqusPlusXcis),
+            (Dataset::EqusPlus, Venue::Iexg) => Ok(Self::EqusPlusIexg),
+            (Dataset::EqusPlus, Venue::Eprl) => Ok(Self::EqusPlusEprl),
+            (Dataset::EqusPlus, Venue::Xnas) => Ok(Self::EqusPlusXnas),
+            (Dataset::EqusPlus, Venue::Xnys) => Ok(Self::EqusPlusXnys),
+            (Dataset::EqusPlus, Venue::Finn) => Ok(Self::EqusPlusFinn),
+            (Dataset::EqusPlus, Venue::Finy) => Ok(Self::EqusPlusFiny),
+            (Dataset::EqusPlus, Venue::Finc) => Ok(Self::EqusPlusFinc),
             (Dataset::IfeuImpact, Venue::Ifeu) => Ok(Self::IfeuImpactIfeu),
             (Dataset::NdexImpact, Venue::Ndex) => Ok(Self::NdexImpactNdex),
             (Dataset::DbeqBasic, Venue::Dbeq) => Ok(Self::DbeqBasicDbeq),
-            (Dataset::DbeqPlus, Venue::Dbeq) => Ok(Self::DbeqPlusDbeq),
+            (Dataset::EqusPlus, Venue::Equs) => Ok(Self::EqusPlusEqus),
             (Dataset::OpraPillar, Venue::Sphr) => Ok(Self::OpraPillarSphr),
-            (Dataset::DbeqMax, Venue::Xchi) => Ok(Self::DbeqMaxXchi),
-            (Dataset::DbeqMax, Venue::Xcis) => Ok(Self::DbeqMaxXcis),
-            (Dataset::DbeqMax, Venue::Iexg) => Ok(Self::DbeqMaxIexg),
-            (Dataset::DbeqMax, Venue::Eprl) => Ok(Self::DbeqMaxEprl),
-            (Dataset::DbeqMax, Venue::Xnas) => Ok(Self::DbeqMaxXnas),
-            (Dataset::DbeqMax, Venue::Xnys) => Ok(Self::DbeqMaxXnys),
-            (Dataset::DbeqMax, Venue::Finn) => Ok(Self::DbeqMaxFinn),
-            (Dataset::DbeqMax, Venue::Finy) => Ok(Self::DbeqMaxFiny),
-            (Dataset::DbeqMax, Venue::Finc) => Ok(Self::DbeqMaxFinc),
-            (Dataset::DbeqMax, Venue::Bats) => Ok(Self::DbeqMaxBats),
-            (Dataset::DbeqMax, Venue::Baty) => Ok(Self::DbeqMaxBaty),
-            (Dataset::DbeqMax, Venue::Edga) => Ok(Self::DbeqMaxEdga),
-            (Dataset::DbeqMax, Venue::Edgx) => Ok(Self::DbeqMaxEdgx),
-            (Dataset::DbeqMax, Venue::Xbos) => Ok(Self::DbeqMaxXbos),
-            (Dataset::DbeqMax, Venue::Xpsx) => Ok(Self::DbeqMaxXpsx),
-            (Dataset::DbeqMax, Venue::Memx) => Ok(Self::DbeqMaxMemx),
-            (Dataset::DbeqMax, Venue::Xase) => Ok(Self::DbeqMaxXase),
-            (Dataset::DbeqMax, Venue::Arcx) => Ok(Self::DbeqMaxArcx),
-            (Dataset::DbeqMax, Venue::Ltse) => Ok(Self::DbeqMaxLtse),
+            (Dataset::EqusAll, Venue::Xchi) => Ok(Self::EqusAllXchi),
+            (Dataset::EqusAll, Venue::Xcis) => Ok(Self::EqusAllXcis),
+            (Dataset::EqusAll, Venue::Iexg) => Ok(Self::EqusAllIexg),
+            (Dataset::EqusAll, Venue::Eprl) => Ok(Self::EqusAllEprl),
+            (Dataset::EqusAll, Venue::Xnas) => Ok(Self::EqusAllXnas),
+            (Dataset::EqusAll, Venue::Xnys) => Ok(Self::EqusAllXnys),
+            (Dataset::EqusAll, Venue::Finn) => Ok(Self::EqusAllFinn),
+            (Dataset::EqusAll, Venue::Finy) => Ok(Self::EqusAllFiny),
+            (Dataset::EqusAll, Venue::Finc) => Ok(Self::EqusAllFinc),
+            (Dataset::EqusAll, Venue::Bats) => Ok(Self::EqusAllBats),
+            (Dataset::EqusAll, Venue::Baty) => Ok(Self::EqusAllBaty),
+            (Dataset::EqusAll, Venue::Edga) => Ok(Self::EqusAllEdga),
+            (Dataset::EqusAll, Venue::Edgx) => Ok(Self::EqusAllEdgx),
+            (Dataset::EqusAll, Venue::Xbos) => Ok(Self::EqusAllXbos),
+            (Dataset::EqusAll, Venue::Xpsx) => Ok(Self::EqusAllXpsx),
+            (Dataset::EqusAll, Venue::Memx) => Ok(Self::EqusAllMemx),
+            (Dataset::EqusAll, Venue::Xase) => Ok(Self::EqusAllXase),
+            (Dataset::EqusAll, Venue::Arcx) => Ok(Self::EqusAllArcx),
+            (Dataset::EqusAll, Venue::Ltse) => Ok(Self::EqusAllLtse),
             (Dataset::XnasBasic, Venue::Xnas) => Ok(Self::XnasBasicXnas),
             (Dataset::XnasBasic, Venue::Finn) => Ok(Self::XnasBasicFinn),
             (Dataset::XnasBasic, Venue::Finc) => Ok(Self::XnasBasicFinc),
@@ -1005,11 +1009,11 @@ impl Publisher {
             (Dataset::XnasNls, Venue::Xpsx) => Ok(Self::XnasNlsXpsx),
             (Dataset::XnasBasic, Venue::Xbos) => Ok(Self::XnasBasicXbos),
             (Dataset::XnasBasic, Venue::Xpsx) => Ok(Self::XnasBasicXpsx),
-            (Dataset::DbeqSummary, Venue::Dbeq) => Ok(Self::DbeqSummaryDbeq),
-            (Dataset::XcisBbotrades, Venue::Xcis) => Ok(Self::XcisBbotradesXcis),
-            (Dataset::XnysBbotrades, Venue::Xnys) => Ok(Self::XnysBbotradesXnys),
-            (Dataset::XnasBasic, Venue::Dbeq) => Ok(Self::XnasBasicDbeq),
-            (Dataset::DbeqMax, Venue::Dbeq) => Ok(Self::DbeqMaxDbeq),
+            (Dataset::EqusSummary, Venue::Equs) => Ok(Self::EqusSummaryEqus),
+            (Dataset::XcisTradesbbo, Venue::Xcis) => Ok(Self::XcisTradesbboXcis),
+            (Dataset::XnysTradesbbo, Venue::Xnys) => Ok(Self::XnysTradesbboXnys),
+            (Dataset::XnasBasic, Venue::Equs) => Ok(Self::XnasBasicEqus),
+            (Dataset::EqusAll, Venue::Equs) => Ok(Self::EqusAllEqus),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1079,39 +1083,39 @@ impl std::str::FromStr for Publisher {
             "XNYS.TRADES.XNYS" => Ok(Self::XnysTradesXnys),
             "XNAS.QBBO.XNAS" => Ok(Self::XnasQbboXnas),
             "XNAS.NLS.XNAS" => Ok(Self::XnasNlsXnas),
-            "DBEQ.PLUS.XCHI" => Ok(Self::DbeqPlusXchi),
-            "DBEQ.PLUS.XCIS" => Ok(Self::DbeqPlusXcis),
-            "DBEQ.PLUS.IEXG" => Ok(Self::DbeqPlusIexg),
-            "DBEQ.PLUS.EPRL" => Ok(Self::DbeqPlusEprl),
-            "DBEQ.PLUS.XNAS" => Ok(Self::DbeqPlusXnas),
-            "DBEQ.PLUS.XNYS" => Ok(Self::DbeqPlusXnys),
-            "DBEQ.PLUS.FINN" => Ok(Self::DbeqPlusFinn),
-            "DBEQ.PLUS.FINY" => Ok(Self::DbeqPlusFiny),
-            "DBEQ.PLUS.FINC" => Ok(Self::DbeqPlusFinc),
+            "EQUS.PLUS.XCHI" => Ok(Self::EqusPlusXchi),
+            "EQUS.PLUS.XCIS" => Ok(Self::EqusPlusXcis),
+            "EQUS.PLUS.IEXG" => Ok(Self::EqusPlusIexg),
+            "EQUS.PLUS.EPRL" => Ok(Self::EqusPlusEprl),
+            "EQUS.PLUS.XNAS" => Ok(Self::EqusPlusXnas),
+            "EQUS.PLUS.XNYS" => Ok(Self::EqusPlusXnys),
+            "EQUS.PLUS.FINN" => Ok(Self::EqusPlusFinn),
+            "EQUS.PLUS.FINY" => Ok(Self::EqusPlusFiny),
+            "EQUS.PLUS.FINC" => Ok(Self::EqusPlusFinc),
             "IFEU.IMPACT.IFEU" => Ok(Self::IfeuImpactIfeu),
             "NDEX.IMPACT.NDEX" => Ok(Self::NdexImpactNdex),
             "DBEQ.BASIC.DBEQ" => Ok(Self::DbeqBasicDbeq),
-            "DBEQ.PLUS.DBEQ" => Ok(Self::DbeqPlusDbeq),
+            "EQUS.PLUS.EQUS" => Ok(Self::EqusPlusEqus),
             "OPRA.PILLAR.SPHR" => Ok(Self::OpraPillarSphr),
-            "DBEQ.MAX.XCHI" => Ok(Self::DbeqMaxXchi),
-            "DBEQ.MAX.XCIS" => Ok(Self::DbeqMaxXcis),
-            "DBEQ.MAX.IEXG" => Ok(Self::DbeqMaxIexg),
-            "DBEQ.MAX.EPRL" => Ok(Self::DbeqMaxEprl),
-            "DBEQ.MAX.XNAS" => Ok(Self::DbeqMaxXnas),
-            "DBEQ.MAX.XNYS" => Ok(Self::DbeqMaxXnys),
-            "DBEQ.MAX.FINN" => Ok(Self::DbeqMaxFinn),
-            "DBEQ.MAX.FINY" => Ok(Self::DbeqMaxFiny),
-            "DBEQ.MAX.FINC" => Ok(Self::DbeqMaxFinc),
-            "DBEQ.MAX.BATS" => Ok(Self::DbeqMaxBats),
-            "DBEQ.MAX.BATY" => Ok(Self::DbeqMaxBaty),
-            "DBEQ.MAX.EDGA" => Ok(Self::DbeqMaxEdga),
-            "DBEQ.MAX.EDGX" => Ok(Self::DbeqMaxEdgx),
-            "DBEQ.MAX.XBOS" => Ok(Self::DbeqMaxXbos),
-            "DBEQ.MAX.XPSX" => Ok(Self::DbeqMaxXpsx),
-            "DBEQ.MAX.MEMX" => Ok(Self::DbeqMaxMemx),
-            "DBEQ.MAX.XASE" => Ok(Self::DbeqMaxXase),
-            "DBEQ.MAX.ARCX" => Ok(Self::DbeqMaxArcx),
-            "DBEQ.MAX.LTSE" => Ok(Self::DbeqMaxLtse),
+            "EQUS.ALL.XCHI" => Ok(Self::EqusAllXchi),
+            "EQUS.ALL.XCIS" => Ok(Self::EqusAllXcis),
+            "EQUS.ALL.IEXG" => Ok(Self::EqusAllIexg),
+            "EQUS.ALL.EPRL" => Ok(Self::EqusAllEprl),
+            "EQUS.ALL.XNAS" => Ok(Self::EqusAllXnas),
+            "EQUS.ALL.XNYS" => Ok(Self::EqusAllXnys),
+            "EQUS.ALL.FINN" => Ok(Self::EqusAllFinn),
+            "EQUS.ALL.FINY" => Ok(Self::EqusAllFiny),
+            "EQUS.ALL.FINC" => Ok(Self::EqusAllFinc),
+            "EQUS.ALL.BATS" => Ok(Self::EqusAllBats),
+            "EQUS.ALL.BATY" => Ok(Self::EqusAllBaty),
+            "EQUS.ALL.EDGA" => Ok(Self::EqusAllEdga),
+            "EQUS.ALL.EDGX" => Ok(Self::EqusAllEdgx),
+            "EQUS.ALL.XBOS" => Ok(Self::EqusAllXbos),
+            "EQUS.ALL.XPSX" => Ok(Self::EqusAllXpsx),
+            "EQUS.ALL.MEMX" => Ok(Self::EqusAllMemx),
+            "EQUS.ALL.XASE" => Ok(Self::EqusAllXase),
+            "EQUS.ALL.ARCX" => Ok(Self::EqusAllArcx),
+            "EQUS.ALL.LTSE" => Ok(Self::EqusAllLtse),
             "XNAS.BASIC.XNAS" => Ok(Self::XnasBasicXnas),
             "XNAS.BASIC.FINN" => Ok(Self::XnasBasicFinn),
             "XNAS.BASIC.FINC" => Ok(Self::XnasBasicFinc),
@@ -1121,11 +1125,11 @@ impl std::str::FromStr for Publisher {
             "XNAS.NLS.XPSX" => Ok(Self::XnasNlsXpsx),
             "XNAS.BASIC.XBOS" => Ok(Self::XnasBasicXbos),
             "XNAS.BASIC.XPSX" => Ok(Self::XnasBasicXpsx),
-            "DBEQ.SUMMARY.DBEQ" => Ok(Self::DbeqSummaryDbeq),
-            "XCIS.BBOTRADES.XCIS" => Ok(Self::XcisBbotradesXcis),
-            "XNYS.BBOTRADES.XNYS" => Ok(Self::XnysBbotradesXnys),
-            "XNAS.BASIC.DBEQ" => Ok(Self::XnasBasicDbeq),
-            "DBEQ.MAX.DBEQ" => Ok(Self::DbeqMaxDbeq),
+            "EQUS.SUMMARY.EQUS" => Ok(Self::EqusSummaryEqus),
+            "XCIS.TRADESBBO.XCIS" => Ok(Self::XcisTradesbboXcis),
+            "XNYS.TRADESBBO.XNYS" => Ok(Self::XnysTradesbboXnys),
+            "XNAS.BASIC.EQUS" => Ok(Self::XnasBasicEqus),
+            "EQUS.ALL.EQUS" => Ok(Self::EqusAllEqus),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -615,10 +615,12 @@ pub enum Publisher {
     EqusAllEqus = 94,
     /// Databento US Equities Mini
     EqusMiniEqus = 95,
+    /// NYSE Trades - Consolidated
+    XnysTradesEqus = 96,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 95;
+pub const PUBLISHER_COUNT: usize = 96;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -719,6 +721,7 @@ impl Publisher {
             Self::XnasBasicEqus => "XNAS.BASIC.EQUS",
             Self::EqusAllEqus => "EQUS.ALL.EQUS",
             Self::EqusMiniEqus => "EQUS.MINI.EQUS",
+            Self::XnysTradesEqus => "XNYS.TRADES.EQUS",
         }
     }
 
@@ -820,6 +823,7 @@ impl Publisher {
             Self::XnasBasicEqus => Venue::Equs,
             Self::EqusAllEqus => Venue::Equs,
             Self::EqusMiniEqus => Venue::Equs,
+            Self::XnysTradesEqus => Venue::Equs,
         }
     }
 
@@ -921,6 +925,7 @@ impl Publisher {
             Self::XnasBasicEqus => Dataset::XnasBasic,
             Self::EqusAllEqus => Dataset::EqusAll,
             Self::EqusMiniEqus => Dataset::EqusMini,
+            Self::XnysTradesEqus => Dataset::XnysTrades,
         }
     }
 
@@ -1024,6 +1029,7 @@ impl Publisher {
             (Dataset::XnasBasic, Venue::Equs) => Ok(Self::XnasBasicEqus),
             (Dataset::EqusAll, Venue::Equs) => Ok(Self::EqusAllEqus),
             (Dataset::EqusMini, Venue::Equs) => Ok(Self::EqusMiniEqus),
+            (Dataset::XnysTrades, Venue::Equs) => Ok(Self::XnysTradesEqus),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1141,6 +1147,7 @@ impl std::str::FromStr for Publisher {
             "XNAS.BASIC.EQUS" => Ok(Self::XnasBasicEqus),
             "EQUS.ALL.EQUS" => Ok(Self::EqusAllEqus),
             "EQUS.MINI.EQUS" => Ok(Self::EqusMiniEqus),
+            "XNYS.TRADES.EQUS" => Ok(Self::XnysTradesEqus),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -309,10 +309,12 @@ pub enum Dataset {
     XcisTradesbbo = 33,
     /// NYSE Trades and BBO
     XnysTradesbbo = 34,
+    /// Databento US Equities Mini
+    EqusMini = 35,
 }
 
 /// The number of Dataset variants.
-pub const DATASET_COUNT: usize = 34;
+pub const DATASET_COUNT: usize = 35;
 
 impl Dataset {
     /// Convert a Dataset to its `str` representation.
@@ -354,6 +356,7 @@ impl Dataset {
             Self::EqusSummary => "EQUS.SUMMARY",
             Self::XcisTradesbbo => "XCIS.TRADESBBO",
             Self::XnysTradesbbo => "XNYS.TRADESBBO",
+            Self::EqusMini => "EQUS.MINI",
         }
     }
 }
@@ -411,6 +414,7 @@ impl std::str::FromStr for Dataset {
             "EQUS.SUMMARY" => Ok(Self::EqusSummary),
             "XCIS.TRADESBBO" => Ok(Self::XcisTradesbbo),
             "XNYS.TRADESBBO" => Ok(Self::XnysTradesbbo),
+            "EQUS.MINI" => Ok(Self::EqusMini),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -609,10 +613,12 @@ pub enum Publisher {
     XnasBasicEqus = 93,
     /// Databento US Equities (All Feeds) - Consolidated
     EqusAllEqus = 94,
+    /// Databento US Equities Mini
+    EqusMiniEqus = 95,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 94;
+pub const PUBLISHER_COUNT: usize = 95;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -712,6 +718,7 @@ impl Publisher {
             Self::XnysTradesbboXnys => "XNYS.TRADESBBO.XNYS",
             Self::XnasBasicEqus => "XNAS.BASIC.EQUS",
             Self::EqusAllEqus => "EQUS.ALL.EQUS",
+            Self::EqusMiniEqus => "EQUS.MINI.EQUS",
         }
     }
 
@@ -812,6 +819,7 @@ impl Publisher {
             Self::XnysTradesbboXnys => Venue::Xnys,
             Self::XnasBasicEqus => Venue::Equs,
             Self::EqusAllEqus => Venue::Equs,
+            Self::EqusMiniEqus => Venue::Equs,
         }
     }
 
@@ -912,6 +920,7 @@ impl Publisher {
             Self::XnysTradesbboXnys => Dataset::XnysTradesbbo,
             Self::XnasBasicEqus => Dataset::XnasBasic,
             Self::EqusAllEqus => Dataset::EqusAll,
+            Self::EqusMiniEqus => Dataset::EqusMini,
         }
     }
 
@@ -1014,6 +1023,7 @@ impl Publisher {
             (Dataset::XnysTradesbbo, Venue::Xnys) => Ok(Self::XnysTradesbboXnys),
             (Dataset::XnasBasic, Venue::Equs) => Ok(Self::XnasBasicEqus),
             (Dataset::EqusAll, Venue::Equs) => Ok(Self::EqusAllEqus),
+            (Dataset::EqusMini, Venue::Equs) => Ok(Self::EqusMiniEqus),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1130,6 +1140,7 @@ impl std::str::FromStr for Publisher {
             "XNYS.TRADESBBO.XNYS" => Ok(Self::XnysTradesbboXnys),
             "XNAS.BASIC.EQUS" => Ok(Self::XnasBasicEqus),
             "EQUS.ALL.EQUS" => Ok(Self::EqusAllEqus),
+            "EQUS.MINI.EQUS" => Ok(Self::EqusMiniEqus),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/python/enums.rs
+++ b/rust/dbn/src/python/enums.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use pyo3::{prelude::*, pyclass::CompareOp, type_object::PyTypeInfo, types::PyType, Bound};
+use pyo3::{prelude::*, type_object::PyTypeInfo, types::PyType, Bound};
 
 use crate::{
     enums::{Compression, Encoding, SType, Schema, SecurityUpdateAction, UserDefinedInstrument},
@@ -15,7 +15,7 @@ impl Side {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -34,20 +34,16 @@ impl Side {
         format!("<Side.{}: '{}'>", self.name(), self.value())
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -56,7 +52,7 @@ impl Side {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -72,7 +68,7 @@ impl Action {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -91,20 +87,16 @@ impl Action {
         format!("<Action.{}: '{}'>", self.name(), self.value())
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -113,7 +105,7 @@ impl Action {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -129,7 +121,7 @@ impl InstrumentClass {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -144,15 +136,11 @@ impl InstrumentClass {
         format!("{}", *self as u8 as char)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -161,7 +149,7 @@ impl InstrumentClass {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -177,7 +165,7 @@ impl MatchAlgorithm {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -192,15 +180,11 @@ impl MatchAlgorithm {
         format!("{}", *self as u8 as char)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -209,7 +193,7 @@ impl MatchAlgorithm {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -225,7 +209,7 @@ impl UserDefinedInstrument {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -248,20 +232,16 @@ impl UserDefinedInstrument {
         )
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -270,7 +250,7 @@ impl UserDefinedInstrument {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -285,7 +265,7 @@ impl UserDefinedInstrument {
 impl SType {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let t = Self::type_object_bound(py);
+        let t = Self::type_object(py);
         Self::py_from_str(&t, value)
     }
 
@@ -301,20 +281,16 @@ impl SType {
         format!("<SType.{}: '{}'>", self.name(), self.value(),)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = Self::py_from_str(&Self::type_object_bound(py), other) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_str().to_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -323,7 +299,7 @@ impl SType {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -340,7 +316,7 @@ impl SType {
 impl RType {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let t = Self::type_object_bound(py);
+        let t = Self::type_object(py);
         Self::py_from_str(&t, value).or_else(|_| Self::py_from_int(&t, value))
     }
 
@@ -356,23 +332,16 @@ impl RType {
         format!("<RType.{}: '{}'>", self.name(), self.value(),)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        if let Ok(other_enum) = Self::py_from_str(&Self::type_object_bound(py), other)
-            .or_else(|_| Self::py_from_int(&Self::type_object_bound(py), other))
-        {
-            match op {
-                CompareOp::Eq => self.eq(&other_enum).into_py(py),
-                CompareOp::Ne => self.ne(&other_enum).into_py(py),
-                _ => py.NotImplemented(),
-            }
-        } else {
-            py.NotImplemented()
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_str().to_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -381,7 +350,7 @@ impl RType {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -405,7 +374,7 @@ impl RType {
     fn py_from_schema(pytype: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
         let schema: Schema = value
             .extract()
-            .or_else(|_| Schema::py_from_str(&Schema::type_object_bound(pytype.py()), value))
+            .or_else(|_| Schema::py_from_str(&Schema::type_object(pytype.py()), value))
             .map_err(to_py_err)?;
         Ok(Self::from(schema))
     }
@@ -415,7 +384,7 @@ impl RType {
 impl Schema {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let t = Self::type_object_bound(py);
+        let t = Self::type_object(py);
         Self::py_from_str(&t, value)
     }
 
@@ -431,20 +400,16 @@ impl Schema {
         format!("<Schema.{}: '{}'>", self.name(), self.value(),)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = Self::py_from_str(&Self::type_object_bound(py), other) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_str().to_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -453,7 +418,7 @@ impl Schema {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -470,7 +435,7 @@ impl Schema {
 impl Encoding {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let t = Self::type_object_bound(py);
+        let t = Self::type_object(py);
         Self::py_from_str(&t, value)
     }
 
@@ -486,20 +451,16 @@ impl Encoding {
         format!("<Encoding.{}: '{}'>", self.name(), self.value(),)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = Self::py_from_str(&Self::type_object_bound(py), other) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_str().to_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -508,7 +469,7 @@ impl Encoding {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -525,7 +486,7 @@ impl Encoding {
 impl Compression {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let t = Self::type_object_bound(py);
+        let t = Self::type_object(py);
         Self::py_from_str(&t, value)
     }
 
@@ -541,20 +502,16 @@ impl Compression {
         format!("<Compression.{}: '{}'>", self.name(), self.value(),)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = Self::py_from_str(&Self::type_object_bound(py), other) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_str().to_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -564,7 +521,7 @@ impl Compression {
 
     // No metaclass support with pyo3, so `for c in Compression: ...` isn't possible
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -582,7 +539,7 @@ impl SecurityUpdateAction {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -597,20 +554,16 @@ impl SecurityUpdateAction {
         format!("<SecurityUpdateAction.{}: '{}'>", self.name(), self.value())
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[getter]
     fn name(&self) -> String {
         self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -619,7 +572,7 @@ impl SecurityUpdateAction {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -642,15 +595,11 @@ impl StatType {
         *self as isize
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -659,7 +608,7 @@ impl StatType {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 }
@@ -676,15 +625,11 @@ impl StatusAction {
         *self as isize
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -693,7 +638,7 @@ impl StatusAction {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 }
@@ -710,15 +655,11 @@ impl StatusReason {
         *self as isize
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -727,7 +668,7 @@ impl StatusReason {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 }
@@ -744,15 +685,11 @@ impl TradingEvent {
         *self as isize
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
         let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
-            return py.NotImplemented();
+            return false;
         };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -761,7 +698,7 @@ impl TradingEvent {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 }
@@ -771,7 +708,7 @@ impl TriState {
     #[new]
     fn py_new(py: Python<'_>, value: &Bound<PyAny>) -> PyResult<Self> {
         let Ok(i) = value.extract::<u8>() else {
-            let t = Self::type_object_bound(py);
+            let t = Self::type_object(py);
             let c = value.extract::<char>().map_err(to_py_err)?;
             return Self::py_from_str(&t, c);
         };
@@ -786,19 +723,15 @@ impl TriState {
         format!("{}", *self as u8 as char)
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn opt_bool(&self) -> Option<bool> {
         Option::from(*self)
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>, py: Python<'_>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(py, other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
     }
 
     #[getter]
@@ -807,7 +740,7 @@ impl TriState {
     }
 
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 
@@ -824,19 +757,8 @@ impl VersionUpgradePolicy {
         *self as isize
     }
 
-    fn __richcmp__(&self, other: &Bound<PyAny>, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        let Ok(other_enum) = other.extract::<Self>() else {
-            return py.NotImplemented();
-        };
-        match op {
-            CompareOp::Eq => self.eq(&other_enum).into_py(py),
-            CompareOp::Ne => self.ne(&other_enum).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     #[classmethod]
-    fn variants(_: &Bound<PyType>, py: Python<'_>) -> EnumIterator {
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
         EnumIterator::new::<Self>(py)
     }
 }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -1,10 +1,10 @@
 use std::{ffi::c_char, mem};
 
 use pyo3::{
+    conversion::IntoPyObjectExt,
     intern,
     prelude::*,
-    pyclass::CompareOp,
-    types::{timezone_utc_bound, PyDateTime, PyDict},
+    types::{timezone_utc, PyDateTime, PyDict},
 };
 
 use crate::{
@@ -83,14 +83,6 @@ impl MboMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -126,12 +118,12 @@ impl MboMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -235,14 +227,6 @@ impl BidAskPair {
         self.bid_px_f64()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -296,14 +280,6 @@ impl BboMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -339,12 +315,12 @@ impl BboMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -444,14 +420,6 @@ impl Cmbp1Msg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -486,12 +454,12 @@ impl Cmbp1Msg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -601,14 +569,6 @@ impl CbboMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -643,12 +603,12 @@ impl CbboMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -749,14 +709,6 @@ impl ConsolidatedBidAskPair {
         self.bid_pb().map(|pb| pb.to_string()).ok()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -811,14 +763,6 @@ impl TradeMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -854,12 +798,12 @@ impl TradeMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -976,14 +920,6 @@ impl Mbp1Msg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -1019,12 +955,12 @@ impl Mbp1Msg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -1153,14 +1089,6 @@ impl Mbp10Msg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -1196,12 +1124,12 @@ impl Mbp10Msg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -1294,14 +1222,6 @@ impl OhlcvMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -1352,7 +1272,7 @@ impl OhlcvMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
@@ -1441,14 +1361,6 @@ impl StatusMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -1479,12 +1391,12 @@ impl StatusMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -1789,14 +1701,6 @@ impl InstrumentDefMsgV3 {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -1862,22 +1766,22 @@ impl InstrumentDefMsgV3 {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
     #[getter]
-    fn get_pretty_activation(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_activation<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.activation)
     }
 
     #[getter]
-    fn get_pretty_expiration(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_expiration<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.expiration)
     }
 
@@ -2265,14 +2169,6 @@ impl InstrumentDefMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -2343,22 +2239,22 @@ impl InstrumentDefMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
     #[getter]
-    fn get_pretty_activation(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_activation<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.activation)
     }
 
     #[getter]
-    fn get_pretty_expiration(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_expiration<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.expiration)
     }
 
@@ -2710,14 +2606,6 @@ impl InstrumentDefMsgV1 {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -2788,22 +2676,22 @@ impl InstrumentDefMsgV1 {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
     #[getter]
-    fn get_pretty_activation(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_activation<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.activation)
     }
 
     #[getter]
-    fn get_pretty_expiration(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_expiration<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.expiration)
     }
 
@@ -2985,14 +2873,6 @@ impl ImbalanceMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3043,12 +2923,12 @@ impl ImbalanceMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
@@ -3181,14 +3061,6 @@ impl StatMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3223,17 +3095,17 @@ impl StatMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_ts_recv(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
     #[getter]
-    fn get_pretty_ts_ref(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_ref<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_ref)
     }
 
@@ -3290,14 +3162,6 @@ impl ErrorMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3328,7 +3192,7 @@ impl ErrorMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
@@ -3389,14 +3253,6 @@ impl ErrorMsgV1 {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3427,7 +3283,7 @@ impl ErrorMsgV1 {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
@@ -3511,14 +3367,6 @@ impl SymbolMappingMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3549,17 +3397,17 @@ impl SymbolMappingMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_end_ts(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_end_ts<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.end_ts)
     }
 
     #[getter]
-    fn get_pretty_start_ts(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_start_ts<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.start_ts)
     }
 
@@ -3655,14 +3503,6 @@ impl SymbolMappingMsgV1 {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3693,17 +3533,17 @@ impl SymbolMappingMsgV1 {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
     #[getter]
-    fn get_pretty_end_ts(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_end_ts<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.end_ts)
     }
 
     #[getter]
-    fn get_pretty_start_ts(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_start_ts<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.start_ts)
     }
 
@@ -3769,14 +3609,6 @@ impl SystemMsg {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3807,7 +3639,7 @@ impl SystemMsg {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
@@ -3873,14 +3705,6 @@ impl SystemMsgV1 {
         self.as_ref()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> Py<PyAny> {
-        match op {
-            CompareOp::Eq => self.eq(other).into_py(py),
-            CompareOp::Ne => self.ne(other).into_py(py),
-            _ => py.NotImplemented(),
-        }
-    }
-
     fn __repr__(&self) -> String {
         format!("{self:?}")
     }
@@ -3911,7 +3735,7 @@ impl SystemMsgV1 {
     }
 
     #[getter]
-    fn get_pretty_ts_event(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn get_pretty_ts_event<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_event())
     }
 
@@ -4056,21 +3880,31 @@ impl<const N: usize> PyFieldDesc for [ConsolidatedBidAskPair; N] {
     }
 }
 
-// `WithTsOut` is converted to a 2-tuple in Python
-impl<R: HasRType + IntoPy<Py<PyAny>>> IntoPy<PyObject> for WithTsOut<R> {
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        let obj = self.rec.into_py(py);
-        obj.setattr(py, intern!(py, "ts_out"), self.ts_out).unwrap();
-        obj
+/// `WithTsOut` adds a `ts_out` field to the main record when converted to Python.
+impl<'py, R> IntoPyObject<'py> for WithTsOut<R>
+where
+    R: HasRType + IntoPyObject<'py>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let obj = self.rec.into_bound_py_any(py)?;
+        obj.setattr(intern!(py, "ts_out"), self.ts_out).unwrap();
+        Ok(obj)
     }
 }
 
-fn new_py_timestamp_or_datetime(py: Python<'_>, timestamp: u64) -> PyResult<Option<PyObject>> {
+fn new_py_timestamp_or_datetime(
+    py: Python<'_>,
+    timestamp: u64,
+) -> PyResult<Option<Bound<'_, PyAny>>> {
     if timestamp == UNDEF_TIMESTAMP {
         return Ok(None);
     }
-    if let Ok(pandas) = PyModule::import_bound(py, intern!(py, "pandas")) {
-        let kwargs = PyDict::new_bound(py);
+    if let Ok(pandas) = PyModule::import(py, intern!(py, "pandas")) {
+        let kwargs = PyDict::new(py);
         if kwargs.set_item(intern!(py, "utc"), true).is_ok()
             && kwargs
                 .set_item(intern!(py, "errors"), intern!(py, "coerce"))
@@ -4081,10 +3915,11 @@ fn new_py_timestamp_or_datetime(py: Python<'_>, timestamp: u64) -> PyResult<Opti
         {
             return pandas
                 .call_method(intern!(py, "to_datetime"), (timestamp,), Some(&kwargs))
-                .map(|o| Some(o.into_py(py)));
+                .map(|o| Some(o.into_pyobject(py).unwrap()));
         }
     }
-    let utc_tz = timezone_utc_bound(py);
+    let utc_tz = timezone_utc(py);
     let timestamp_ms = timestamp as f64 / 1_000_000.0;
-    PyDateTime::from_timestamp_bound(py, timestamp_ms, Some(&utc_tz)).map(|o| Some(o.into_py(py)))
+    PyDateTime::from_timestamp(py, timestamp_ms, Some(&utc_tz))
+        .map(|o| Some(o.into_pyobject(py).unwrap().into_any()))
 }

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -34,7 +34,7 @@ pub use conv::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(eq, get_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -69,7 +69,7 @@ pub struct RecordHeader {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "MBOMsg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "MBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -128,7 +128,7 @@ pub struct MboMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(eq, get_all, set_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(test, derive(type_layout::TypeLayout))]
@@ -156,7 +156,7 @@ pub struct BidAskPair {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, set_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(eq, get_all, set_all, dict, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(test, derive(type_layout::TypeLayout))]
@@ -195,7 +195,7 @@ pub struct ConsolidatedBidAskPair {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -250,7 +250,7 @@ pub struct TradeMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "MBP1Msg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "MBP1Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -309,7 +309,7 @@ pub struct Mbp1Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "MBP10Msg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "MBP10Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -368,7 +368,7 @@ pub struct Mbp10Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "BBOMsg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "BBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -427,7 +427,7 @@ pub struct BboMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "CMBP1Msg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "CMBP1Msg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -486,7 +486,7 @@ pub struct Cmbp1Msg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn", name = "CBBOMsg"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn", name = "CBBOMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -560,7 +560,7 @@ pub type Cbbo1MMsg = CbboMsg;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, dict, module = "databento_dbn", name = "OHLCVMsg"),
+    pyo3::pyclass(dict, eq, get_all, module = "databento_dbn", name = "OHLCVMsg"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -605,7 +605,7 @@ pub struct OhlcvMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -658,7 +658,7 @@ pub struct StatusMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -911,7 +911,7 @@ pub struct InstrumentDefMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -1005,7 +1005,7 @@ pub struct ImbalanceMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(get_all, dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, get_all, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -1071,7 +1071,7 @@ pub struct StatMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -1102,7 +1102,7 @@ pub struct ErrorMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope
@@ -1149,7 +1149,7 @@ pub struct SymbolMappingMsg {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(dict, module = "databento_dbn"),
+    pyo3::pyclass(dict, eq, module = "databento_dbn"),
     derive(crate::macros::PyFieldDesc)
 )]
 #[cfg_attr(not(feature = "python"), derive(MockPyo3))] // bring `pyo3` attribute into scope

--- a/rust/dbn/src/symbol_map.rs
+++ b/rust/dbn/src/symbol_map.rs
@@ -191,7 +191,7 @@ impl PitSymbolMap {
         let is_inverse = is_inverse(metadata)?;
         let datetime = PrimitiveDateTime::new(date, time!(0:00)).assume_utc();
         // need to compare with `end` as a datetime to handle midnight case
-        if date < metadata.start().date() || metadata.end().map_or(false, |end| datetime >= end) {
+        if date < metadata.start().date() || metadata.end().is_some_and(|end| datetime >= end) {
             return Err(crate::Error::BadArgument {
                 param_name: "date".to_owned(),
                 desc: "Outside the query range".to_owned(),


### PR DESCRIPTION
### Breaking changes
- Updated enumerations for unreleased US equities datasets and publishers

### Enhancements
- Added new venue `EQUS` for consolidated US equities
- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and `XNYS.TRADES.EQUS`
- Upgraded `pyo3` version to 0.23.4 with improved support for Python 3.13

### Bug fixes
- Fixed export of `InstrumentDefMsgV3` to Python