### PR TITLE
VER: Release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.33.0 - TBD
+
+### Enhancements
+- Added `SystemCode` and `ErrorCode` enums to indicate types of system and error
+  messages
+- Added `code()` methods to `SystemMsg` and `ErrorMsg` to retrieve the enum value if
+  one exists and equivalent properties in Python
+- Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the heartbeat
+  value
+
+### Breaking changes
+- Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
+- Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more like
+  function invocation
+
 ## 0.32.0 - 2025-04-14
 
 ### Enhancements
@@ -7,10 +22,6 @@
   dispatching, async functions and methods, and now always verifies the record length
 - Refactored the `schema_dispatch` macro to be more flexible: it supports `ts_out`
   dispatching and async functions and methods
-
-### Breaking changes
-- Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more like
-  function invocation
 
 ### Deprecations
 - Deprecated macros `rtype_async_dispatch`, `rtype_ts_out_dispatch`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
   one exists and equivalent properties in Python
 - Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the heartbeat
   value
+- Introduced `ASSET_CSTR_LEN` constant containing the size of `asset` field in `InstrumentDefMsg`
 
 ### Breaking changes
 - Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
 - Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more like
   function invocation
+- Increased the size of `asset` field in `InstrumentDefMsgV3` from 7 to 11. The `InstrumentDefMsgV3`
+  message size remains 520 bytes.
 
 ## 0.32.0 - 2025-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.33.0 - TBD
+## 0.33.0 - 2025-04-22
 
 ### Enhancements
 - Added `SystemCode` and `ErrorCode` enums to indicate types of system and error
@@ -9,16 +9,17 @@
   one exists and equivalent properties in Python
 - Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the heartbeat
   value
-- Introduced `ASSET_CSTR_LEN` constant containing the size of `asset` field in `InstrumentDefMsg`
-- Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a record along with its
-  text symbolto match the sync encoder
+- Added `ASSET_CSTR_LEN` constants for the size of `asset` field in `InstrumentDefMsg`
+  in different DBN versions
+- Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a record
+  along with its text symbol to match the sync encoder
 
 ### Breaking changes
 - Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
 - Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more like
   function invocation
-- Increased the size of `asset` field in `InstrumentDefMsgV3` from 7 to 11. The `InstrumentDefMsgV3`
-  message size remains 520 bytes.
+- Increased the size of `asset` field in `v3::InstrumentDefMsg` from 7 to 11. The
+  `InstrumentDefMsgV3` message size remains 520 bytes.
 
 ## 0.32.0 - 2025-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the heartbeat
   value
 - Introduced `ASSET_CSTR_LEN` constant containing the size of `asset` field in `InstrumentDefMsg`
+- Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a record along with its
+  text symbolto match the sync encoder
 
 ### Breaking changes
 - Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
 dependencies = [
  "futures-core",
  "memchr",
@@ -193,9 +193,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "csv",
  "dbn",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -701,18 +701,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.32.0"
+version = "0.33.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-anyhow = "1.0.97"
+anyhow = "1.0.98"
 csv = "1.3"
-pyo3 = "0.24.1"
-pyo3-build-config = "0.24.1"
+pyo3 = "0.24.2"
+pyo3-build-config = "0.24.2"
 rstest = "0.25.0"
 serde = { version = "1.0", features = ["derive"] }
 time = "0.3.41"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = { workspace = true }
 dbn = { path = "../rust/dbn", features = [] }
-libc = "0.2.171"
+libc = "0.2.172"
 
 [build-dependencies]
 cbindgen = { version = "0.28.0", default-features = false }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.32.0"
+version = "0.33.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.32.0"
+version = "0.33.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -822,6 +822,60 @@ class VersionUpgradePolicy(Enum):
     AS_IS: int
     UPGRADE_TO_V2: int
 
+class ErrorCode(Enum):
+    """
+    An error code from the live subscription gateway.
+
+    AUTH_FAILED
+        The authentication step failed.
+    API_KEY_DEACTIVATED
+        The user account or API key were deactivated.
+    CONNECTION_LIMIT_EXCEEDED
+        The user has exceeded their open connection limit
+    SYMBOL_RESOLUTION_FAILED
+        One or more symbols failed to resolve.
+    INVALID_SUBSCRIPTION
+        There was an issue with a subscription request (other than symbol resolution).
+     INTERNAL_ERROR
+        An error occurred in the gateway.
+
+    """
+
+    AUTH_FAILED: int
+    API_KEY_DEACTIVATED: int
+    CONNECTION_LIMIT_EXCEEDED: int
+    SYMBOL_RESOLUTION_FAILED: int
+    INVALID_SUBSCRIPTION: int
+    INTERNAL_ERROR: int
+
+    @classmethod
+    def variants(cls) -> Iterable[ErrorCode]: ...
+
+class SystemCode(Enum):
+    """
+    A `SystemMsg` code indicating the type of message from the live subscription
+    gateway.
+
+    HEARTBEAT
+        A message sent in the absence of other records to indicate the connection
+        remains open.
+    SUBSCRIPTION_ACK
+        An acknowledgement of a subscription request.
+    SLOW_READER_WARNING
+        The gateway has detected this session is falling behind real-time.
+    REPLAY_COMPLETED
+        Indicates a replay subscription has caught up with real-time data.
+
+    """
+
+    HEARTBEAT: int
+    SUBSCRIPTION_ACK: int
+    SLOW_READER_WARNING: int
+    REPLAY_COMPLETED: int
+
+    @classmethod
+    def variants(cls) -> Iterable[ErrorCode]: ...
+
 class Metadata(SupportsBytes):
     """
     Information about the data contained in a DBN file or stream. DBN requires
@@ -5937,6 +5991,19 @@ class ErrorMsg(ErrorMsgV1):
     An error message from the Databento Live Subscription Gateway (LSG).
     """
 
+    def __init__(
+        self, ts_event: int, err: str, is_last: bool = True, code: ErrorCode | None = None
+    ) -> None: ...
+    @property
+    def code(self) -> ErrorCode | None:
+        """
+        The error code, if any.
+
+        Returns
+        -------
+        ErrorCode | None
+        """
+
     @property
     def is_last(self) -> int:
         """
@@ -6087,14 +6154,15 @@ class SystemMsg(SystemMsgV1):
 
     """
 
+    def __init__(self, ts_event: int, msg: str, code: SystemCode | None = None) -> None: ...
     @property
-    def code(self) -> int:
+    def code(self) -> SystemCode | None:
         """
-        Type of system message, currently unused.
+        Type of system message, if any.
 
         Returns
         -------
-        int
+        SystemCode | None
         """
 
 class SystemMsgV1(Record):

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -164,7 +164,7 @@ mod tests {
         let metadata_pos = encoder.get_ref().len();
         assert!(matches!(target.decode(), Ok(recs) if recs.len() == 1));
         assert!(target.has_decoded_metadata);
-        let rec = ErrorMsg::new(1680708278000000000, "Python", true);
+        let rec = ErrorMsg::new(1680708278000000000, None, "Python", true);
         encoder.encode_record(&rec).unwrap();
         assert!(target.buffer.get_ref().is_empty());
         let record_pos = encoder.get_ref().len();
@@ -204,7 +204,7 @@ mod tests {
         let metadata_pos = encoder.get_ref().len();
         assert!(matches!(decoder.decode(), Ok(recs) if recs.len() == 1));
         assert!(decoder.has_decoded_metadata);
-        let rec1 = ErrorMsg::new(1680708278000000000, "Python", true);
+        let rec1 = ErrorMsg::new(1680708278000000000, None, "Python", true);
         let rec2 = OhlcvMsg {
             hd: RecordHeader::new::<OhlcvMsg>(rtype::OHLCV_1S, 1, 1, 1681228173000000000),
             open: 100,

--- a/python/src/encode.rs
+++ b/python/src/encode.rs
@@ -131,10 +131,10 @@ fn py_to_rs_io_err(e: PyErr) -> io::Error {
 
         match e_as_object.call_method(intern!(py, "__str__"), (), None) {
             Ok(repr) => match repr.extract::<String>() {
-                Ok(s) => io::Error::new(io::ErrorKind::Other, s),
-                Err(_e) => io::Error::new(io::ErrorKind::Other, "An unknown error has occurred"),
+                Ok(s) => io::Error::other(s),
+                Err(_e) => io::Error::other("An unknown error has occurred"),
             },
-            Err(_) => io::Error::new(io::ErrorKind::Other, "Err doesn't have __str__"),
+            Err(_) => io::Error::other("Err doesn't have __str__"),
         }
     })
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7,12 +7,12 @@ use dbn::{
     flags,
     python::{DBNError, EnumIterator},
     Action, BboMsg, BidAskPair, CbboMsg, Cmbp1Msg, Compression, ConsolidatedBidAskPair, Encoding,
-    ErrorMsg, ImbalanceMsg, InstrumentClass, InstrumentDefMsg, MatchAlgorithm, MboMsg, Mbp10Msg,
-    Mbp1Msg, Metadata, OhlcvMsg, RType, RecordHeader, SType, Schema, SecurityUpdateAction, Side,
-    StatMsg, StatType, StatUpdateAction, StatusAction, StatusMsg, StatusReason, SymbolMappingMsg,
-    SystemMsg, TradeMsg, TradingEvent, TriState, UserDefinedInstrument, VersionUpgradePolicy,
-    DBN_VERSION, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_STAT_QUANTITY,
-    UNDEF_TIMESTAMP,
+    ErrorCode, ErrorMsg, ImbalanceMsg, InstrumentClass, InstrumentDefMsg, MatchAlgorithm, MboMsg,
+    Mbp10Msg, Mbp1Msg, Metadata, OhlcvMsg, RType, RecordHeader, SType, Schema,
+    SecurityUpdateAction, Side, StatMsg, StatType, StatUpdateAction, StatusAction, StatusMsg,
+    StatusReason, SymbolMappingMsg, SystemCode, SystemMsg, TradeMsg, TradingEvent, TriState,
+    UserDefinedInstrument, VersionUpgradePolicy, DBN_VERSION, FIXED_PRICE_SCALE, UNDEF_ORDER_SIZE,
+    UNDEF_PRICE, UNDEF_STAT_QUANTITY, UNDEF_TIMESTAMP,
 };
 
 mod dbn_decoder;
@@ -63,6 +63,7 @@ fn databento_dbn(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     checked_add_class::<Action>(m)?;
     checked_add_class::<Compression>(m)?;
     checked_add_class::<Encoding>(m)?;
+    checked_add_class::<ErrorCode>(m)?;
     checked_add_class::<InstrumentClass>(m)?;
     checked_add_class::<MatchAlgorithm>(m)?;
     checked_add_class::<RType>(m)?;
@@ -74,6 +75,7 @@ fn databento_dbn(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     checked_add_class::<StatUpdateAction>(m)?;
     checked_add_class::<StatusAction>(m)?;
     checked_add_class::<StatusReason>(m)?;
+    checked_add_class::<SystemCode>(m)?;
     checked_add_class::<TradingEvent>(m)?;
     checked_add_class::<TriState>(m)?;
     checked_add_class::<UserDefinedInstrument>(m)?;

--- a/python/src/transcoder.rs
+++ b/python/src/transcoder.rs
@@ -533,7 +533,7 @@ mod tests {
                 .has_decoded_metadata
         );
         let metadata_pos = encoder.get_ref().len();
-        let rec = ErrorMsg::new(1680708278000000000, "This is a test", true);
+        let rec = ErrorMsg::new(1680708278000000000, None, "This is a test", true);
         encoder.encode_record(&rec).unwrap();
         Python::with_gil(|py| {
             assert!(target.buffer(py).is_empty().unwrap());
@@ -603,7 +603,7 @@ mod tests {
                 .downcast_unchecked::<{ Encoding::Csv as u8 }>()
                 .has_decoded_metadata
         );
-        let rec1 = ErrorMsg::new(1680708278000000000, "This is a test", true);
+        let rec1 = ErrorMsg::new(1680708278000000000, None, "This is a test", true);
         let rec2 = OhlcvMsg {
             hd: RecordHeader::new::<OhlcvMsg>(rtype::OHLCV_1S, 1, 1, 1681228173000000000),
             open: 100,

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.32.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.33.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.3.0"
-proc-macro2 = "1.0.94"
+proc-macro2 = "1.0.95"
 quote = "1.0.40"
 syn = { version = "2.0", features = ["full"] }
 

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,9 +25,9 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.32.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.33.0", path = "../dbn-macros" }
 
-async-compression = { version = "0.4.22", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "0.4.23", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }
 fallible-streaming-iterator = { version = "0.1.9", features = ["std"] }
 # Fast integer to string conversion

--- a/rust/dbn/src/compat.rs
+++ b/rust/dbn/src/compat.rs
@@ -6,6 +6,14 @@ pub const SYMBOL_CSTR_LEN_V1: usize = 22;
 pub const SYMBOL_CSTR_LEN_V2: usize = 71;
 /// The length of symbol fields in DBN version 3 (future version).
 pub const SYMBOL_CSTR_LEN_V3: usize = SYMBOL_CSTR_LEN_V2;
+
+/// The length of asset field in instrument definitions in DBN version 1.
+pub const ASSET_CSTR_LEN_V1: usize = 7;
+/// The length of asset field in instrument definitions in DBN version 2 (current version).
+pub const ASSET_CSTR_LEN_V2: usize = ASSET_CSTR_LEN_V1;
+/// The length of asset field in instrument definitions in DBN version 3 (future version).
+pub const ASSET_CSTR_LEN_V3: usize = 11;
+
 pub(crate) const METADATA_RESERVED_LEN_V1: usize = 47;
 
 /// Returns the length of symbol fields in the given DBN version
@@ -735,7 +743,7 @@ pub struct InstrumentDefMsgV3 {
     /// The underlying asset code (product code) of the instrument.
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "crate::record::cstr_serde"))]
-    pub asset: [c_char; 7],
+    pub asset: [c_char; ASSET_CSTR_LEN_V3],
     /// The ISO standard instrument categorization code.
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "crate::record::cstr_serde"))]
@@ -814,7 +822,7 @@ pub struct InstrumentDefMsgV3 {
     // Filler for alignment.
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub _reserved: [u8; 21],
+    pub _reserved: [u8; 17],
 }
 
 #[cfg(test)]

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -954,7 +954,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_decode_record_length_longer_than_buffer() {
-        let rec = ErrorMsg::new(1680703198000000000, "Test", true);
+        let rec = ErrorMsg::new(1680703198000000000, None, "Test", true);
         let mut target = RecordDecoder::new(&rec.as_ref()[..rec.record_size() - 1]);
         let res = target.decode_ref().await;
         dbg!(&res);

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -1079,7 +1079,7 @@ mod tests {
             close: 125,
             volume: 65,
         };
-        let error_msg: ErrorMsg = ErrorMsg::new(0, "Test failed successfully", true);
+        let error_msg = ErrorMsg::new(0, None, "Test failed successfully", true);
         encoder.encode_record(&OHLCV_MSG).unwrap();
         encoder.encode_record(&error_msg).unwrap();
 
@@ -1124,7 +1124,7 @@ mod tests {
 
     #[test]
     fn test_decode_record_length_longer_than_buffer() {
-        let rec = ErrorMsg::new(1680703198000000000, "Test", true);
+        let rec = ErrorMsg::new(1680703198000000000, None, "Test", true);
         let mut target = RecordDecoder::new(&rec.as_ref()[..rec.record_size() - 1]);
         assert!(matches!(target.decode_ref(), Ok(None)));
     }

--- a/rust/dbn/src/encode/json/sync.rs
+++ b/rust/dbn/src/encode/json/sync.rs
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn test_serialize_quoted_str_to_json() {
         let json = write_json_to_string(
-            vec![ErrorMsg::new(0, "\"A test", true)].as_slice(),
+            vec![ErrorMsg::new(0, None, "\"A test", true)].as_slice(),
             false,
             true,
             true,

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -1277,6 +1277,106 @@ pub enum VersionUpgradePolicy {
     UpgradeToV2,
 }
 
+/// An error code from the live subscription gateway.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
+#[cfg_attr(
+    feature = "python",
+    derive(strum::EnumIter),
+    pyo3::pyclass(module = "databento_dbn", rename_all = "SCREAMING_SNAKE_CASE")
+)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ErrorCode {
+    /// The authentication step failed.
+    AuthFailed = 1,
+    /// The user account or API key were deactivated.
+    ApiKeyDeactivated = 2,
+    /// The user has exceeded their open connection limit
+    ConnectionLimitExceeded = 3,
+    /// One or more symbols failed to resolve.
+    SymbolResolutionFailed = 4,
+    /// There was an issue with a subscription request (other than symbol resolution).
+    InvalidSubscription = 5,
+    /// An error occurred in the gateway.
+    InternalError = 6,
+}
+
+impl AsRef<str> for ErrorCode {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl ErrorCode {
+    /// Converts the given error code to a `&'static str`.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            ErrorCode::AuthFailed => "auth_failed",
+            ErrorCode::ApiKeyDeactivated => "api_key_deactivated",
+            ErrorCode::ConnectionLimitExceeded => "connection_limit_exceeded",
+            ErrorCode::SymbolResolutionFailed => "symbol_resolution_failed",
+            ErrorCode::InvalidSubscription => "invalid_subscription",
+            ErrorCode::InternalError => "internal_error",
+        }
+    }
+}
+
+impl Display for ErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A [`SystemMsg`](crate::SystemMsg) code indicating the type of message from the live
+/// subscription gateway.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPrimitive, TryFromPrimitive,
+)]
+#[cfg_attr(
+    feature = "python",
+    derive(strum::EnumIter),
+    pyo3::pyclass(module = "databento_dbn", rename_all = "SCREAMING_SNAKE_CASE")
+)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum SystemCode {
+    /// A message sent in the absence of other records to indicate the connection
+    /// remains open.
+    Heartbeat = 0,
+    /// An acknowledgement of a subscription request.
+    SubscriptionAck = 1,
+    /// The gateway has detected this session is falling behind real-time.
+    SlowReaderWarning = 2,
+    /// Indicates a replay subscription has caught up with real-time data.
+    ReplayCompleted = 3,
+}
+
+impl AsRef<str> for SystemCode {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl SystemCode {
+    /// Converts the given system code to a `&'static str`.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            SystemCode::Heartbeat => "heartbeat",
+            SystemCode::SubscriptionAck => "subscription_ack",
+            SystemCode::SlowReaderWarning => "slow_reader_warning",
+            SystemCode::ReplayCompleted => "replay_completed",
+        }
+    }
+}
+
+impl Display for SystemCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[cfg(feature = "serde")]
 mod deserialize {
     use std::str::FromStr;

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -62,9 +62,10 @@ pub mod v3;
 
 pub use crate::{
     enums::{
-        rtype, Action, Compression, Encoding, InstrumentClass, MatchAlgorithm, RType, SType,
-        Schema, SecurityUpdateAction, Side, StatType, StatUpdateAction, StatusAction, StatusReason,
-        TradingEvent, TriState, UserDefinedInstrument, VersionUpgradePolicy,
+        rtype, Action, Compression, Encoding, ErrorCode, InstrumentClass, MatchAlgorithm, RType,
+        SType, Schema, SecurityUpdateAction, Side, StatType, StatUpdateAction, StatusAction,
+        StatusReason, SystemCode, TradingEvent, TriState, UserDefinedInstrument,
+        VersionUpgradePolicy,
     },
     error::{Error, Result},
     flags::FlagSet,

--- a/rust/dbn/src/macros.rs
+++ b/rust/dbn/src/macros.rs
@@ -72,7 +72,11 @@ macro_rules! rtype_dispatch_base {
     }};
 }
 
-/// Specializes a generic function to all record types and dispatches based `rtype`.
+/// Dispatches to a generic function or method based on `$rtype` and optionally `$ts_out`.
+///
+/// # Panics
+/// This function will panic if the encoded length of the given record is shorter
+/// than expected for its `rtype`.
 ///
 /// # Errors
 /// This macro returns an error if the rtype is not recognized.
@@ -237,7 +241,10 @@ macro_rules! schema_dispatch_base {
     }};
 }
 
-/// Specializes a generic function to all record types with an associated schema.
+/// Dispatches to a generic function or method based on `$schema` and optionally `$ts_out`.
+///
+/// # Errors
+/// This macro returns an error when the generic function or method returns an error.
 #[macro_export]
 macro_rules! schema_dispatch {
     // generic async method

--- a/rust/dbn/src/python/enums.rs
+++ b/rust/dbn/src/python/enums.rs
@@ -4,8 +4,8 @@ use pyo3::{prelude::*, type_object::PyTypeInfo, types::PyType, Bound};
 
 use crate::{
     enums::{Compression, Encoding, SType, Schema, SecurityUpdateAction, UserDefinedInstrument},
-    Action, InstrumentClass, MatchAlgorithm, RType, Side, StatType, StatusAction, StatusReason,
-    TradingEvent, TriState, VersionUpgradePolicy,
+    Action, ErrorCode, InstrumentClass, MatchAlgorithm, RType, Side, StatType, StatusAction,
+    StatusReason, SystemCode, TradingEvent, TriState, VersionUpgradePolicy,
 };
 
 use super::{to_py_err, EnumIterator, PyFieldDesc};
@@ -772,5 +772,91 @@ impl PyFieldDesc for SecurityUpdateAction {
 impl PyFieldDesc for UserDefinedInstrument {
     fn field_dtypes(field_name: &str) -> Vec<(String, String)> {
         vec![(field_name.to_owned(), "S1".to_owned())]
+    }
+}
+
+#[pymethods]
+impl ErrorCode {
+    #[new]
+    fn py_new(value: &Bound<PyAny>) -> PyResult<Self> {
+        let i = value.extract::<u8>().map_err(to_py_err)?;
+        Self::try_from(i).map_err(to_py_err)
+    }
+
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+
+    fn __str__(&self) -> &'static str {
+        self.as_str()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<ErrorCode.{}: '{}'>", self.name(), self.value())
+    }
+
+    #[getter]
+    fn name(&self) -> String {
+        self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
+    }
+
+    #[getter]
+    fn value(&self) -> &'static str {
+        self.as_str()
+    }
+
+    #[classmethod]
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
+        EnumIterator::new::<Self>(py)
+    }
+}
+
+#[pymethods]
+impl SystemCode {
+    #[new]
+    fn py_new(value: &Bound<PyAny>) -> PyResult<Self> {
+        let i = value.extract::<u8>().map_err(to_py_err)?;
+        Self::try_from(i).map_err(to_py_err)
+    }
+
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+
+    fn __str__(&self) -> &'static str {
+        self.as_str()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<SystemCode.{}: '{}'>", self.name(), self.value())
+    }
+
+    #[getter]
+    fn name(&self) -> String {
+        self.as_ref().to_ascii_uppercase()
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        let Ok(other_enum) = other.extract::<Self>().or_else(|_| Self::py_new(other)) else {
+            return false;
+        };
+        self.eq(&other_enum)
+    }
+
+    #[getter]
+    fn value(&self) -> &'static str {
+        self.as_str()
+    }
+
+    #[classmethod]
+    fn variants(_: &Bound<PyType>, py: Python<'_>) -> PyResult<EnumIterator> {
+        EnumIterator::new::<Self>(py)
     }
 }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -11,11 +11,11 @@ use crate::{
     compat::{ErrorMsgV1, InstrumentDefMsgV1, InstrumentDefMsgV3, SymbolMappingMsgV1, SystemMsgV1},
     pretty::px_to_f64,
     record::str_to_c_chars,
-    rtype, BboMsg, BidAskPair, CbboMsg, Cmbp1Msg, ConsolidatedBidAskPair, ErrorMsg, FlagSet,
-    HasRType, ImbalanceMsg, InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Record,
+    rtype, BboMsg, BidAskPair, CbboMsg, Cmbp1Msg, ConsolidatedBidAskPair, ErrorCode, ErrorMsg,
+    FlagSet, HasRType, ImbalanceMsg, InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Record,
     RecordHeader, SType, SecurityUpdateAction, Side, StatMsg, StatUpdateAction, StatusAction,
-    StatusMsg, StatusReason, SymbolMappingMsg, SystemMsg, TradeMsg, TradingEvent, TriState,
-    UserDefinedInstrument, WithTsOut, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
+    StatusMsg, StatusReason, SymbolMappingMsg, SystemCode, SystemMsg, TradeMsg, TradingEvent,
+    TriState, UserDefinedInstrument, WithTsOut, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
 };
 
 use super::{to_py_err, PyFieldDesc};
@@ -3153,9 +3153,9 @@ impl StatMsg {
 #[pymethods]
 impl ErrorMsg {
     #[new]
-    #[pyo3(signature = (ts_event, err, is_last = true))]
-    fn py_new(ts_event: u64, err: &str, is_last: bool) -> PyResult<Self> {
-        Ok(ErrorMsg::new(ts_event, err, is_last))
+    #[pyo3(signature = (ts_event, err, is_last = true, code = None))]
+    fn py_new(ts_event: u64, err: &str, is_last: bool, code: Option<ErrorCode>) -> PyResult<Self> {
+        Ok(ErrorMsg::new(ts_event, code, err, is_last))
     }
 
     fn __bytes__(&self) -> &[u8] {
@@ -3204,6 +3204,11 @@ impl ErrorMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn get_code(&self) -> Option<ErrorCode> {
+        self.code()
     }
 
     #[getter]
@@ -3601,8 +3606,9 @@ impl SymbolMappingMsgV1 {
 #[pymethods]
 impl SystemMsg {
     #[new]
-    fn py_new(ts_event: u64, msg: &str) -> PyResult<Self> {
-        Ok(SystemMsg::new(ts_event, msg)?)
+    #[pyo3(signature = (ts_event, msg, code = None))]
+    fn py_new(ts_event: u64, msg: &str, code: Option<SystemCode>) -> PyResult<Self> {
+        Ok(SystemMsg::new(ts_event, code, msg)?)
     }
 
     fn __bytes__(&self) -> &[u8] {
@@ -3651,6 +3657,11 @@ impl SystemMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn get_code(&self) -> Option<SystemCode> {
+        self.code()
     }
 
     #[getter]

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -1092,7 +1092,7 @@ pub struct ErrorMsg {
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "conv::cstr_serde"))]
     pub err: [c_char; 302],
-    /// The error code. Currently unused.
+    /// The error code.
     #[pyo3(get, set)]
     pub code: u8,
     /// Sometimes multiple errors are sent together. This field will be non-zero for the
@@ -1170,7 +1170,7 @@ pub struct SystemMsg {
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "conv::cstr_serde"))]
     pub msg: [c_char; 303],
-    /// Type of system message, currently unused.
+    /// Type of system message.
     #[pyo3(get, set)]
     pub code: u8,
 }
@@ -1419,6 +1419,6 @@ mod tests {
 
     #[test]
     fn test_record_object_safe() {
-        let _record: Box<dyn Record> = Box::new(ErrorMsg::new(1, "Boxed record", true));
+        let _record: Box<dyn Record> = Box::new(ErrorMsg::new(1, None, "Boxed record", true));
     }
 }

--- a/rust/dbn/src/v1.rs
+++ b/rust/dbn/src/v1.rs
@@ -6,6 +6,7 @@ pub use crate::compat::InstrumentDefMsgV1 as InstrumentDefMsg;
 use crate::compat::InstrumentDefRec;
 pub use crate::compat::SymbolMappingMsgV1 as SymbolMappingMsg;
 pub use crate::compat::SystemMsgV1 as SystemMsg;
+pub use crate::compat::ASSET_CSTR_LEN_V1 as ASSET_CSTR_LEN;
 pub use crate::compat::SYMBOL_CSTR_LEN_V1 as SYMBOL_CSTR_LEN;
 pub use crate::record::{
     Bbo1MMsg, Bbo1SMsg, BboMsg, Cbbo1MMsg, Cbbo1SMsg, CbboMsg, Cmbp1Msg, ImbalanceMsg, MboMsg,

--- a/rust/dbn/src/v2.rs
+++ b/rust/dbn/src/v2.rs
@@ -11,6 +11,7 @@ pub use crate::record::{
     TcbboMsg, TradeMsg, WithTsOut,
 };
 
+use crate::SystemCode;
 use crate::{compat::SymbolMappingRec, rtype, v1, RecordHeader};
 
 impl From<&v1::InstrumentDefMsg> for InstrumentDefMsg {
@@ -136,6 +137,9 @@ impl From<&v1::SystemMsg> for SystemMsg {
             ),
             ..Default::default()
         };
+        if old.is_heartbeat() {
+            new.code = SystemCode::Heartbeat as u8;
+        }
         new.msg[..old.msg.len()].copy_from_slice(old.msg.as_slice());
         new
     }

--- a/rust/dbn/src/v2.rs
+++ b/rust/dbn/src/v2.rs
@@ -4,6 +4,7 @@
 use std::os::raw::c_char;
 
 use crate::compat::InstrumentDefRec;
+pub use crate::compat::ASSET_CSTR_LEN_V2 as ASSET_CSTR_LEN;
 pub use crate::compat::SYMBOL_CSTR_LEN_V2 as SYMBOL_CSTR_LEN;
 pub use crate::record::{
     Bbo1MMsg, Bbo1SMsg, BboMsg, Cbbo1MMsg, Cbbo1SMsg, CbboMsg, Cmbp1Msg, ErrorMsg, ImbalanceMsg,

--- a/rust/dbn/src/v3.rs
+++ b/rust/dbn/src/v3.rs
@@ -2,7 +2,8 @@
 //! in the upcoming DBN version 3.
 
 pub use crate::compat::{
-    InstrumentDefMsgV3 as InstrumentDefMsg, SYMBOL_CSTR_LEN_V3 as SYMBOL_CSTR_LEN,
+    InstrumentDefMsgV3 as InstrumentDefMsg, ASSET_CSTR_LEN_V3 as ASSET_CSTR_LEN,
+    SYMBOL_CSTR_LEN_V3 as SYMBOL_CSTR_LEN,
 };
 pub use crate::record::{
     Bbo1MMsg, Bbo1SMsg, BboMsg, Cbbo1MMsg, Cbbo1SMsg, CbboMsg, Cmbp1Msg, ErrorMsg, ImbalanceMsg,

--- a/rust/dbn/src/v3/methods.rs
+++ b/rust/dbn/src/v3/methods.rs
@@ -53,7 +53,6 @@ impl From<&v1::InstrumentDefMsg> for InstrumentDefMsg {
             secsubtype: old.secsubtype,
             group: old.group,
             exchange: old.exchange,
-            asset: old.asset,
             cfi: old.cfi,
             security_type: old.security_type,
             unit_of_measure: old.unit_of_measure,
@@ -76,6 +75,7 @@ impl From<&v1::InstrumentDefMsg> for InstrumentDefMsg {
             tick_rule: old.tick_rule,
             ..Default::default()
         };
+        res.asset[..v1::ASSET_CSTR_LEN].copy_from_slice(old.asset.as_slice());
         res.raw_symbol[..v1::SYMBOL_CSTR_LEN].copy_from_slice(old.raw_symbol.as_slice());
         res
     }
@@ -83,7 +83,7 @@ impl From<&v1::InstrumentDefMsg> for InstrumentDefMsg {
 
 impl From<&v2::InstrumentDefMsg> for InstrumentDefMsg {
     fn from(old: &v2::InstrumentDefMsg) -> Self {
-        Self {
+        let mut res = Self {
             // recalculate length
             hd: RecordHeader::new::<Self>(
                 rtype::INSTRUMENT_DEF,
@@ -125,7 +125,6 @@ impl From<&v2::InstrumentDefMsg> for InstrumentDefMsg {
             secsubtype: old.secsubtype,
             group: old.group,
             exchange: old.exchange,
-            asset: old.asset,
             cfi: old.cfi,
             security_type: old.security_type,
             unit_of_measure: old.unit_of_measure,
@@ -148,7 +147,9 @@ impl From<&v2::InstrumentDefMsg> for InstrumentDefMsg {
             tick_rule: old.tick_rule,
             raw_symbol: old.raw_symbol,
             ..Default::default()
-        }
+        };
+        res.asset[..v2::ASSET_CSTR_LEN].copy_from_slice(old.asset.as_slice());
+        res
     }
 }
 


### PR DESCRIPTION
### Enhancements
- Added `SystemCode` and `ErrorCode` enums to indicate types of system and error
  messages
- Added `code()` methods to `SystemMsg` and `ErrorMsg` to retrieve the enum value if
  one exists and equivalent properties in Python
- Converting a `v1::SystemMsg` to a `v2::SystemMsg` now sets to `code` to the heartbeat
  value
- Added `ASSET_CSTR_LEN` constants for the size of `asset` field in `InstrumentDefMsg`
  in different DBN versions
- Added `encode_record_with_sym()`  method to `AsyncJsonEncoder` which encodes a record
  along with its text symbol to match the sync encoder

### Breaking changes
- Added `code` parameter to `SystemCode::new()` and `ErrorMsg::new()`
- Updated the `rtype_dispatch` and `schema_dispatch` macro invocations to look more like
  function invocation
- Increased the size of `asset` field in `v3::InstrumentDefMsg` from 7 to 11. The
  `InstrumentDefMsgV3` message size remains 520 bytes.

