### PR TITLE
VER: Release 0.29.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,7 +237,8 @@ jobs:
           merge-multiple: true
       # Install publish dependencies
       - name: Install publish dependencies
-        run: python -m pip install --upgrade twine
+        # Upgrade packaging here to try to resolve https://github.com/pypa/twine/issues/1216
+        run: python -m pip install --upgrade packaging twine
 
       - name: Publish to PyPI
         id: publish-to-pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Enhancements
 - Added new venues, datasets, and publishers for ICE Futures US, ICE Futures Europe
   (Financial products), Eurex, and European Energy Exchange (EEX)
+- Added new `SkipBytes` and `AsyncSkipBytes` traits which are a subset of the `Seek`
+  and `AsyncSeek` traits respectively, only supporting seeking forward from the current
+  position
+
+### Deprecations
+- Deprecated `AsyncRecordDecoder::get_mut()` and `AsyncDecoder::get_mut()` as modifying
+  the inner reader after decoding any records could lead to a corrupted stream and
+  decoding errors
 
 ### Bug fixes
 - Fixed typo in `-s`/`--map-symbols` help text (credit: @wtn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.29.0 - TBD
+## 0.29.0 - 2025-03-17
 
 ### Enhancements
 - Added new venues, datasets, and publishers for ICE Futures US, ICE Futures Europe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.29.0 - TBD
 
 ### Enhancements
-- Added new venues, datasets, and publishers for ICE Futures US and for ICE Futures
-  Europe (Financial products)
+- Added new venues, datasets, and publishers for ICE Futures US, ICE Futures Europe
+  (Financial products), Eurex, and European Energy Exchange (EEX)
 
 ### Bug fixes
 - Fixed typo in `-s`/`--map-symbols` help text (credit: @wtn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.28.1 - TBD
+
+### Bug fixes
+- Fixed typo in `-s`/`--map-symbols` help text (credit: @wtn)
+
 ## 0.28.0 - 2025-02-11
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.28.1 - TBD
+## 0.29.0 - TBD
+
+### Enhancements
+- Added new venues, datasets, and publishers for ICE Futures US and for ICE Futures
+  Europe (Financial products)
 
 ### Bug fixes
 - Fixed typo in `-s`/`--map-symbols` help text (credit: @wtn)
@@ -18,7 +22,8 @@
 
 ### Enhancements
 - Added new venue `EQUS` for consolidated US equities
-- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and `XNYS.TRADES.EQUS`
+- Added new dataset `EQUS.MINI` and new publishers `EQUS.MINI.EQUS` and
+  `XNYS.TRADES.EQUS`
 - Upgraded `pyo3` version to 0.23.4 with improved support for Python 3.13
 
 ### Bug fixes
@@ -45,7 +50,8 @@
 - Relaxed `DecodeRecord` trait constraint on `StreamIterDecoder`'s inner decoder
 - Added `DbnMetadata` implementation for `StreamInnerDecoder` if the inner decoder
   implements `DbnMetadata`
-- Eliminate `unsafe` in `From` implementations for record structs from different versions
+- Eliminate `unsafe` in `From` implementations for record structs from different
+  versions
 
 ## 0.25.0 - 2024-12-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "assert_cmd"
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
 dependencies = [
  "futures-core",
  "memchr",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bstr"
@@ -152,15 +152,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
  "indexmap",
@@ -169,16 +169,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.96",
+ "syn 2.0.99",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -193,9 +193,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -216,14 +216,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -326,7 +326,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "trybuild",
 ]
 
@@ -354,9 +354,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -390,52 +390,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -445,14 +403,8 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -472,13 +424,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -486,13 +434,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -527,9 +476,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -574,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linux-raw-sys"
@@ -586,9 +535,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -616,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -662,7 +611,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -676,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "pin-project-lite"
@@ -694,15 +643,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -751,18 +700,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -778,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -788,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -798,34 +747,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -867,21 +816,21 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
@@ -891,7 +840,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.99",
  "unicode-ident",
 ]
 
@@ -912,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
@@ -931,41 +880,41 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1005,24 +954,24 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1038,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1055,15 +1004,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1100,22 +1049,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1169,14 +1118,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1195,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -1208,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
 dependencies = [
  "glob",
  "serde",
@@ -1244,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unindent"
@@ -1262,18 +1211,21 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi-util"
@@ -1359,36 +1311,45 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "zstd"
-version = "0.13.2"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-anyhow = "1.0.94"
+anyhow = "1.0.97"
 csv = "1.3"
-pyo3 = "0.23.4"
-pyo3-build-config = "0.23.4"
-rstest = "0.23.0"
+pyo3 = "0.23.5"
+pyo3-build-config = "0.23.5"
+rstest = "0.25.0"
 serde = { version = "1.0", features = ["derive"] }
 time = ">=0.3.35"
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.28.0"
+version = "0.29.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = { workspace = true }
 dbn = { path = "../rust/dbn", features = [] }
-libc = "0.2.168"
+libc = "0.2.170"
 
 [build-dependencies]
-cbindgen = { version = "0.27.0", default-features = false }
+cbindgen = { version = "0.28.0", default-features = false }

--- a/c/build.rs
+++ b/c/build.rs
@@ -14,9 +14,8 @@ fn find_target_dir() -> PathBuf {
         if dir.file_name() == Some(OsStr::new("target"))
             // Want to find the top directory containing a CACHEDIR.TAG file
             || (dir.join("CACHEDIR.TAG").exists()
-                && !(dir
-                    .parent()
-                    .map_or(true, |p| p.join("CACHEDIR.TAG").exists())))
+                && !dir
+                    .parent().is_none_or(|p| p.join("CACHEDIR.TAG").exists()))
         {
             return dir;
         }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.28.0"
+version = "0.29.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.28.0"
+version = "0.29.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1062,7 +1062,7 @@ class RecordHeader:
     @property
     def ts_event(self) -> int:
         """
-        The matching-engine-received timestamp expressed as number of
+        The matching-engine-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -1160,7 +1160,7 @@ class Record(SupportsBytes):
     @property
     def ts_event(self) -> int:
         """
-        The matching-engine-received timestamp expressed as number of
+        The matching-engine-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -1172,7 +1172,7 @@ class Record(SupportsBytes):
     @property
     def ts_out(self) -> int | None:
         """
-        The live gateway send timestamp expressed as number of nanoseconds
+        The live gateway send timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
         Returns
@@ -1301,7 +1301,7 @@ class _MBOBase:
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -1725,7 +1725,7 @@ class _MBPBase:
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -1917,7 +1917,7 @@ class BBOMsg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -2073,7 +2073,7 @@ class CMBP1Msg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The interval timestamp expressed as number of nanoseconds since the UNIX epoch.
+        The interval timestamp expressed as the number of nanoseconds since the UNIX epoch.
 
         Returns
         -------
@@ -2217,7 +2217,7 @@ class CBBOMsg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -2535,7 +2535,7 @@ class InstrumentDefMsgV3(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -3496,7 +3496,7 @@ class InstrumentDefMsg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns
@@ -4447,7 +4447,7 @@ class InstrumentDefMsgV1(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The capture-server-received timestamp expressed as number of
+        The capture-server-received timestamp expressed as the number of
         nanoseconds since the UNIX epoch.
 
         Returns

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -136,7 +136,7 @@ mod tests {
         record::{ErrorMsg, OhlcvMsg, RecordHeader},
         Dataset, MetadataBuilder, DBN_VERSION,
     };
-    use pyo3::{py_run, types::PyString};
+    use pyo3::{ffi::c_str, py_run, types::PyString};
 
     use super::*;
     use crate::tests::setup;
@@ -262,8 +262,8 @@ for record in records[1:]:
     fn test_dbn_decoder_decoding_error() {
         setup();
         Python::with_gil(|py| {
-            py.run_bound(
-                r#"from _lib import DBNDecoder, DBNError, Metadata, Schema, SType
+            Python::run(py,
+                c_str!(r#"from _lib import DBNDecoder, DBNError, Metadata, Schema, SType
 
 metadata = Metadata(
     dataset="GLBX.MDP3",
@@ -290,7 +290,7 @@ except DBNError as ex:
     assert "RType" in str(ex)
 except Exception:
     assert False
-"#,
+"#),
                 None,
                 None,
             )
@@ -301,8 +301,10 @@ except Exception:
     fn test_dbn_decoder_no_metadata() {
         setup();
         Python::with_gil(|py| {
-            py.run_bound(
-                r#"from _lib import DBNDecoder, OHLCVMsg
+            Python::run(
+                py,
+                c_str!(
+                    r#"from _lib import DBNDecoder, OHLCVMsg
 
 decoder = DBNDecoder(has_metadata=False)
 record = OHLCVMsg(0x20, 1, 10, 0, 0, 0, 0, 0, 0)
@@ -310,7 +312,8 @@ decoder.write(bytes(record))
 records = decoder.decode()
 assert len(records) == 1
 assert records[0] == record
-"#,
+"#
+                ),
                 None,
                 None,
             )

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.28.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.29.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -25,9 +25,9 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 # CLI integration tests
-assert_cmd = "2.0.16"
+assert_cmd = "2.0"
 # assert_cmd companion
-predicates = "3.1.2"
+predicates = "3.1"
 rstest = { workspace = true }
 # A library for managing temporary files and directories
-tempfile = "3.14.0"
+tempfile = "3.17"

--- a/rust/dbn-cli/src/lib.rs
+++ b/rust/dbn-cli/src/lib.rs
@@ -134,7 +134,7 @@ pub struct Args {
          action = ArgAction::SetTrue,
          default_value = "false",
          conflicts_with_all = ["input_fragment", "dbn", "fragment"],
-         help ="Use symbology mappings from the metadata to create a 'symbol' field mapping the intstrument ID to its requested symbol."
+         help ="Use symbology mappings from the metadata to create a 'symbol' field mapping the instrument ID to its requested symbol."
     )]
     pub map_symbols: bool,
     #[clap(

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -13,13 +13,13 @@ proc-macro = true
 [dependencies]
 # Get name of current crate in macros, like $crate in macro_rules macros
 proc-macro-crate = "3.2.0"
-proc-macro2 = "1.0.92"
+proc-macro2 = "1.0.94"
 # Convert code to token streams
-quote = "1.0.37"
+quote = "1.0.39"
 # Token parsing
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 csv = { workspace = true }
 dbn = { path = "../dbn" }
-trybuild = "1.0.101"
+trybuild = "1.0.103"

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.28.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.29.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.20", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -27,7 +27,7 @@ trivial_copy = []
 [dependencies]
 dbn-macros = { version = "=0.28.0", path = "../dbn-macros" }
 
-async-compression = { version = "0.4.18", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "0.4.20", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }
 fallible-streaming-iterator = { version = "0.1.9", features = ["std"] }
 # Fast integer to string conversion
@@ -37,7 +37,7 @@ pyo3 = { workspace = true, optional = true }
 json-writer = "0.4"
 serde = { workspace = true, features = ["derive"], optional = true }
 # extra enum traits for Python
-strum = { version = "0.26", features = ["derive"], optional = true }
+strum = { version = "0.27", features = ["derive"], optional = true }
 thiserror = "2.0"
 time = { workspace = true, features = ["formatting", "macros"] }
 tokio = { version = ">=1.28", features = ["fs", "io-util"], optional = true }
@@ -45,7 +45,7 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 # Checking alignment and padding
 type-layout = "0.2.0"

--- a/rust/dbn/src/compat.rs
+++ b/rust/dbn/src/compat.rs
@@ -174,8 +174,8 @@ pub struct InstrumentDefMsgV1 {
     /// The common header.
     #[pyo3(get, set)]
     pub hd: RecordHeader,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since the
-    /// UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -510,8 +510,8 @@ pub struct InstrumentDefMsgV3 {
     /// The common header.
     #[pyo3(get, set)]
     pub hd: RecordHeader,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since the
-    /// UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -642,7 +642,7 @@ pub struct InstrumentDefMsgV3 {
     #[dbn(encode_order(168))]
     #[pyo3(get, set)]
     pub leg_ratio_price_denominator: i32,
-    /// The denominator of the price ratio of the leg within the spread.
+    /// The numerator of the price ratio of the leg within the spread.
     #[dbn(encode_order(169))]
     #[pyo3(get, set)]
     pub leg_ratio_qty_numerator: i32,

--- a/rust/dbn/src/decode/stream.rs
+++ b/rust/dbn/src/decode/stream.rs
@@ -31,6 +31,11 @@ where
             _marker: PhantomData,
         }
     }
+
+    /// Returns an immutable reference to the inner decoder.
+    pub fn get_ref(&self) -> &D {
+        &self.decoder
+    }
 }
 
 impl<D, T> FallibleStreamingIterator for StreamIterDecoder<D, T>

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -109,10 +109,14 @@ pub enum Venue {
     Ifus = 48,
     /// ICE Futures Europe (Financials)
     Ifll = 49,
+    /// Eurex Exchange
+    Xeur = 50,
+    /// European Energy Exchange
+    Xeer = 51,
 }
 
 /// The number of Venue variants.
-pub const VENUE_COUNT: usize = 49;
+pub const VENUE_COUNT: usize = 51;
 
 impl Venue {
     /// Convert a Venue to its `str` representation.
@@ -167,6 +171,8 @@ impl Venue {
             Self::Equs => "EQUS",
             Self::Ifus => "IFUS",
             Self::Ifll => "IFLL",
+            Self::Xeur => "XEUR",
+            Self::Xeer => "XEER",
         }
     }
 }
@@ -237,6 +243,8 @@ impl std::str::FromStr for Venue {
             "EQUS" => Ok(Self::Equs),
             "IFUS" => Ok(Self::Ifus),
             "IFLL" => Ok(Self::Ifll),
+            "XEUR" => Ok(Self::Xeur),
+            "XEER" => Ok(Self::Xeer),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -323,10 +331,14 @@ pub enum Dataset {
     IfusImpact = 36,
     /// ICE Futures Europe (Financials) iMpact
     IfllImpact = 37,
+    /// Eurex EOBI
+    XeurEobi = 38,
+    /// European Energy Exchange EOBI
+    XeerEobi = 39,
 }
 
 /// The number of Dataset variants.
-pub const DATASET_COUNT: usize = 37;
+pub const DATASET_COUNT: usize = 39;
 
 impl Dataset {
     /// Convert a Dataset to its `str` representation.
@@ -371,6 +383,8 @@ impl Dataset {
             Self::EqusMini => "EQUS.MINI",
             Self::IfusImpact => "IFUS.IMPACT",
             Self::IfllImpact => "IFLL.IMPACT",
+            Self::XeurEobi => "XEUR.EOBI",
+            Self::XeerEobi => "XEER.EOBI",
         }
     }
 }
@@ -431,6 +445,8 @@ impl std::str::FromStr for Dataset {
             "EQUS.MINI" => Ok(Self::EqusMini),
             "IFUS.IMPACT" => Ok(Self::IfusImpact),
             "IFLL.IMPACT" => Ok(Self::IfllImpact),
+            "XEUR.EOBI" => Ok(Self::XeurEobi),
+            "XEER.EOBI" => Ok(Self::XeerEobi),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -641,10 +657,14 @@ pub enum Publisher {
     IfllImpactIfll = 99,
     /// ICE Futures Europe (Financials) - Off-Market Trades
     IfllImpactXoff = 100,
+    /// Eurex EOBI
+    XeurEobiXeur = 101,
+    /// European Energy Exchange EOBI
+    XeerEobiXeer = 102,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 100;
+pub const PUBLISHER_COUNT: usize = 102;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -750,6 +770,8 @@ impl Publisher {
             Self::IfusImpactXoff => "IFUS.IMPACT.XOFF",
             Self::IfllImpactIfll => "IFLL.IMPACT.IFLL",
             Self::IfllImpactXoff => "IFLL.IMPACT.XOFF",
+            Self::XeurEobiXeur => "XEUR.EOBI.XEUR",
+            Self::XeerEobiXeer => "XEER.EOBI.XEER",
         }
     }
 
@@ -856,6 +878,8 @@ impl Publisher {
             Self::IfusImpactXoff => Venue::Xoff,
             Self::IfllImpactIfll => Venue::Ifll,
             Self::IfllImpactXoff => Venue::Xoff,
+            Self::XeurEobiXeur => Venue::Xeur,
+            Self::XeerEobiXeer => Venue::Xeer,
         }
     }
 
@@ -962,6 +986,8 @@ impl Publisher {
             Self::IfusImpactXoff => Dataset::IfusImpact,
             Self::IfllImpactIfll => Dataset::IfllImpact,
             Self::IfllImpactXoff => Dataset::IfllImpact,
+            Self::XeurEobiXeur => Dataset::XeurEobi,
+            Self::XeerEobiXeer => Dataset::XeerEobi,
         }
     }
 
@@ -1070,6 +1096,8 @@ impl Publisher {
             (Dataset::IfusImpact, Venue::Xoff) => Ok(Self::IfusImpactXoff),
             (Dataset::IfllImpact, Venue::Ifll) => Ok(Self::IfllImpactIfll),
             (Dataset::IfllImpact, Venue::Xoff) => Ok(Self::IfllImpactXoff),
+            (Dataset::XeurEobi, Venue::Xeur) => Ok(Self::XeurEobiXeur),
+            (Dataset::XeerEobi, Venue::Xeer) => Ok(Self::XeerEobiXeer),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1192,6 +1220,8 @@ impl std::str::FromStr for Publisher {
             "IFUS.IMPACT.XOFF" => Ok(Self::IfusImpactXoff),
             "IFLL.IMPACT.IFLL" => Ok(Self::IfllImpactIfll),
             "IFLL.IMPACT.XOFF" => Ok(Self::IfllImpactXoff),
+            "XEUR.EOBI.XEUR" => Ok(Self::XeurEobiXeur),
+            "XEER.EOBI.XEER" => Ok(Self::XeerEobiXeer),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -105,10 +105,14 @@ pub enum Venue {
     Aspi = 46,
     /// Databento US Equities - Consolidated
     Equs = 47,
+    /// ICE Futures US
+    Ifus = 48,
+    /// ICE Futures Europe (Financials)
+    Ifll = 49,
 }
 
 /// The number of Venue variants.
-pub const VENUE_COUNT: usize = 47;
+pub const VENUE_COUNT: usize = 49;
 
 impl Venue {
     /// Convert a Venue to its `str` representation.
@@ -161,6 +165,8 @@ impl Venue {
             Self::Asmt => "ASMT",
             Self::Aspi => "ASPI",
             Self::Equs => "EQUS",
+            Self::Ifus => "IFUS",
+            Self::Ifll => "IFLL",
         }
     }
 }
@@ -229,6 +235,8 @@ impl std::str::FromStr for Venue {
             "ASMT" => Ok(Self::Asmt),
             "ASPI" => Ok(Self::Aspi),
             "EQUS" => Ok(Self::Equs),
+            "IFUS" => Ok(Self::Ifus),
+            "IFLL" => Ok(Self::Ifll),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -311,10 +319,14 @@ pub enum Dataset {
     XnysTradesbbo = 34,
     /// Databento US Equities Mini
     EqusMini = 35,
+    /// ICE Futures US iMpact
+    IfusImpact = 36,
+    /// ICE Futures Europe (Financials) iMpact
+    IfllImpact = 37,
 }
 
 /// The number of Dataset variants.
-pub const DATASET_COUNT: usize = 35;
+pub const DATASET_COUNT: usize = 37;
 
 impl Dataset {
     /// Convert a Dataset to its `str` representation.
@@ -357,6 +369,8 @@ impl Dataset {
             Self::XcisTradesbbo => "XCIS.TRADESBBO",
             Self::XnysTradesbbo => "XNYS.TRADESBBO",
             Self::EqusMini => "EQUS.MINI",
+            Self::IfusImpact => "IFUS.IMPACT",
+            Self::IfllImpact => "IFLL.IMPACT",
         }
     }
 }
@@ -415,6 +429,8 @@ impl std::str::FromStr for Dataset {
             "XCIS.TRADESBBO" => Ok(Self::XcisTradesbbo),
             "XNYS.TRADESBBO" => Ok(Self::XnysTradesbbo),
             "EQUS.MINI" => Ok(Self::EqusMini),
+            "IFUS.IMPACT" => Ok(Self::IfusImpact),
+            "IFLL.IMPACT" => Ok(Self::IfllImpact),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }
@@ -617,10 +633,18 @@ pub enum Publisher {
     EqusMiniEqus = 95,
     /// NYSE Trades - Consolidated
     XnysTradesEqus = 96,
+    /// ICE Futures US
+    IfusImpactIfus = 97,
+    /// ICE Futures US - Off-Market Trades
+    IfusImpactXoff = 98,
+    /// ICE Futures Europe (Financials)
+    IfllImpactIfll = 99,
+    /// ICE Futures Europe (Financials) - Off-Market Trades
+    IfllImpactXoff = 100,
 }
 
 /// The number of Publisher variants.
-pub const PUBLISHER_COUNT: usize = 96;
+pub const PUBLISHER_COUNT: usize = 100;
 
 impl Publisher {
     /// Convert a Publisher to its `str` representation.
@@ -722,6 +746,10 @@ impl Publisher {
             Self::EqusAllEqus => "EQUS.ALL.EQUS",
             Self::EqusMiniEqus => "EQUS.MINI.EQUS",
             Self::XnysTradesEqus => "XNYS.TRADES.EQUS",
+            Self::IfusImpactIfus => "IFUS.IMPACT.IFUS",
+            Self::IfusImpactXoff => "IFUS.IMPACT.XOFF",
+            Self::IfllImpactIfll => "IFLL.IMPACT.IFLL",
+            Self::IfllImpactXoff => "IFLL.IMPACT.XOFF",
         }
     }
 
@@ -824,6 +852,10 @@ impl Publisher {
             Self::EqusAllEqus => Venue::Equs,
             Self::EqusMiniEqus => Venue::Equs,
             Self::XnysTradesEqus => Venue::Equs,
+            Self::IfusImpactIfus => Venue::Ifus,
+            Self::IfusImpactXoff => Venue::Xoff,
+            Self::IfllImpactIfll => Venue::Ifll,
+            Self::IfllImpactXoff => Venue::Xoff,
         }
     }
 
@@ -926,6 +958,10 @@ impl Publisher {
             Self::EqusAllEqus => Dataset::EqusAll,
             Self::EqusMiniEqus => Dataset::EqusMini,
             Self::XnysTradesEqus => Dataset::XnysTrades,
+            Self::IfusImpactIfus => Dataset::IfusImpact,
+            Self::IfusImpactXoff => Dataset::IfusImpact,
+            Self::IfllImpactIfll => Dataset::IfllImpact,
+            Self::IfllImpactXoff => Dataset::IfllImpact,
         }
     }
 
@@ -1030,6 +1066,10 @@ impl Publisher {
             (Dataset::EqusAll, Venue::Equs) => Ok(Self::EqusAllEqus),
             (Dataset::EqusMini, Venue::Equs) => Ok(Self::EqusMiniEqus),
             (Dataset::XnysTrades, Venue::Equs) => Ok(Self::XnysTradesEqus),
+            (Dataset::IfusImpact, Venue::Ifus) => Ok(Self::IfusImpactIfus),
+            (Dataset::IfusImpact, Venue::Xoff) => Ok(Self::IfusImpactXoff),
+            (Dataset::IfllImpact, Venue::Ifll) => Ok(Self::IfllImpactIfll),
+            (Dataset::IfllImpact, Venue::Xoff) => Ok(Self::IfllImpactXoff),
             _ => Err(Error::conversion::<Self>(format!("({dataset}, {venue})"))),
         }
     }
@@ -1148,6 +1188,10 @@ impl std::str::FromStr for Publisher {
             "EQUS.ALL.EQUS" => Ok(Self::EqusAllEqus),
             "EQUS.MINI.EQUS" => Ok(Self::EqusMiniEqus),
             "XNYS.TRADES.EQUS" => Ok(Self::XnysTradesEqus),
+            "IFUS.IMPACT.IFUS" => Ok(Self::IfusImpactIfus),
+            "IFUS.IMPACT.XOFF" => Ok(Self::IfusImpactXoff),
+            "IFLL.IMPACT.IFLL" => Ok(Self::IfllImpactIfll),
+            "IFLL.IMPACT.XOFF" => Ok(Self::IfllImpactXoff),
             _ => Err(Error::conversion::<Self>(s)),
         }
     }

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -54,8 +54,8 @@ pub struct RecordHeader {
     /// The numeric ID assigned to the instrument.
     #[pyo3(set)]
     pub instrument_id: u32,
-    /// The matching-engine-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The matching-engine-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), unix_nanos)]
     #[pyo3(set)]
     pub ts_event: u64,
@@ -108,8 +108,8 @@ pub struct MboMsg {
     /// **N**one where no side is specified by the original source.
     #[dbn(c_char, encode_order(3))]
     pub side: c_char,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -229,8 +229,8 @@ pub struct TradeMsg {
     #[dbn(encode_order(4))]
     #[pyo3(get, set)]
     pub depth: u8,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -285,8 +285,8 @@ pub struct Mbp1Msg {
     #[dbn(encode_order(4))]
     #[pyo3(get, set)]
     pub depth: u8,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -344,8 +344,8 @@ pub struct Mbp10Msg {
     #[dbn(encode_order(4))]
     #[pyo3(get, set)]
     pub depth: u8,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -379,11 +379,12 @@ pub struct BboMsg {
     #[pyo3(get)]
     pub hd: RecordHeader,
     /// The price of the last trade expressed as a signed integer where every 1 unit
-    /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE)
+    /// if there was no last trade in the session.
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub price: i64,
-    /// The quantity of the last trade.
+    /// The last trade quantity.
     #[pyo3(get, set)]
     pub size: u32,
     // Reserved for later usage.
@@ -392,7 +393,8 @@ pub struct BboMsg {
     pub _reserved1: u8,
     /// The side that initiated the last trade. Can be **A**sk for a sell order (or sell
     /// aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
-    /// **N**one where no side is specified by the original source.
+    /// **N**one where no side is specified by the original source or if there was no last
+    /// trade.
     #[dbn(c_char, encode_order(2))]
     pub side: c_char,
     /// A bit field indicating event end, message characteristics, and data quality. See
@@ -403,7 +405,8 @@ pub struct BboMsg {
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _reserved2: u8,
-    /// The interval timestamp expressed as number of nanoseconds since the UNIX epoch.
+    /// The end timestamp of the interval as the number of nanoseconds since the UNIX
+    /// epoch. Clamped to the 1-second or 1-minute boundary.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -462,8 +465,8 @@ pub struct Cmbp1Msg {
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _reserved1: [c_char; 1],
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -521,7 +524,8 @@ pub struct CbboMsg {
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _reserved2: u8,
-    /// The interval timestamp expressed as number of nanoseconds since the UNIX epoch.
+    /// The interval timestamp expressed as the number of nanoseconds since the UNIX
+    /// epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -615,8 +619,8 @@ pub struct StatusMsg {
     /// The common header.
     #[pyo3(get)]
     pub hd: RecordHeader,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since
-    /// the UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -668,8 +672,8 @@ pub struct InstrumentDefMsg {
     /// The common header.
     #[pyo3(get, set)]
     pub hd: RecordHeader,
-    /// The capture-server-received timestamp expressed as number of nanoseconds since the
-    /// UNIX epoch.
+    /// The capture-server-received timestamp expressed as the number of nanoseconds
+    /// since the UNIX epoch.
     #[dbn(encode_order(0), index_ts, unix_nanos)]
     #[pyo3(get, set)]
     pub ts_recv: u64,
@@ -1027,7 +1031,7 @@ pub struct StatMsg {
     pub ts_ref: u64,
     /// The value for price statistics expressed as a signed integer where every 1 unit
     /// corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be
-    /// [`crate::UNDEF_PRICE`] when unused.
+    /// [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
     #[dbn(fixed_price)]
     #[pyo3(set)]
     pub price: i64,
@@ -1247,7 +1251,8 @@ pub trait HasRType: Record + RecordMut {
 pub struct WithTsOut<T: HasRType> {
     /// The inner record.
     pub rec: T,
-    /// The live gateway send timestamp expressed as number of nanoseconds since the UNIX epoch.
+    /// The live gateway send timestamp expressed as the number of nanoseconds since the
+    /// UNIX epoch.
     pub ts_out: u64,
 }
 


### PR DESCRIPTION
### Enhancements
- Added new venues, datasets, and publishers for ICE Futures US, ICE Futures Europe
  (Financial products), Eurex, and European Energy Exchange (EEX)
- Added new `SkipBytes` and `AsyncSkipBytes` traits which are a subset of the `Seek`
  and `AsyncSeek` traits respectively, only supporting seeking forward from the current
  position

### Deprecations
- Deprecated `AsyncRecordDecoder::get_mut()` and `AsyncDecoder::get_mut()` as modifying
  the inner reader after decoding any records could lead to a corrupted stream and
  decoding errors

### Bug fixes
- Fixed typo in `-s`/`--map-symbols` help text (credit: @wtn)
