### PR TITLE
VER: 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,23 @@
 # Changelog
 
-## 0.31.0 - TBD
+## 0.31.0 - 2025-04-01
 
 ### Enhancements
 - Added `Ord` and `PartialOrd` implementations for all enums and `FlagSet` to allow
   for use in ordered containers like `BTreeMap`
 - Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
   which is similar to the sync decoder methods of the same name
+- Upgraded `pyo3` version to 0.24.1
+- Upgraded `time` version to 0.3.41
 
 ### Breaking changes
 - Removed deprecated `dataset` module. The top-level `Dataset` enum and its `const` `as_str()`
   method provide the same functionality for all datasets
 - Removed deprecated `SymbolIndex::get_for_rec_ref()` method
+
+### Bug fixes
+- Fixed Python type annotation for `SystemMsg::is_heartbeat()` method that was previously
+  annotated as a property
 
 ## 0.30.0 - 2025-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
   which is similar to the sync decoder methods of the same name
 
+### Breaking changes
+- Removed deprecated `dataset` module. The top-level `Dataset` enum and its `const` `as_str()`
+  method provide the same functionality for all datasets
+- Removed deprecated `SymbolIndex::get_for_rec_ref()` method
+
 ## 0.30.0 - 2025-03-25
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.31.0 - TBD
+
+### Enhancements
+- Added `Ord` and `PartialOrd` implementations for all enums and `FlagSet` to allow
+  for use in ordered containers like `BTreeMap`
+- Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
+  which is similar to the sync decoder methods of the same name
+
 ## 0.30.0 - 2025-03-25
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "csv",
  "dbn",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pin-project-lite"
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.30.0"
+version = "0.31.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"
@@ -19,9 +19,9 @@ license = "Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.97"
 csv = "1.3"
-pyo3 = "0.24.0"
-pyo3-build-config = "0.24.0"
+pyo3 = "0.24.1"
+pyo3-build-config = "0.24.1"
 rstest = "0.25.0"
 serde = { version = "1.0", features = ["derive"] }
-time = ">=0.3.35"
+time = "0.3.41"
 zstd = "0.13"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.30.0"
+version = "0.31.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -6094,10 +6094,9 @@ class SystemMsgV1(Record):
 
         """
 
-    @property
     def is_heartbeat(self) -> bool:
         """
-        `true` if this message is a heartbeat, used to indicate the connection
+        Return `true` if this message is a heartbeat, used to indicate the connection
         with the gateway is still open.
 
         Returns

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.30.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.31.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.30.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.31.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.22", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -13,7 +13,19 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 /// A [side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types)
 /// of the market. The side of the market for resting orders, or the side of the
 /// aggressor for trades.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, TryFromPrimitive, IntoPrimitive)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    TryFromPrimitive,
+    IntoPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter, strum::AsRefStr),
@@ -41,7 +53,19 @@ impl From<Side> for char {
 /// For example usage see:
 /// - [Order actions](https://databento.com/docs/examples/order-book/order-actions)
 /// - [Order tracking](https://databento.com/docs/examples/order-book/order-tracking)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, TryFromPrimitive, IntoPrimitive)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    TryFromPrimitive,
+    IntoPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter, strum::AsRefStr),
@@ -76,7 +100,9 @@ impl From<Action> for char {
 ///
 /// For example usage see
 /// [Getting options with their underlying](https://databento.com/docs/examples/options/options-and-futures).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive, IntoPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -139,7 +165,19 @@ impl InstrumentClass {
 }
 
 /// The type of matching algorithm used for the instrument at the exchange.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TryFromPrimitive,
+    IntoPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -186,7 +224,19 @@ impl From<MatchAlgorithm> for char {
 ///
 /// For example usage see
 /// [Getting options with their underlying](https://databento.com/docs/examples/options/options-and-futures).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TryFromPrimitive,
+    IntoPrimitive,
+    Default,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter, strum::AsRefStr),
@@ -211,7 +261,7 @@ impl From<UserDefinedInstrument> for char {
 /// A symbology type. Refer to the
 /// [symbology documentation](https://databento.com/docs/api-reference-historical/basics/symbology)
 /// for more information.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -323,7 +373,7 @@ pub mod rtype {
     /// Use in [`RecordHeader`](crate::RecordHeader) to indicate the type of record,
     /// which is useful when working with DBN streams containing multiple record types
     /// or an unknown record type.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
     #[cfg_attr(
         feature = "python",
         derive(strum::EnumIter),
@@ -572,7 +622,7 @@ pub mod rtype {
 ///
 /// See [List of supported market data schemas](https://databento.com/docs/schemas-and-data-formats/whats-a-schema)
 /// for an overview of the differences and use cases of each schema.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -723,7 +773,7 @@ impl Display for Schema {
 }
 
 /// A data encoding format.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -776,7 +826,7 @@ impl Display for Encoding {
 }
 
 /// A compression format or none if uncompressed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -847,7 +897,9 @@ pub mod flags {
 
 /// The type of [`InstrumentDefMsg`](crate::record::InstrumentDefMsg) update.
 #[allow(clippy::manual_non_exhaustive)] // false positive
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter, strum::AsRefStr),
@@ -868,7 +920,9 @@ pub enum SecurityUpdateAction {
 }
 
 /// The type of statistic contained in a [`StatMsg`](crate::record::StatMsg).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -932,7 +986,9 @@ pub enum StatType {
 }
 
 /// The type of [`StatMsg`](crate::record::StatMsg) update.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -947,7 +1003,19 @@ pub enum StatUpdateAction {
 }
 
 /// The primary enum for the type of [`StatusMsg`](crate::record::StatusMsg) update.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Default,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -994,7 +1062,19 @@ pub enum StatusAction {
 
 /// The secondary enum for a [`StatusMsg`](crate::record::StatusMsg) update, explains
 /// the cause of a halt or other change in `action`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Default,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -1078,7 +1158,19 @@ pub enum StatusReason {
 }
 
 /// Further information about a status update.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Default,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -1102,7 +1194,19 @@ pub enum TradingEvent {
 
 /// An enum for representing unknown, true, or false values. Equivalent to
 /// `Option<bool>` but with a human-readable repr.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive, Default)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Default,
+)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),
@@ -1140,7 +1244,7 @@ impl From<Option<bool>> for TriState {
 }
 
 /// How to handle decoding DBN data from other versions.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
     feature = "python",
     derive(strum::EnumIter),

--- a/rust/dbn/src/flags.rs
+++ b/rust/dbn/src/flags.rs
@@ -23,7 +23,7 @@ pub const MAYBE_BAD_BOOK: u8 = 1 << 2;
 /// A transparent wrapper around the bit field used in several DBN record types,
 /// namely [`MboMsg`](crate::MboMsg) and record types derived from it.
 #[repr(transparent)]
-#[derive(Copy, Clone, PartialEq, Eq, Default, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 #[cfg_attr(feature = "python", derive(FromPyObject), pyo3(transparent))]
 #[cfg_attr(
     feature = "serde",

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -107,18 +107,3 @@ pub const UNDEF_STAT_QUANTITY: i32 = i32::MAX;
 pub const UNDEF_TIMESTAMP: u64 = u64::MAX;
 /// The length in bytes of the largest record type.
 pub const MAX_RECORD_LEN: usize = std::mem::size_of::<WithTsOut<v3::InstrumentDefMsg>>();
-
-/// Contains dataset code constants.
-#[deprecated(since = "0.25.0", note = "Use the `Dataset` enum instead")]
-pub mod datasets {
-    use crate::publishers::Dataset;
-
-    /// The dataset code for Databento Equities Basic.
-    pub const DBEQ_BASIC: &str = Dataset::DbeqBasic.as_str();
-    /// The dataset code for CME Globex MDP 3.0.
-    pub const GLBX_MDP3: &str = Dataset::GlbxMdp3.as_str();
-    /// The dataset code for OPRA PILLAR.
-    pub const OPRA_PILLAR: &str = Dataset::OpraPillar.as_str();
-    /// The dataset code for Nasdaq TotalView-ITCH.
-    pub const XNAS_ITCH: &str = Dataset::XnasItch.as_str();
-}

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -7,7 +7,9 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{Error, Result};
 
 /// A trading execution venue.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum Venue {
@@ -251,7 +253,9 @@ impl std::str::FromStr for Venue {
 }
 
 /// A source of data.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum Dataset {
@@ -453,7 +457,9 @@ impl std::str::FromStr for Dataset {
 }
 
 /// A specific Venue from a specific data source.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum Publisher {

--- a/rust/dbn/src/symbol_map.rs
+++ b/rust/dbn/src/symbol_map.rs
@@ -24,16 +24,6 @@ pub trait SymbolIndex {
     /// Returns the associated symbol mapping for `record`. Returns `None` if no mapping
     /// exists.
     fn get_for_rec<R: Record>(&self, record: &R) -> Option<&String>;
-
-    /// Returns the associated symbol mapping for `rec_ref`. Returns `None` if no mapping
-    /// exists.
-    #[deprecated(
-        since = "0.13.0",
-        note = "The trait bound for get_for_rec was loosened to accept RecordRefs, making this function redundant"
-    )]
-    fn get_for_rec_ref(&self, rec_ref: RecordRef) -> Option<&String> {
-        self.get_for_rec(&rec_ref)
-    }
 }
 
 impl TsSymbolMap {


### PR DESCRIPTION
### Enhancements
- Added `Ord` and `PartialOrd` implementations for all enums and `FlagSet` to allow
  for use in ordered containers like `BTreeMap`
- Added `decode_records()` method to `AsyncDbnDecoder` and `AsyncDbnRecordDecoder`
  which is similar to the sync decoder methods of the same name
- Upgraded `pyo3` version to 0.24.1
- Upgraded `time` version to 0.3.41

### Breaking changes
- Removed deprecated `dataset` module. The top-level `Dataset` enum and its `const` `as_str()`
  method provide the same functionality for all datasets
- Removed deprecated `SymbolIndex::get_for_rec_ref()` method

### Bug fixes
- Fixed Python type annotation for `SystemMsg::is_heartbeat()` method that was previously
  annotated as a property
