### PR TITLE
Fix typo

### DIFF
--- a/rust/dbn-cli/src/lib.rs
+++ b/rust/dbn-cli/src/lib.rs
@@ -134,7 +134,7 @@ pub struct Args {
          action = ArgAction::SetTrue,
          default_value = "false",
          conflicts_with_all = ["input_fragment", "dbn", "fragment"],
-         help ="Use symbology mappings from the metadata to create a 'symbol' field mapping the intstrument ID to its requested symbol."
+         help ="Use symbology mappings from the metadata to create a 'symbol' field mapping the instrument ID to its requested symbol."
     )]
     pub map_symbols: bool,
     #[clap(


### PR DESCRIPTION
# Pull request

This commit fixes a typo in the `dbn --help` output.

## Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.