### PR TITLE
VER: Release 0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 - Fixed behavior where encoding metadata could lower the `version`
 - Changed `DbnFsm::data()` to exclude all processed data
+- Fixed `Metadata::upgrade()` behavior with `UpgradeToV2`
 
 ## 0.35.0 - 2025-05-28
 This version marks the release of DBN version 3 (DBNv3), which is the new default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.35.1 - TBD
 
+### Enhancements
+- Documented `AsyncMetadataDecoder::decode`, `AsyncDecoder::new`, and
+  `AsyncDecoder::with_upgrade_policy()` as now being cancellation safe
+- Added `DbnFsm::reset()` method that resets state to facilitate reuse
+- Added `DbnFsm::has_decoded_metadata()` method to check the internal
+  state
+
 ### Bug fixes
 - Fixed behavior where encoding metadata could lower the `version`
 - Changed `DbnFsm::data()` to exclude all processed data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.35.1 - TBD
+
+### Bug fixes
+- Changed `DbnFsm::data()` to exclude all processed data
+
 ## 0.35.0 - 2025-05-28
 This version marks the release of DBN version 3 (DBNv3), which is the new default.
 Decoders support decoding all versions of DBN and the DBN encoders default to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.35.1 - TBD
 
 ### Bug fixes
+- Fixed behavior where encoding metadata could lower the `version`
 - Changed `DbnFsm::data()` to exclude all processed data
 
 ## 0.35.0 - 2025-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.35.1 - TBD
+## 0.35.1 - 2025-06-03
 
 ### Enhancements
 - Documented `AsyncMetadataDecoder::decode`, `AsyncDecoder::new`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "dbn",
  "pyo3",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "async-compression",
  "csv",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.35.0"
+version = "0.35.1"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.35.0"
+version = "0.35.1"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.35.0"
+version = "0.35.1"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.35.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.35.1", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.35.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.35.1", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.23", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/decode/dbn.rs
+++ b/rust/dbn/src/decode/dbn.rs
@@ -16,6 +16,7 @@ pub mod fsm;
 mod r#async;
 #[cfg(feature = "async")]
 pub use r#async::{
-    Decoder as AsyncDecoder, MetadataDecoder as AsyncMetadataDecoder,
-    RecordDecoder as AsyncRecordDecoder,
+    decode_metadata_with_fsm as async_decode_metadata_with_fsm,
+    decode_record_ref_with_fsm as async_decode_record_ref_with_fsm, Decoder as AsyncDecoder,
+    MetadataDecoder as AsyncMetadataDecoder, RecordDecoder as AsyncRecordDecoder,
 };

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -102,7 +102,7 @@ where
     /// incompatible.
     pub fn set_upgrade_policy(&mut self, upgrade_policy: VersionUpgradePolicy) -> Result<()> {
         self.decoder.set_upgrade_policy(upgrade_policy)?;
-        self.metadata.set_version(upgrade_policy);
+        self.metadata.upgrade(upgrade_policy);
         Ok(())
     }
 
@@ -770,7 +770,7 @@ mod tests {
             VersionUpgradePolicy::UpgradeToV2,
         )
         .await?;
-        assert_eq!(decoder.metadata().version, crate::DBN_VERSION);
+        assert_eq!(decoder.metadata().version, 2);
         assert_eq!(decoder.metadata().symbol_cstr_len, crate::SYMBOL_CSTR_LEN);
         let mut has_decoded = false;
         while let Some(_rec) = decoder.decode_record::<v2::InstrumentDefMsg>().await? {

--- a/rust/dbn/src/decode/dbn/fsm.rs
+++ b/rust/dbn/src/decode/dbn/fsm.rs
@@ -173,7 +173,10 @@ impl DbnFsm {
 
     /// Returns the unprocessed data in the buffer.
     pub fn data(&self) -> &[u8] {
-        self.buffer.data()
+        match self.state {
+            State::Consume { read, .. } => &self.buffer.data()[read..],
+            _ => self.buffer.data(),
+        }
     }
 
     /// Returns the mutable slice to all writable space in the buffer.

--- a/rust/dbn/src/decode/dbn/fsm.rs
+++ b/rust/dbn/src/decode/dbn/fsm.rs
@@ -202,6 +202,21 @@ impl DbnFsm {
         self.compat_buffer.grow(size);
     }
 
+    /// Returns `true` if DBN metadata has been decoded or it was skipped.
+    pub fn has_decoded_metadata(&self) -> bool {
+        matches!(self.state, State::Record | State::Consume { .. })
+    }
+
+    /// Resets the state machine to expect DBN metadata.
+    ///
+    /// If decoding streams with no metadata, it's not necessary to reset the state.
+    pub fn reset(&mut self) {
+        self.state = State::Prelude;
+        self.buffer.reset();
+        self.compat_buffer.reset();
+        self.input_dbn_version = None;
+    }
+
     /// Skips ahead `nbytes`. Returns the actual number of bytes skipped.
     pub fn skip(&mut self, nbytes: usize) -> usize {
         match self.state {
@@ -1214,6 +1229,132 @@ mod tests {
                 }
                 assert!(limit.is_none_or(|l| l.get() >= processed_count));
                 assert_eq!(processed_count, recs.len() as u64);
+                rec_count += recs.len();
+            } else {
+                panic!("unexpected result after writing all input");
+            }
+        }
+        assert_eq!(rec_count, 10_000);
+    }
+
+    #[rstest]
+    #[case::v1_asis(1, VersionUpgradePolicy::AsIs, true)]
+    #[case::v1_upgradev2(1, VersionUpgradePolicy::UpgradeToV2, true)]
+    #[case::v1_upgradev3(1, VersionUpgradePolicy::UpgradeToV3, true)]
+    #[case::v2_asis(2, VersionUpgradePolicy::AsIs, true)]
+    #[case::v2_upgradev2(2, VersionUpgradePolicy::UpgradeToV2, true)]
+    #[case::v2_upgradev3(2, VersionUpgradePolicy::UpgradeToV3, true)]
+    #[case::v3_asis(3, VersionUpgradePolicy::AsIs, true)]
+    #[case::v3_upgradev3(3, VersionUpgradePolicy::UpgradeToV3, true)]
+    #[case::no_metadata(DBN_VERSION, VersionUpgradePolicy::default(), false)]
+    fn test_process_many(
+        #[case] input_version: u8,
+        #[case] upgrade_policy: VersionUpgradePolicy,
+        #[case] has_metadata: bool,
+        #[values(7, 16_384, DbnFsm::DEFAULT_BUF_SIZE, 1 << 20)] chunk_size: usize,
+        #[values(MAX_RECORD_LEN, DbnFsm::DEFAULT_BUF_SIZE)] buffer_size: usize,
+        #[values(0, MAX_RECORD_LEN, DbnFsm::DEFAULT_BUF_SIZE)] compat_size: usize,
+    ) {
+        let mut data = Vec::new();
+        let start_date = date!(2025 - 05 - 15);
+        let end_date = date!(2025 - 05 - 17);
+        let mut metadata = Metadata::builder()
+            .version(input_version)
+            .dataset(Dataset::EqusMini)
+            .schema(Some(Schema::Trades))
+            .stype_in(Some(SType::RawSymbol))
+            .stype_out(SType::InstrumentId)
+            .start(datetime!(2025-05-15 00:00 UTC).unix_timestamp_nanos() as u64)
+            .symbols(vec![
+                "AAPL".to_owned(),
+                "META".to_owned(),
+                "MSFT".to_owned(),
+                "NVDA".to_owned(),
+            ])
+            .mappings(vec![
+                SymbolMapping {
+                    raw_symbol: "AAPL".to_owned(),
+                    intervals: vec![MappingInterval {
+                        start_date,
+                        end_date,
+                        symbol: 1.to_string(),
+                    }],
+                },
+                SymbolMapping {
+                    raw_symbol: "META".to_owned(),
+                    intervals: vec![MappingInterval {
+                        start_date,
+                        end_date,
+                        symbol: 2.to_string(),
+                    }],
+                },
+                SymbolMapping {
+                    raw_symbol: "MSFT".to_owned(),
+                    intervals: vec![MappingInterval {
+                        start_date,
+                        end_date,
+                        symbol: 1.to_string(),
+                    }],
+                },
+                SymbolMapping {
+                    raw_symbol: "NVDA".to_owned(),
+                    intervals: vec![MappingInterval {
+                        start_date,
+                        end_date,
+                        symbol: 1.to_string(),
+                    }],
+                },
+            ])
+            .build();
+        if has_metadata {
+            let mut encoder = DbnMetadataEncoder::new(&mut data);
+            encoder.encode(&metadata).unwrap();
+        }
+        let mut encoder = DbnRecordEncoder::new(&mut data);
+        for _ in 0..10_000 {
+            encoder.encode_record(&TradeMsg::default()).unwrap();
+        }
+        let mut target = DbnFsm::builder()
+            .buffer_size(buffer_size)
+            .compat_size(compat_size)
+            .skip_metadata(!has_metadata)
+            .input_dbn_version(Some(input_version))
+            .unwrap()
+            .upgrade_policy(upgrade_policy)
+            .build()
+            .unwrap();
+        let mut rec_count = 0;
+        for slice in data.chunks(chunk_size) {
+            target.write_all(slice);
+            let mut recs = [None; 64];
+            let res = target.process_many(&mut recs);
+            dbg!(&res, data.len(), slice.len());
+            assert!(!matches!(res, ProcessResult::Err(_)));
+            match res {
+                ProcessResult::ReadMore(_) => continue,
+                ProcessResult::Metadata(decoded_metadata) => {
+                    assert!(has_metadata);
+                    if upgrade_policy.is_upgrade_situation(input_version) {
+                        metadata.upgrade(upgrade_policy);
+                        assert_eq!(decoded_metadata, metadata);
+                    } else {
+                        assert_eq!(decoded_metadata, metadata);
+                    }
+                }
+                ProcessResult::Record(recs) => {
+                    rec_count += recs.len();
+                }
+                ProcessResult::Err(error) => panic!("unexpected error {error}"),
+            }
+        }
+        loop {
+            let mut recs = [None; 64];
+            let res = target.process_many(&mut recs);
+            dbg!(&res);
+            if let ProcessResult::Record(recs) = res {
+                if recs.is_empty() {
+                    break;
+                }
                 rec_count += recs.len();
             } else {
                 panic!("unexpected result after writing all input");

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -82,7 +82,7 @@ where
         upgrade_policy: VersionUpgradePolicy,
     ) -> crate::Result<()> {
         self.decoder.set_upgrade_policy(upgrade_policy)?;
-        self.metadata.set_version(upgrade_policy);
+        self.metadata.upgrade(upgrade_policy);
         Ok(())
     }
 }
@@ -759,7 +759,7 @@ mod tests {
             .unwrap(),
             VersionUpgradePolicy::UpgradeToV2,
         )?;
-        assert_eq!(decoder.metadata().version, crate::DBN_VERSION);
+        assert_eq!(decoder.metadata().version, 2);
         assert_eq!(decoder.metadata().symbol_cstr_len, crate::SYMBOL_CSTR_LEN);
         decoder.decode_records::<v2::InstrumentDefMsg>()?;
         Ok(())

--- a/rust/dbn/src/decode/zstd.rs
+++ b/rust/dbn/src/decode/zstd.rs
@@ -15,9 +15,9 @@ pub fn starts_with_prefix(bytes: &[u8]) -> bool {
     ZSTD_MAGIC_NUMBER == magic
 }
 
-/// Helper to always set multiple members.
+/// Helper to create an async Zstandard decoder with multiple member support.
 #[cfg(feature = "async")]
-pub(crate) fn zstd_decoder<R>(reader: R) -> async_compression::tokio::bufread::ZstdDecoder<R>
+pub fn zstd_decoder<R>(reader: R) -> async_compression::tokio::bufread::ZstdDecoder<R>
 where
     R: tokio::io::AsyncBufReadExt + Unpin,
 {


### PR DESCRIPTION
### Enhancements
- Documented `AsyncMetadataDecoder::decode`, `AsyncDecoder::new`, and
  `AsyncDecoder::with_upgrade_policy()` as now being cancellation safe
- Added `DbnFsm::reset()` method that resets state to facilitate reuse
- Added `DbnFsm::has_decoded_metadata()` method to check the internal
  state

### Bug fixes
- Fixed behavior where encoding metadata could lower the `version`
- Changed `DbnFsm::data()` to exclude all processed data
- Fixed `Metadata::upgrade()` behavior with `UpgradeToV2`

