### PR TITLE
VER: Release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.36.0 - TBD
+## 0.36.0 - 2025-06-10
 
 ### Enhancements
 - Added support for width, fill, and padding when formatting `pretty::Ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.35.2 - TBD
+
+### Bug fixes
+- Added missing Python type stubs for several leg properties of `InstrumentDefMsg`
+
 ## 0.35.1 - 2025-06-03
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.35.2 - TBD
 
+### Enhancements
+- Added support for width, fill, and padding when formatting `pretty::Ts`
+- Added support for sign, precision, width, fill, and padding when formatting
+  `pretty::Px`
+- Optimized pretty formatting of prices and timestamps
+
 ### Bug fixes
 - Added missing Python type stubs for several leg properties of `InstrumentDefMsg`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
-## 0.35.2 - TBD
+## 0.36.0 - TBD
 
 ### Enhancements
 - Added support for width, fill, and padding when formatting `pretty::Ts`
 - Added support for sign, precision, width, fill, and padding when formatting
   `pretty::Px`
 - Optimized pretty formatting of prices and timestamps
+
+### Breaking changes
+- Moved core async decoding and encoding functionality to new traits to
+  match the sync interface and present a standardized interface
+  - Decoding: `AsyncDecodeRecordRef` and `AsyncDecodeRecord`
+  - Encoding: `AsyncEncodeRecord`, `AsyncEncodeRecordRef`, and
+    `AsyncEncodeRecordTextExt`
 
 ### Bug fixes
 - Added missing Python type stubs for several leg properties of `InstrumentDefMsg`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.35.1"
+version = "0.36.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.35.1"
+version = "0.36.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.35.1"
+version = "0.36.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1130,7 +1130,7 @@ class RecordHeader:
         """
         The publisher ID assigned by Databento, which denotes the dataset and venue.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
 
         Returns
         -------
@@ -1222,7 +1222,7 @@ class Record(SupportsBytes):
         """
         The publisher ID assigned by Databento, which denotes the dataset and venue.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
 
         Returns
         -------
@@ -1699,7 +1699,7 @@ class ConsolidatedBidAskPair:
         """
         The publisher ID indicating the venue containing the best bid.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
 
         Returns
         -------
@@ -1723,7 +1723,7 @@ class ConsolidatedBidAskPair:
         """
         The publisher ID indicating the venue containing the best ask.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
 
         Returns
         -------

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -3496,6 +3496,36 @@ class InstrumentDefMsg(Record):
         """
 
     @property
+    def leg_count(self) -> int:
+        """
+        The number of legs in the strategy or spread. Will be 0 for outrights.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_index
+
+        """
+
+    @property
+    def leg_index(self) -> int:
+        """
+        The 0-based index of the leg.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_count
+
+        """
+
+    @property
     def pretty_leg_price(self) -> float:
         """
         The leg price as a float.
@@ -3558,6 +3588,136 @@ class InstrumentDefMsg(Record):
         See Also
         --------
         leg_delta
+
+        """
+
+    @property
+    def leg_instrument_id(self) -> int:
+        """
+        The numeric ID assigned to the leg instrument.
+        See [Instrument identifiers] https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_raw_symbol
+
+        """
+
+    @property
+    def leg_ratio_price_numerator(self) -> int:
+        """
+        The numerator of the price ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_ratio_price_denominator
+
+        """
+
+    @property
+    def leg_ratio_price_denominator(self) -> int:
+        """
+        The denominator of the price ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_ratio_price_numerator
+
+        """
+
+    @property
+    def leg_ratio_qty_numerator(self) -> int:
+        """
+        The numerator of the quantity ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_ratio_qty_denominator
+
+        """
+
+    @property
+    def leg_ratio_qty_denominator(self) -> int:
+        """
+        The denominator of the quantity ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        leg_ratio_qty_numerator
+
+        """
+
+    @property
+    def leg_underlying_id(self) -> int:
+        """
+        The numeric ID of the leg instrument's underlying instrument.
+        See [Instrument identifiers] https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        instrument_id
+
+        """
+
+    @property
+    def leg_raw_symbol(self) -> str:
+        """
+        The leg instrument's raw symbol assigned by the publisher.
+
+        Returns
+        -------
+        str
+
+        See Also
+        --------
+        leg_instrument_id
+
+        """
+
+    @property
+    def leg_instrument_class(self) -> str | None:
+        """
+        The matching algorithm used for the instrument, typically **F**IFO.
+        See `Matching algorithm` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm.
+
+        Returns
+        -------
+        str | None
+
+        """
+
+    @property
+    def leg_side(self) -> str | None:
+        """
+        The side taken for the leg when purchasing the spread.
+
+        Returns
+        -------
+        str | None
 
         """
 

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.35.1", default-features = false }
+dbn = { path = "../dbn", version = "=0.36.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.35.1", path = "../dbn-macros" }
+dbn-macros = { version = "=0.36.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.23", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/decode.rs
+++ b/rust/dbn/src/decode.rs
@@ -11,9 +11,11 @@ pub mod dbn;
     )
 )]
 pub mod dbz;
+mod dyn_decoder;
+mod dyn_reader;
+mod merge;
 mod stream;
 // used in databento_dbn
-mod merge;
 #[doc(hidden)]
 pub mod zstd;
 
@@ -21,22 +23,14 @@ pub mod zstd;
 pub use self::dbn::{
     Decoder as DbnDecoder, MetadataDecoder as DbnMetadataDecoder, RecordDecoder as DbnRecordDecoder,
 };
+pub use dyn_decoder::DynDecoder;
+pub use dyn_reader::*;
 pub use merge::{Decoder as MergeDecoder, RecordDecoder as MergeRecordDecoder};
 pub use stream::StreamIterDecoder;
 
-use std::{
-    fs::File,
-    io::{self, BufReader, ErrorKind, Read, Seek},
-    mem,
-    path::Path,
-};
+use std::{io::Seek, mem};
 
-use crate::{
-    enums::{Compression, VersionUpgradePolicy},
-    record::HasRType,
-    record_ref::RecordRef,
-    Metadata, Record,
-};
+use crate::{HasRType, Metadata, Record, RecordRef, VersionUpgradePolicy};
 
 /// Trait for types that decode references to DBN records of a dynamic type.
 pub trait DecodeRecordRef {
@@ -127,206 +121,6 @@ pub trait DecodeStream: DecodeRecord + private::LastRecord {
     where
         Self: Sized;
 }
-
-/// A decoder implementing [`DecodeDbn`] whose [`Encoding`](crate::enums::Encoding) and
-/// [`Compression`] are determined at runtime by peeking at the first few bytes.
-pub struct DynDecoder<'a, R>(DynDecoderImpl<'a, R>)
-where
-    R: io::BufRead;
-
-enum DynDecoderImpl<'a, R>
-where
-    R: io::BufRead,
-{
-    Dbn(dbn::Decoder<R>),
-    ZstdDbn(dbn::Decoder<::zstd::stream::Decoder<'a, R>>),
-    // Boxed due to size difference
-    #[allow(deprecated)]
-    LegacyDbz(Box<dbz::Decoder<R>>),
-}
-
-impl<R> DynDecoder<'_, BufReader<R>>
-where
-    R: io::Read,
-{
-    /// Creates a new [`DynDecoder`] from a reader, with the specified `compression`. It
-    /// will decode records from previous DBN versions according to `upgrade_policy`.
-    ///
-    /// # Errors
-    /// This function will return an error if it fails to parse the metadata.
-    pub fn new(
-        reader: R,
-        compression: Compression,
-        upgrade_policy: VersionUpgradePolicy,
-    ) -> crate::Result<Self> {
-        Self::with_buffer(BufReader::new(reader), compression, upgrade_policy)
-    }
-
-    /// Creates a new [`DynDecoder`] from a reader, inferring the encoding and
-    /// compression. If `reader` also implements [`io::BufRead`], it is better to use
-    /// [`inferred_with_buffer()`](Self::inferred_with_buffer). It will decode records
-    /// from previous DBN versions according to `upgrade_policy`.
-    ///
-    /// # Errors
-    /// This function will return an error if it is unable to determine
-    /// the encoding of `reader` or it fails to parse the metadata.
-    pub fn new_inferred(reader: R, upgrade_policy: VersionUpgradePolicy) -> crate::Result<Self> {
-        Self::inferred_with_buffer(BufReader::new(reader), upgrade_policy)
-    }
-}
-
-impl<R> DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    /// Creates a new [`DynDecoder`] from a buffered reader with the specified
-    /// `compression`.It will decode records from previous DBN versions according to
-    /// `upgrade_policy`.
-    ///
-    /// # Errors
-    /// This function will return an error if it is unable to determine
-    /// the encoding of `reader` or it fails to parse the metadata.
-    pub fn with_buffer(
-        reader: R,
-        compression: Compression,
-        upgrade_policy: VersionUpgradePolicy,
-    ) -> crate::Result<Self> {
-        match compression {
-            Compression::None => Ok(Self(DynDecoderImpl::Dbn(
-                dbn::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
-            ))),
-            Compression::ZStd => Ok(Self(DynDecoderImpl::ZstdDbn(
-                dbn::Decoder::with_upgrade_policy(
-                    ::zstd::stream::Decoder::with_buffer(reader)
-                        .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
-                    upgrade_policy,
-                )?,
-            ))),
-        }
-    }
-
-    /// Creates a new [`DynDecoder`] from a buffered reader, inferring the encoding
-    /// and compression.It will decode records from previous DBN versions according
-    /// to `upgrade_policy`.
-    ///
-    /// # Errors
-    /// This function will return an error if it is unable to determine
-    /// the encoding of `reader` or it fails to parse the metadata.
-    pub fn inferred_with_buffer(
-        mut reader: R,
-        upgrade_policy: VersionUpgradePolicy,
-    ) -> crate::Result<Self> {
-        let first_bytes = reader
-            .fill_buf()
-            .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
-        #[allow(deprecated)]
-        if dbz::starts_with_prefix(first_bytes) {
-            Ok(Self(DynDecoderImpl::LegacyDbz(Box::new(
-                dbz::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
-            ))))
-        } else if dbn::starts_with_prefix(first_bytes) {
-            Ok(Self(DynDecoderImpl::Dbn(
-                dbn::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
-            )))
-        } else if zstd::starts_with_prefix(first_bytes) {
-            Ok(Self(DynDecoderImpl::ZstdDbn(
-                dbn::Decoder::with_upgrade_policy(
-                    ::zstd::stream::Decoder::with_buffer(reader)
-                        .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
-                    upgrade_policy,
-                )?,
-            )))
-        } else {
-            Err(crate::Error::decode("unable to determine encoding"))
-        }
-    }
-}
-
-impl DynDecoder<'_, BufReader<File>> {
-    /// Creates a new [`DynDecoder`] from the file at `path`. It will decode records
-    /// from previous DBN versions according to `upgrade_policy`.
-    ///
-    /// # Errors
-    /// This function will return an error if the file doesn't exist, it is unable to
-    /// determine the encoding of the file or it fails to parse the metadata.
-    pub fn from_file(
-        path: impl AsRef<Path>,
-        upgrade_policy: VersionUpgradePolicy,
-    ) -> crate::Result<Self> {
-        let file = File::open(path.as_ref()).map_err(|e| {
-            crate::Error::io(
-                e,
-                format!(
-                    "opening file to decode at path '{}'",
-                    path.as_ref().display()
-                ),
-            )
-        })?;
-        DynDecoder::new_inferred(file, upgrade_policy)
-    }
-}
-
-impl<R> DecodeRecordRef for DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    fn decode_record_ref(&mut self) -> crate::Result<Option<RecordRef>> {
-        match &mut self.0 {
-            DynDecoderImpl::Dbn(decoder) => decoder.decode_record_ref(),
-            DynDecoderImpl::ZstdDbn(decoder) => decoder.decode_record_ref(),
-            DynDecoderImpl::LegacyDbz(decoder) => decoder.decode_record_ref(),
-        }
-    }
-}
-
-#[allow(deprecated)]
-impl<R> DbnMetadata for DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    fn metadata(&self) -> &Metadata {
-        match &self.0 {
-            DynDecoderImpl::Dbn(decoder) => decoder.metadata(),
-            DynDecoderImpl::ZstdDbn(decoder) => decoder.metadata(),
-            DynDecoderImpl::LegacyDbz(decoder) => decoder.metadata(),
-        }
-    }
-
-    fn metadata_mut(&mut self) -> &mut Metadata {
-        match &mut self.0 {
-            DynDecoderImpl::Dbn(decoder) => decoder.metadata_mut(),
-            DynDecoderImpl::ZstdDbn(decoder) => decoder.metadata_mut(),
-            DynDecoderImpl::LegacyDbz(decoder) => decoder.metadata_mut(),
-        }
-    }
-}
-
-#[allow(deprecated)]
-impl<R> DecodeRecord for DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    fn decode_record<T: HasRType>(&mut self) -> crate::Result<Option<&T>> {
-        match &mut self.0 {
-            DynDecoderImpl::Dbn(decoder) => decoder.decode_record(),
-            DynDecoderImpl::ZstdDbn(decoder) => decoder.decode_record(),
-            DynDecoderImpl::LegacyDbz(decoder) => decoder.decode_record(),
-        }
-    }
-}
-
-impl<R> DecodeStream for DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    fn decode_stream<T: HasRType>(self) -> StreamIterDecoder<Self, T>
-    where
-        Self: Sized,
-    {
-        StreamIterDecoder::new(self)
-    }
-}
-
 /// Like [`Seek`], but only allows seeking forward from the current
 /// position.
 pub trait SkipBytes {
@@ -348,178 +142,88 @@ where
     }
 }
 
-/// Type for runtime polymorphism over whether decoding uncompressed or ZStd-compressed
-/// DBN records. Implements [`std::io::Write`].
-pub struct DynReader<'a, R>(DynReaderImpl<'a, R>)
-where
-    R: io::BufRead;
-
-enum DynReaderImpl<'a, R>
-where
-    R: io::BufRead,
-{
-    Uncompressed(R),
-    ZStd(::zstd::stream::Decoder<'a, R>),
-}
-
-impl<R> DynReader<'_, BufReader<R>>
-where
-    R: io::Read,
-{
-    /// Creates a new [`DynReader`] from a reader, with the specified `compression`.
-    /// If `reader` also implements [`BufRead`](io::BufRead), it's better to use
-    /// [`with_buffer()`](Self::with_buffer).
+/// Async trait for types that decode references to DBN records of a dynamic type.
+#[cfg(feature = "async")]
+#[allow(async_fn_in_trait)] // the futures can't be Send because self is borrowed mutably
+pub trait AsyncDecodeRecordRef {
+    /// Tries to decode a generic reference a record. Returns `Ok(None)` if input
+    /// has been exhausted.
     ///
     /// # Errors
-    /// This function will return an error if it fails to create the zstd decoder.
-    pub fn new(reader: R, compression: Compression) -> crate::Result<Self> {
-        Self::with_buffer(BufReader::new(reader), compression)
-    }
+    /// This function returns an error if the underlying reader returns an error of a
+    /// kind other than `io::ErrorKind::UnexpectedEof` upon reading.
+    ///
+    /// If the `length` property of the record is invalid, an
+    /// [`Error::Decode`](crate::Error::Decode) will be returned.
+    ///
+    /// # Cancel safety
+    /// This method is cancel safe. It can be used within a `tokio::select!` statement
+    /// without the potential for corrupting the input stream.
+    async fn decode_record_ref(&mut self) -> crate::Result<Option<RecordRef>>;
+}
 
-    /// Creates a new [`DynReader`] from a reader, inferring the compression.
-    /// If `reader` also implements [`io::BufRead`], it is better to use
-    /// [`inferred_with_buffer()`](Self::inferred_with_buffer).
+/// Async trait for types that decode DBN records of a particular type.
+#[cfg(feature = "async")]
+#[allow(async_fn_in_trait)] // the futures can't be Send because self is borrowed mutably
+pub trait AsyncDecodeRecord {
+    /// Tries to decode a reference to a single record of type `T`. Returns `Ok(None)`
+    /// if the input has been exhausted.
     ///
     /// # Errors
-    /// This function will return an error if it is unable to read from `reader`
-    /// or it fails to create the zstd decoder.
-    pub fn new_inferred(reader: R) -> crate::Result<Self> {
-        Self::inferred_with_buffer(BufReader::new(reader))
-    }
-}
+    /// This function returns an error if the underlying reader returns an error of a
+    /// kind other than `io::ErrorKind::UnexpectedEof` upon reading.
+    ///
+    /// If the next record is of a different type than `T`, an
+    /// [`Error::Conversion`](crate::Error::Conversion) will be returned.
+    ///
+    /// If the `length` property of the record is invalid, an
+    /// [`Error::Decode`](crate::Error::Decode) will be returned.
+    ///
+    /// # Cancel safety
+    /// This method is cancel safe. It can be used within a `tokio::select!` statement
+    /// without the potential for corrupting the input stream.
+    async fn decode_record<'a, T: HasRType + 'a>(&'a mut self) -> crate::Result<Option<&'a T>>;
 
-impl<R> DynReader<'_, R>
-where
-    R: io::BufRead,
-{
-    /// Creates a new [`DynReader`] from a buffered reader with the specified
-    /// `compression`.
+    /// Tries to decode all records into a `Vec`. This eagerly decodes the data.
     ///
     /// # Errors
-    /// This function will return an error if it fails to create the zstd decoder.
-    pub fn with_buffer(reader: R, compression: Compression) -> crate::Result<Self> {
-        match compression {
-            Compression::None => Ok(Self(DynReaderImpl::Uncompressed(reader))),
-            Compression::ZStd => Ok(Self(DynReaderImpl::ZStd(
-                ::zstd::stream::Decoder::with_buffer(reader)
-                    .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
-            ))),
+    /// This function returns an error if the underlying reader returns an error of a
+    /// kind other than `io::ErrorKind::UnexpectedEof` upon reading.
+    ///
+    /// If any of the records is of a different type than `T`, an
+    /// [`Error::Conversion`](crate::Error::Conversion) will be returned.
+    ///
+    /// If the `length` property of any of the records is invalid, a
+    /// [`Error::Decode`](crate::Error::Decode) will be returned.
+    ///
+    /// # Cancel safety
+    /// This method is not cancellation safe. If used within a `tokio::select!` statement
+    /// partially decoded records will be lost and the stream may be corrupted.
+    async fn decode_records<T: HasRType + Clone>(mut self) -> crate::Result<Vec<T>>
+    where
+        Self: Sized,
+    {
+        let mut res = Vec::new();
+        while let Some(rec) = self.decode_record::<T>().await? {
+            res.push(rec.clone());
         }
+        Ok(res)
     }
+}
 
-    /// Creates a new [`DynReader`] from a buffered reader, inferring the compression.
+/// Like [`AsyncSeek`](tokio::io::AsyncSeek), but only allows seeking forward from the current position.
+#[cfg(feature = "async")]
+#[allow(async_fn_in_trait)] // the futures can't be Send because self is borrowed mutably
+pub trait AsyncSkipBytes {
+    /// Skips ahead `n_bytes` bytes.
     ///
     /// # Errors
-    /// This function will return an error if it fails to read from `reader` or creating
-    /// the zstd decoder fails.
-    pub fn inferred_with_buffer(mut reader: R) -> crate::Result<Self> {
-        let first_bytes = reader
-            .fill_buf()
-            .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
-        if zstd::starts_with_prefix(first_bytes) {
-            Ok(Self(DynReaderImpl::ZStd(
-                ::zstd::stream::Decoder::with_buffer(reader)
-                    .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
-            )))
-        } else {
-            Ok(Self(DynReaderImpl::Uncompressed(reader)))
-        }
-    }
-
-    /// Returns a mutable reference to the inner reader.
-    pub fn get_mut(&mut self) -> &mut R {
-        match &mut self.0 {
-            DynReaderImpl::Uncompressed(reader) => reader,
-            DynReaderImpl::ZStd(reader) => reader.get_mut(),
-        }
-    }
-
-    /// Returns a reference to the inner reader.
-    pub fn get_ref(&self) -> &R {
-        match &self.0 {
-            DynReaderImpl::Uncompressed(reader) => reader,
-            DynReaderImpl::ZStd(reader) => reader.get_ref(),
-        }
-    }
+    /// This function returns an error if the I/O operations fail.
+    async fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()>;
 }
 
-impl DynReader<'_, BufReader<File>> {
-    /// Creates a new [`DynReader`] from the file at `path`.
-    ///
-    /// # Errors
-    /// This function will return an error if the file doesn't exist, it is unable to
-    /// determine the encoding of the file, or it fails to create the zstd decoder.
-    pub fn from_file(path: impl AsRef<Path>) -> crate::Result<Self> {
-        let file = File::open(path.as_ref()).map_err(|e| {
-            crate::Error::io(
-                e,
-                format!(
-                    "opening file to decode at path '{}'",
-                    path.as_ref().display()
-                ),
-            )
-        })?;
-        DynReader::new_inferred(file)
-    }
-}
-
-impl<R> io::Read for DynReader<'_, R>
-where
-    R: io::BufRead,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match &mut self.0 {
-            DynReaderImpl::Uncompressed(r) => r.read(buf),
-            DynReaderImpl::ZStd(r) => r.read(buf),
-        }
-    }
-}
-
-impl<R> SkipBytes for DynReader<'_, R>
-where
-    R: io::BufRead + io::Read + io::Seek,
-{
-    fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
-        let handle_err = |err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes"));
-        match &mut self.0 {
-            DynReaderImpl::Uncompressed(reader) => {
-                reader.seek_relative(n_bytes as i64).map_err(handle_err)
-            }
-            DynReaderImpl::ZStd(reader) => {
-                let mut buf = [0; 1024];
-                let mut remaining = n_bytes;
-                while remaining > 0 {
-                    let max_read_size = remaining.min(buf.len());
-                    let read_size = reader.read(&mut buf[..max_read_size]).map_err(handle_err)?;
-                    if read_size == 0 {
-                        return Err(crate::Error::io(
-                            std::io::Error::from(ErrorKind::UnexpectedEof),
-                            format!(
-                                "seeking ahead {n_bytes} bytes. Only able to seek {} bytes",
-                                n_bytes - remaining
-                            ),
-                        ));
-                    }
-                    remaining -= read_size;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
-impl<R> private::LastRecord for DynDecoder<'_, R>
-where
-    R: io::BufRead,
-{
-    fn last_record(&self) -> Option<RecordRef> {
-        match &self.0 {
-            DynDecoderImpl::Dbn(decoder) => decoder.last_record(),
-            DynDecoderImpl::ZstdDbn(decoder) => decoder.last_record(),
-            DynDecoderImpl::LegacyDbz(decoder) => decoder.last_record(),
-        }
-    }
-}
+#[cfg(feature = "async")]
+const ZSTD_FILE_BUFFER_CAPACITY: usize = 1 << 20;
 
 #[doc(hidden)]
 pub mod private {
@@ -575,280 +279,11 @@ impl FromLittleEndianSlice for u16 {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
-
-    use crate::enums::VersionUpgradePolicy;
-
-    use super::*;
-
     pub const TEST_DATA_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/data");
-
-    #[test]
-    fn test_dyn_reader() {
-        let mut uncompressed =
-            DynReader::from_file(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn")).unwrap();
-        let mut compressed =
-            DynReader::from_file(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn.zst")).unwrap();
-        let mut uncompressed_res = Vec::new();
-        uncompressed.read_to_end(&mut uncompressed_res).unwrap();
-        let mut compressed_res = Vec::new();
-        compressed.read_to_end(&mut compressed_res).unwrap();
-        assert_eq!(compressed_res, uncompressed_res);
-    }
-
-    #[test]
-    fn test_detects_any_dbn_version_as_dbn() {
-        let mut buf = Vec::new();
-        let mut file = File::open(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn")).unwrap();
-        file.read_to_end(&mut buf).unwrap();
-        // change version
-        buf[3] = crate::DBN_VERSION + 1;
-        let res = DynDecoder::new_inferred(io::Cursor::new(buf), VersionUpgradePolicy::default());
-        assert!(matches!(res, Err(e) if e
-            .to_string()
-            .contains("can't decode newer version of DBN")));
-    }
 }
 
 #[cfg(feature = "async")]
-pub use self::{
-    dbn::{
-        AsyncDecoder as AsyncDbnDecoder, AsyncMetadataDecoder as AsyncDbnMetadataDecoder,
-        AsyncRecordDecoder as AsyncDbnRecordDecoder,
-    },
-    r#async::DynReader as AsyncDynReader,
+pub use self::dbn::{
+    AsyncDecoder as AsyncDbnDecoder, AsyncMetadataDecoder as AsyncDbnMetadataDecoder,
+    AsyncRecordDecoder as AsyncDbnRecordDecoder,
 };
-
-#[cfg(feature = "async")]
-mod r#async {
-    use std::{future::Future, io::ErrorKind, path::Path, pin::Pin};
-
-    use async_compression::tokio::bufread::ZstdDecoder;
-    use tokio::{
-        fs::File,
-        io::{self, AsyncReadExt, AsyncSeekExt, BufReader},
-    };
-
-    pub(crate) const ZSTD_FILE_BUFFER_CAPACITY: usize = 1 << 20;
-
-    use crate::enums::Compression;
-
-    use super::zstd::zstd_decoder;
-
-    /// Like [`AsyncSeek`](tokio::io::AsyncSeek), but only allows seeking forward from the current position.
-    pub trait AsyncSkipBytes {
-        /// Skips ahead `n_bytes` bytes.
-        ///
-        /// # Errors
-        /// This function returns an error if the I/O operations fail.
-        fn skip_bytes(&mut self, n_bytes: usize) -> impl Future<Output = crate::Result<()>>;
-    }
-
-    impl<T> AsyncSkipBytes for T
-    where
-        T: AsyncSeekExt + Unpin,
-    {
-        async fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
-            self.seek(std::io::SeekFrom::Current(n_bytes as i64))
-                .await
-                .map(drop)
-                .map_err(|err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes")))
-        }
-    }
-
-    /// A type for runtime polymorphism on compressed and uncompressed input.
-    /// The async version of [`DynReader`](super::DynReader).
-    pub struct DynReader<R>(DynReaderImpl<R>)
-    where
-        R: io::AsyncBufReadExt + Unpin;
-
-    enum DynReaderImpl<R>
-    where
-        R: io::AsyncBufReadExt + Unpin,
-    {
-        Uncompressed(R),
-        ZStd(ZstdDecoder<R>),
-    }
-
-    impl<R> DynReader<BufReader<R>>
-    where
-        R: io::AsyncReadExt + Unpin,
-    {
-        /// Creates a new instance of [`DynReader`] with the specified `compression`. If
-        /// `reader` also implements [`AsyncBufRead`](tokio::io::AsyncBufRead), it's
-        /// better to use [`with_buffer()`](Self::with_buffer).
-        pub fn new(reader: R, compression: Compression) -> Self {
-            Self::with_buffer(BufReader::new(reader), compression)
-        }
-
-        /// Creates a new [`DynReader`] from a reader, inferring the compression.
-        /// If `reader` also implements [`AsyncBufRead`](tokio::io::AsyncBufRead), it is
-        /// better to use [`inferred_with_buffer()`](Self::inferred_with_buffer).
-        ///
-        /// # Errors
-        /// This function will return an error if it is unable to read from `reader`.
-        pub async fn new_inferred(reader: R) -> crate::Result<Self> {
-            Self::inferred_with_buffer(BufReader::new(reader)).await
-        }
-    }
-
-    impl<R> DynReader<R>
-    where
-        R: io::AsyncBufReadExt + Unpin,
-    {
-        /// Creates a new [`DynReader`] from a buffered reader with the specified
-        /// `compression`.
-        pub fn with_buffer(reader: R, compression: Compression) -> Self {
-            match compression {
-                Compression::None => Self(DynReaderImpl::Uncompressed(reader)),
-                Compression::ZStd => Self(DynReaderImpl::ZStd(ZstdDecoder::new(reader))),
-            }
-        }
-
-        /// Creates a new [`DynReader`] from a buffered reader, inferring the compression.
-        ///
-        /// # Errors
-        /// This function will return an error if it fails to read from `reader`.
-        pub async fn inferred_with_buffer(mut reader: R) -> crate::Result<Self> {
-            let first_bytes = reader
-                .fill_buf()
-                .await
-                .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
-            Ok(if super::zstd::starts_with_prefix(first_bytes) {
-                Self(DynReaderImpl::ZStd(zstd_decoder(reader)))
-            } else {
-                Self(DynReaderImpl::Uncompressed(reader))
-            })
-        }
-
-        /// Returns a mutable reference to the inner reader.
-        pub fn get_mut(&mut self) -> &mut R {
-            match &mut self.0 {
-                DynReaderImpl::Uncompressed(reader) => reader,
-                DynReaderImpl::ZStd(reader) => reader.get_mut(),
-            }
-        }
-
-        /// Returns a reference to the inner reader.
-        pub fn get_ref(&self) -> &R {
-            match &self.0 {
-                DynReaderImpl::Uncompressed(reader) => reader,
-                DynReaderImpl::ZStd(reader) => reader.get_ref(),
-            }
-        }
-    }
-
-    impl DynReader<BufReader<File>> {
-        /// Creates a new [`DynReader`] from the file at `path`.
-        ///
-        /// # Errors
-        /// This function will return an error if the file doesn't exist, it is unable
-        /// to read from it.
-        pub async fn from_file(path: impl AsRef<Path>) -> crate::Result<Self> {
-            let file = File::open(path.as_ref()).await.map_err(|e| {
-                crate::Error::io(
-                    e,
-                    format!(
-                        "opening file to decode at path '{}'",
-                        path.as_ref().display()
-                    ),
-                )
-            })?;
-            DynReader::inferred_with_buffer(BufReader::with_capacity(
-                ZSTD_FILE_BUFFER_CAPACITY,
-                file,
-            ))
-            .await
-        }
-    }
-
-    impl<R> io::AsyncRead for DynReader<R>
-    where
-        R: io::AsyncRead + io::AsyncReadExt + io::AsyncBufReadExt + Unpin,
-    {
-        fn poll_read(
-            mut self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-            buf: &mut io::ReadBuf<'_>,
-        ) -> std::task::Poll<std::io::Result<()>> {
-            match &mut self.0 {
-                DynReaderImpl::Uncompressed(reader) => {
-                    io::AsyncRead::poll_read(Pin::new(reader), cx, buf)
-                }
-                DynReaderImpl::ZStd(reader) => io::AsyncRead::poll_read(Pin::new(reader), cx, buf),
-            }
-        }
-    }
-
-    impl<R> AsyncSkipBytes for DynReader<R>
-    where
-        R: io::AsyncSeekExt + io::AsyncBufReadExt + Unpin,
-    {
-        /// Like AsyncSeek, but only allows seeking forward from the current position.
-        ///
-        /// # Cancellation safety
-        /// This method is not cancel safe.
-        async fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
-            let handle_err = |err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes"));
-            match &mut self.0 {
-                DynReaderImpl::Uncompressed(reader) => reader
-                    .seek(std::io::SeekFrom::Current(n_bytes as i64))
-                    .await
-                    .map(drop)
-                    .map_err(handle_err),
-                DynReaderImpl::ZStd(reader) => {
-                    let mut buf = [0; 1024];
-                    let mut remaining = n_bytes;
-                    while remaining > 0 {
-                        let max_read_size = remaining.min(buf.len());
-                        let read_size = reader
-                            .read(&mut buf[..max_read_size])
-                            .await
-                            .map_err(handle_err)?;
-                        if read_size == 0 {
-                            return Err(crate::Error::io(
-                                std::io::Error::from(ErrorKind::UnexpectedEof),
-                                format!(
-                                    "seeking ahead {n_bytes} bytes. Only able to seek {} bytes",
-                                    n_bytes - remaining
-                                ),
-                            ));
-                        }
-                        remaining -= read_size;
-                    }
-                    Ok(())
-                }
-            }
-        }
-    }
-    #[cfg(test)]
-    mod tests {
-        use crate::{
-            compat::InstrumentDefMsgV1,
-            decode::{tests::TEST_DATA_PATH, AsyncDbnRecordDecoder},
-            VersionUpgradePolicy,
-        };
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_decode_multiframe_zst() {
-            let mut decoder = AsyncDbnRecordDecoder::with_version(
-                DynReader::from_file(&format!(
-                    "{TEST_DATA_PATH}/multi-frame.definition.v1.dbn.frag.zst"
-                ))
-                .await
-                .unwrap(),
-                1,
-                VersionUpgradePolicy::AsIs,
-                false,
-            )
-            .unwrap();
-            let mut count = 0;
-            while let Some(_rec) = decoder.decode::<InstrumentDefMsgV1>().await.unwrap() {
-                count += 1;
-            }
-            assert_eq!(count, 8);
-        }
-    }
-}

--- a/rust/dbn/src/decode/dyn_decoder.rs
+++ b/rust/dbn/src/decode/dyn_decoder.rs
@@ -1,0 +1,243 @@
+#![allow(deprecated)] // DBZ
+
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::Path,
+};
+
+use crate::{Compression, HasRType, Metadata, RecordRef, VersionUpgradePolicy};
+
+use super::{
+    dbn, dbz, private, zstd, DbnMetadata, DecodeRecord, DecodeRecordRef, DecodeStream,
+    StreamIterDecoder,
+};
+
+/// A decoder whose [`Encoding`](crate::enums::Encoding) and [`Compression`] are
+/// determined at runtime by peeking at the first few bytes.
+pub struct DynDecoder<'a, R>(DynDecoderImpl<'a, R>)
+where
+    R: io::BufRead;
+
+enum DynDecoderImpl<'a, R>
+where
+    R: io::BufRead,
+{
+    Dbn(dbn::Decoder<R>),
+    ZstdDbn(dbn::Decoder<::zstd::stream::Decoder<'a, R>>),
+    LegacyDbz(dbz::Decoder<R>),
+}
+
+impl<R> DynDecoder<'_, BufReader<R>>
+where
+    R: io::Read,
+{
+    /// Creates a new [`DynDecoder`] from a reader, with the specified `compression`. It
+    /// will decode records from previous DBN versions according to `upgrade_policy`.
+    ///
+    /// # Errors
+    /// This function will return an error if it fails to parse the metadata.
+    pub fn new(
+        reader: R,
+        compression: Compression,
+        upgrade_policy: VersionUpgradePolicy,
+    ) -> crate::Result<Self> {
+        Self::with_buffer(BufReader::new(reader), compression, upgrade_policy)
+    }
+
+    /// Creates a new [`DynDecoder`] from a reader, inferring the encoding and
+    /// compression. If `reader` also implements [`io::BufRead`], it is better to use
+    /// [`inferred_with_buffer()`](Self::inferred_with_buffer). It will decode records
+    /// from previous DBN versions according to `upgrade_policy`.
+    ///
+    /// # Errors
+    /// This function will return an error if it is unable to determine
+    /// the encoding of `reader` or it fails to parse the metadata.
+    pub fn new_inferred(reader: R, upgrade_policy: VersionUpgradePolicy) -> crate::Result<Self> {
+        Self::inferred_with_buffer(BufReader::new(reader), upgrade_policy)
+    }
+}
+
+impl<R> DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    /// Creates a new [`DynDecoder`] from a buffered reader with the specified
+    /// `compression`.It will decode records from previous DBN versions according to
+    /// `upgrade_policy`.
+    ///
+    /// # Errors
+    /// This function will return an error if it is unable to determine
+    /// the encoding of `reader` or it fails to parse the metadata.
+    pub fn with_buffer(
+        reader: R,
+        compression: Compression,
+        upgrade_policy: VersionUpgradePolicy,
+    ) -> crate::Result<Self> {
+        match compression {
+            Compression::None => Ok(Self(DynDecoderImpl::Dbn(
+                dbn::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
+            ))),
+            Compression::ZStd => Ok(Self(DynDecoderImpl::ZstdDbn(
+                dbn::Decoder::with_upgrade_policy(
+                    ::zstd::stream::Decoder::with_buffer(reader)
+                        .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
+                    upgrade_policy,
+                )?,
+            ))),
+        }
+    }
+
+    /// Creates a new [`DynDecoder`] from a buffered reader, inferring the encoding
+    /// and compression.It will decode records from previous DBN versions according
+    /// to `upgrade_policy`.
+    ///
+    /// # Errors
+    /// This function will return an error if it is unable to determine
+    /// the encoding of `reader` or it fails to parse the metadata.
+    pub fn inferred_with_buffer(
+        mut reader: R,
+        upgrade_policy: VersionUpgradePolicy,
+    ) -> crate::Result<Self> {
+        let first_bytes = reader
+            .fill_buf()
+            .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
+        if dbz::starts_with_prefix(first_bytes) {
+            Ok(Self(DynDecoderImpl::LegacyDbz(
+                dbz::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
+            )))
+        } else if dbn::starts_with_prefix(first_bytes) {
+            Ok(Self(DynDecoderImpl::Dbn(
+                dbn::Decoder::with_upgrade_policy(reader, upgrade_policy)?,
+            )))
+        } else if zstd::starts_with_prefix(first_bytes) {
+            Ok(Self(DynDecoderImpl::ZstdDbn(
+                dbn::Decoder::with_upgrade_policy(
+                    ::zstd::stream::Decoder::with_buffer(reader)
+                        .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
+                    upgrade_policy,
+                )?,
+            )))
+        } else {
+            Err(crate::Error::decode("unable to determine encoding"))
+        }
+    }
+}
+
+impl DynDecoder<'_, BufReader<File>> {
+    /// Creates a new [`DynDecoder`] from the file at `path`. It will decode records
+    /// from previous DBN versions according to `upgrade_policy`.
+    ///
+    /// # Errors
+    /// This function will return an error if the file doesn't exist, it is unable to
+    /// determine the encoding of the file or it fails to parse the metadata.
+    pub fn from_file(
+        path: impl AsRef<Path>,
+        upgrade_policy: VersionUpgradePolicy,
+    ) -> crate::Result<Self> {
+        let file = File::open(path.as_ref()).map_err(|e| {
+            crate::Error::io(
+                e,
+                format!(
+                    "opening file to decode at path '{}'",
+                    path.as_ref().display()
+                ),
+            )
+        })?;
+        DynDecoder::new_inferred(file, upgrade_policy)
+    }
+}
+
+impl<R> DecodeRecordRef for DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    fn decode_record_ref(&mut self) -> crate::Result<Option<RecordRef>> {
+        match &mut self.0 {
+            DynDecoderImpl::Dbn(decoder) => decoder.decode_record_ref(),
+            DynDecoderImpl::ZstdDbn(decoder) => decoder.decode_record_ref(),
+            DynDecoderImpl::LegacyDbz(decoder) => decoder.decode_record_ref(),
+        }
+    }
+}
+
+impl<R> DbnMetadata for DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    fn metadata(&self) -> &Metadata {
+        match &self.0 {
+            DynDecoderImpl::Dbn(decoder) => decoder.metadata(),
+            DynDecoderImpl::ZstdDbn(decoder) => decoder.metadata(),
+            DynDecoderImpl::LegacyDbz(decoder) => decoder.metadata(),
+        }
+    }
+
+    fn metadata_mut(&mut self) -> &mut Metadata {
+        match &mut self.0 {
+            DynDecoderImpl::Dbn(decoder) => decoder.metadata_mut(),
+            DynDecoderImpl::ZstdDbn(decoder) => decoder.metadata_mut(),
+            DynDecoderImpl::LegacyDbz(decoder) => decoder.metadata_mut(),
+        }
+    }
+}
+
+impl<R> DecodeRecord for DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    fn decode_record<T: HasRType>(&mut self) -> crate::Result<Option<&T>> {
+        match &mut self.0 {
+            DynDecoderImpl::Dbn(decoder) => decoder.decode_record(),
+            DynDecoderImpl::ZstdDbn(decoder) => decoder.decode_record(),
+            DynDecoderImpl::LegacyDbz(decoder) => decoder.decode_record(),
+        }
+    }
+}
+
+impl<R> DecodeStream for DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    fn decode_stream<T: HasRType>(self) -> StreamIterDecoder<Self, T>
+    where
+        Self: Sized,
+    {
+        StreamIterDecoder::new(self)
+    }
+}
+
+impl<R> private::LastRecord for DynDecoder<'_, R>
+where
+    R: io::BufRead,
+{
+    fn last_record(&self) -> Option<RecordRef> {
+        match &self.0 {
+            DynDecoderImpl::Dbn(decoder) => decoder.last_record(),
+            DynDecoderImpl::ZstdDbn(decoder) => decoder.last_record(),
+            DynDecoderImpl::LegacyDbz(decoder) => decoder.last_record(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use crate::{decode::tests::TEST_DATA_PATH, enums::VersionUpgradePolicy};
+
+    use super::*;
+
+    #[test]
+    fn test_detects_any_dbn_version_as_dbn() {
+        let mut buf = Vec::new();
+        let mut file = File::open(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn")).unwrap();
+        file.read_to_end(&mut buf).unwrap();
+        // change version
+        buf[3] = crate::DBN_VERSION + 1;
+        let res = DynDecoder::new_inferred(io::Cursor::new(buf), VersionUpgradePolicy::default());
+        assert!(matches!(res, Err(e) if e
+            .to_string()
+            .contains("can't decode newer version of DBN")));
+    }
+}

--- a/rust/dbn/src/decode/dyn_reader.rs
+++ b/rust/dbn/src/decode/dyn_reader.rs
@@ -1,0 +1,418 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, ErrorKind, Read},
+    path::Path,
+};
+
+use crate::Compression;
+
+use super::{zstd, SkipBytes};
+
+/// Type for runtime polymorphism over whether decoding uncompressed or ZStd-compressed
+/// DBN records. Implements [`std::io::Write`].
+pub struct DynReader<'a, R>(DynReaderImpl<'a, R>)
+where
+    R: io::BufRead;
+
+enum DynReaderImpl<'a, R>
+where
+    R: io::BufRead,
+{
+    Uncompressed(R),
+    ZStd(::zstd::stream::Decoder<'a, R>),
+}
+
+impl<R> DynReader<'_, BufReader<R>>
+where
+    R: io::Read,
+{
+    /// Creates a new [`DynReader`] from a reader, with the specified `compression`.
+    /// If `reader` also implements [`BufRead`](io::BufRead), it's better to use
+    /// [`with_buffer()`](Self::with_buffer).
+    ///
+    /// # Errors
+    /// This function will return an error if it fails to create the zstd decoder.
+    pub fn new(reader: R, compression: Compression) -> crate::Result<Self> {
+        Self::with_buffer(BufReader::new(reader), compression)
+    }
+
+    /// Creates a new [`DynReader`] from a reader, inferring the compression.
+    /// If `reader` also implements [`io::BufRead`], it is better to use
+    /// [`inferred_with_buffer()`](Self::inferred_with_buffer).
+    ///
+    /// # Errors
+    /// This function will return an error if it is unable to read from `reader`
+    /// or it fails to create the zstd decoder.
+    pub fn new_inferred(reader: R) -> crate::Result<Self> {
+        Self::inferred_with_buffer(BufReader::new(reader))
+    }
+}
+
+impl<R> DynReader<'_, R>
+where
+    R: io::BufRead,
+{
+    /// Creates a new [`DynReader`] from a buffered reader with the specified
+    /// `compression`.
+    ///
+    /// # Errors
+    /// This function will return an error if it fails to create the zstd decoder.
+    pub fn with_buffer(reader: R, compression: Compression) -> crate::Result<Self> {
+        match compression {
+            Compression::None => Ok(Self(DynReaderImpl::Uncompressed(reader))),
+            Compression::ZStd => Ok(Self(DynReaderImpl::ZStd(
+                ::zstd::stream::Decoder::with_buffer(reader)
+                    .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
+            ))),
+        }
+    }
+
+    /// Creates a new [`DynReader`] from a buffered reader, inferring the compression.
+    ///
+    /// # Errors
+    /// This function will return an error if it fails to read from `reader` or creating
+    /// the zstd decoder fails.
+    pub fn inferred_with_buffer(mut reader: R) -> crate::Result<Self> {
+        let first_bytes = reader
+            .fill_buf()
+            .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
+        if zstd::starts_with_prefix(first_bytes) {
+            Ok(Self(DynReaderImpl::ZStd(
+                ::zstd::stream::Decoder::with_buffer(reader)
+                    .map_err(|e| crate::Error::io(e, "creating zstd decoder"))?,
+            )))
+        } else {
+            Ok(Self(DynReaderImpl::Uncompressed(reader)))
+        }
+    }
+
+    /// Returns a mutable reference to the inner reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        match &mut self.0 {
+            DynReaderImpl::Uncompressed(reader) => reader,
+            DynReaderImpl::ZStd(reader) => reader.get_mut(),
+        }
+    }
+
+    /// Returns a reference to the inner reader.
+    pub fn get_ref(&self) -> &R {
+        match &self.0 {
+            DynReaderImpl::Uncompressed(reader) => reader,
+            DynReaderImpl::ZStd(reader) => reader.get_ref(),
+        }
+    }
+}
+
+impl DynReader<'_, BufReader<File>> {
+    /// Creates a new [`DynReader`] from the file at `path`.
+    ///
+    /// # Errors
+    /// This function will return an error if the file doesn't exist, it is unable to
+    /// determine the encoding of the file, or it fails to create the zstd decoder.
+    pub fn from_file(path: impl AsRef<Path>) -> crate::Result<Self> {
+        let file = File::open(path.as_ref()).map_err(|e| {
+            crate::Error::io(
+                e,
+                format!(
+                    "opening file to decode at path '{}'",
+                    path.as_ref().display()
+                ),
+            )
+        })?;
+        DynReader::new_inferred(file)
+    }
+}
+
+impl<R> io::Read for DynReader<'_, R>
+where
+    R: io::BufRead,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.0 {
+            DynReaderImpl::Uncompressed(r) => r.read(buf),
+            DynReaderImpl::ZStd(r) => r.read(buf),
+        }
+    }
+}
+
+impl<R> SkipBytes for DynReader<'_, R>
+where
+    R: io::BufRead + io::Read + io::Seek,
+{
+    fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
+        let handle_err = |err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes"));
+        match &mut self.0 {
+            DynReaderImpl::Uncompressed(reader) => {
+                reader.seek_relative(n_bytes as i64).map_err(handle_err)
+            }
+            DynReaderImpl::ZStd(reader) => {
+                let mut buf = [0; 1024];
+                let mut remaining = n_bytes;
+                while remaining > 0 {
+                    let max_read_size = remaining.min(buf.len());
+                    let read_size = reader.read(&mut buf[..max_read_size]).map_err(handle_err)?;
+                    if read_size == 0 {
+                        return Err(crate::Error::io(
+                            std::io::Error::from(ErrorKind::UnexpectedEof),
+                            format!(
+                                "seeking ahead {n_bytes} bytes. Only able to seek {} bytes",
+                                n_bytes - remaining
+                            ),
+                        ));
+                    }
+                    remaining -= read_size;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::decode::tests::TEST_DATA_PATH;
+
+    #[test]
+    fn test_dyn_reader() {
+        let mut uncompressed =
+            DynReader::from_file(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn")).unwrap();
+        let mut compressed =
+            DynReader::from_file(format!("{TEST_DATA_PATH}/test_data.mbo.v3.dbn.zst")).unwrap();
+        let mut uncompressed_res = Vec::new();
+        uncompressed.read_to_end(&mut uncompressed_res).unwrap();
+        let mut compressed_res = Vec::new();
+        compressed.read_to_end(&mut compressed_res).unwrap();
+        assert_eq!(compressed_res, uncompressed_res);
+    }
+}
+
+#[cfg(feature = "async")]
+pub use self::r#async::DynReader as AsyncDynReader;
+
+#[cfg(feature = "async")]
+mod r#async {
+    use std::{io::ErrorKind, path::Path, pin::Pin};
+
+    use async_compression::tokio::bufread::ZstdDecoder;
+    use tokio::{
+        fs::File,
+        io::{self, AsyncReadExt, AsyncSeekExt, BufReader},
+    };
+
+    use crate::{
+        decode::{AsyncSkipBytes, ZSTD_FILE_BUFFER_CAPACITY},
+        enums::Compression,
+    };
+
+    use super::zstd::zstd_decoder;
+
+    impl<T> AsyncSkipBytes for T
+    where
+        T: AsyncSeekExt + Unpin,
+    {
+        async fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
+            self.seek(std::io::SeekFrom::Current(n_bytes as i64))
+                .await
+                .map(drop)
+                .map_err(|err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes")))
+        }
+    }
+
+    /// A type for runtime polymorphism on compressed and uncompressed input.
+    /// The async version of [`DynReader`](super::DynReader).
+    pub struct DynReader<R>(DynReaderImpl<R>)
+    where
+        R: io::AsyncBufReadExt + Unpin;
+
+    enum DynReaderImpl<R>
+    where
+        R: io::AsyncBufReadExt + Unpin,
+    {
+        Uncompressed(R),
+        ZStd(ZstdDecoder<R>),
+    }
+
+    impl<R> DynReader<BufReader<R>>
+    where
+        R: io::AsyncReadExt + Unpin,
+    {
+        /// Creates a new instance of [`DynReader`] with the specified `compression`. If
+        /// `reader` also implements [`AsyncBufRead`](tokio::io::AsyncBufRead), it's
+        /// better to use [`with_buffer()`](Self::with_buffer).
+        pub fn new(reader: R, compression: Compression) -> Self {
+            Self::with_buffer(BufReader::new(reader), compression)
+        }
+
+        /// Creates a new [`DynReader`] from a reader, inferring the compression.
+        /// If `reader` also implements [`AsyncBufRead`](tokio::io::AsyncBufRead), it is
+        /// better to use [`inferred_with_buffer()`](Self::inferred_with_buffer).
+        ///
+        /// # Errors
+        /// This function will return an error if it is unable to read from `reader`.
+        pub async fn new_inferred(reader: R) -> crate::Result<Self> {
+            Self::inferred_with_buffer(BufReader::new(reader)).await
+        }
+    }
+
+    impl<R> DynReader<R>
+    where
+        R: io::AsyncBufReadExt + Unpin,
+    {
+        /// Creates a new [`DynReader`] from a buffered reader with the specified
+        /// `compression`.
+        pub fn with_buffer(reader: R, compression: Compression) -> Self {
+            match compression {
+                Compression::None => Self(DynReaderImpl::Uncompressed(reader)),
+                Compression::ZStd => Self(DynReaderImpl::ZStd(ZstdDecoder::new(reader))),
+            }
+        }
+
+        /// Creates a new [`DynReader`] from a buffered reader, inferring the compression.
+        ///
+        /// # Errors
+        /// This function will return an error if it fails to read from `reader`.
+        pub async fn inferred_with_buffer(mut reader: R) -> crate::Result<Self> {
+            let first_bytes = reader
+                .fill_buf()
+                .await
+                .map_err(|e| crate::Error::io(e, "creating buffer to infer encoding"))?;
+            Ok(if super::zstd::starts_with_prefix(first_bytes) {
+                Self(DynReaderImpl::ZStd(zstd_decoder(reader)))
+            } else {
+                Self(DynReaderImpl::Uncompressed(reader))
+            })
+        }
+
+        /// Returns a mutable reference to the inner reader.
+        pub fn get_mut(&mut self) -> &mut R {
+            match &mut self.0 {
+                DynReaderImpl::Uncompressed(reader) => reader,
+                DynReaderImpl::ZStd(reader) => reader.get_mut(),
+            }
+        }
+
+        /// Returns a reference to the inner reader.
+        pub fn get_ref(&self) -> &R {
+            match &self.0 {
+                DynReaderImpl::Uncompressed(reader) => reader,
+                DynReaderImpl::ZStd(reader) => reader.get_ref(),
+            }
+        }
+    }
+
+    impl DynReader<BufReader<File>> {
+        /// Creates a new [`DynReader`] from the file at `path`.
+        ///
+        /// # Errors
+        /// This function will return an error if the file doesn't exist, it is unable
+        /// to read from it.
+        pub async fn from_file(path: impl AsRef<Path>) -> crate::Result<Self> {
+            let file = File::open(path.as_ref()).await.map_err(|e| {
+                crate::Error::io(
+                    e,
+                    format!(
+                        "opening file to decode at path '{}'",
+                        path.as_ref().display()
+                    ),
+                )
+            })?;
+            DynReader::inferred_with_buffer(BufReader::with_capacity(
+                ZSTD_FILE_BUFFER_CAPACITY,
+                file,
+            ))
+            .await
+        }
+    }
+
+    impl<R> io::AsyncRead for DynReader<R>
+    where
+        R: io::AsyncRead + io::AsyncReadExt + io::AsyncBufReadExt + Unpin,
+    {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            match &mut self.0 {
+                DynReaderImpl::Uncompressed(reader) => {
+                    io::AsyncRead::poll_read(Pin::new(reader), cx, buf)
+                }
+                DynReaderImpl::ZStd(reader) => io::AsyncRead::poll_read(Pin::new(reader), cx, buf),
+            }
+        }
+    }
+
+    impl<R> AsyncSkipBytes for DynReader<R>
+    where
+        R: io::AsyncSeekExt + io::AsyncBufReadExt + Unpin,
+    {
+        /// Like AsyncSeek, but only allows seeking forward from the current position.
+        ///
+        /// # Cancellation safety
+        /// This method is not cancel safe.
+        async fn skip_bytes(&mut self, n_bytes: usize) -> crate::Result<()> {
+            let handle_err = |err| crate::Error::io(err, format!("seeking ahead {n_bytes} bytes"));
+            match &mut self.0 {
+                DynReaderImpl::Uncompressed(reader) => reader
+                    .seek(std::io::SeekFrom::Current(n_bytes as i64))
+                    .await
+                    .map(drop)
+                    .map_err(handle_err),
+                DynReaderImpl::ZStd(reader) => {
+                    let mut buf = [0; 1024];
+                    let mut remaining = n_bytes;
+                    while remaining > 0 {
+                        let max_read_size = remaining.min(buf.len());
+                        let read_size = reader
+                            .read(&mut buf[..max_read_size])
+                            .await
+                            .map_err(handle_err)?;
+                        if read_size == 0 {
+                            return Err(crate::Error::io(
+                                std::io::Error::from(ErrorKind::UnexpectedEof),
+                                format!(
+                                    "seeking ahead {n_bytes} bytes. Only able to seek {} bytes",
+                                    n_bytes - remaining
+                                ),
+                            ));
+                        }
+                        remaining -= read_size;
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+    #[cfg(test)]
+    mod tests {
+        use crate::{
+            compat::InstrumentDefMsgV1,
+            decode::{tests::TEST_DATA_PATH, AsyncDbnRecordDecoder},
+            VersionUpgradePolicy,
+        };
+
+        use super::*;
+
+        #[tokio::test]
+        async fn test_decode_multiframe_zst() {
+            let mut decoder = AsyncDbnRecordDecoder::with_version(
+                DynReader::from_file(&format!(
+                    "{TEST_DATA_PATH}/multi-frame.definition.v1.dbn.frag.zst"
+                ))
+                .await
+                .unwrap(),
+                1,
+                VersionUpgradePolicy::AsIs,
+                false,
+            )
+            .unwrap();
+            let mut count = 0;
+            while let Some(_rec) = decoder.decode::<InstrumentDefMsgV1>().await.unwrap() {
+                count += 1;
+            }
+            assert_eq!(count, 8);
+        }
+    }
+}

--- a/rust/dbn/src/encode/dbn/sync.rs
+++ b/rust/dbn/src/encode/dbn/sync.rs
@@ -432,7 +432,7 @@ where
     /// Encodes a single DBN record.
     ///
     /// # Safety
-    /// The DBN encoding a [`RecordRef`] is safe because no dispatching based on type
+    /// DBN encoding a [`RecordRef`] is safe because no dispatching based on type
     /// is required.
     ///
     /// # Errors

--- a/rust/dbn/src/encode/json/serialize.rs
+++ b/rust/dbn/src/encode/json/serialize.rs
@@ -2,7 +2,7 @@ use std::ffi::c_char;
 
 use crate::{
     json_writer::{JsonObjectWriter, NULL},
-    pretty::{fmt_px, fmt_ts},
+    pretty::{fmt_px_into, fmt_ts},
     record::{c_chars_to_str, ConsolidatedBidAskPair},
     BidAskPair, FlagSet, HasRType, Metadata, RecordHeader, SecurityUpdateAction,
     UserDefinedInstrument, WithTsOut, UNDEF_PRICE, UNDEF_TIMESTAMP,
@@ -356,7 +356,10 @@ pub fn write_px_field<J: crate::json_writer::JsonWriter, const PRETTY_PX: bool>(
         if px == UNDEF_PRICE {
             writer.value(key, NULL);
         } else {
-            writer.value(key, &fmt_px(px));
+            let str_writer = writer.string_writer(key);
+            fmt_px_into(str_writer, px)
+                // Writing to a string is infallible
+                .unwrap();
         }
     } else {
         // Convert to string to avoid a loss of precision

--- a/rust/dbn/src/pretty.rs
+++ b/rust/dbn/src/pretty.rs
@@ -1,5 +1,4 @@
-//! Contains new types for pretty-printing values found in DBN
-//! records.
+//! Contains new types for pretty-printing timestamp and prices found in DBN records.
 
 use std::fmt;
 
@@ -7,12 +6,31 @@ use time::format_description::BorrowedFormatItem;
 
 use crate::FIXED_PRICE_SCALE;
 
-/// A new type for formatting nanosecond UNIX timestamps.
+/// A [new type](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)
+/// for formatting nanosecond UNIX timestamps to the canonical ISO 8601 format used
+/// by Databento.
+///
+/// Supports
+/// - width `{:N}` to specify a minimum width of `N` characters
+/// - fill and alignment: change the default fill character from a space
+///   and alignment from the default of right-aligned. See the
+///   [format docs](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) for
+///   details
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Ts(pub u64);
 
-/// A new type for formatting prices.
+/// A [new type](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) for
+/// formatting the fixed-precision prices used in DBN.
+///
+/// Supports
+/// - sign `{:+}` to always print the sign
+/// - width `{:N}` to specify a minimum width of `N` characters
+/// - fill and alignment: change the default fill character from a space
+///   and alignment from the default of right-aligned. See the
+///   [format docs](https://doc.rust-lang.org/std/fmt/index.html#fillalignment) for
+///   details
+/// - precision `{:.N}` to print `N` decimal places. By default all 9 are printed
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Px(pub i64);
@@ -37,48 +55,103 @@ impl fmt::Debug for Ts {
 
 impl fmt::Debug for Px {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&fmt_px(self.0))
+        fmt::Display::fmt(&self, f)
     }
 }
 
 impl fmt::Display for Ts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&fmt_ts(self.0))
+        const TS_FORMAT: &[BorrowedFormatItem<'static>] = time::macros::format_description!(
+            "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
+        );
+        let ts = self.0;
+        if ts != 0 {
+            // Should always be in range because we're widening from u64 to i128
+            let dt = time::OffsetDateTime::from_unix_timestamp_nanos(ts as i128).unwrap();
+            if let Ok(dt_str) = dt.format(TS_FORMAT) {
+                f.pad(&dt_str)?;
+            } else {
+                // Fall back to regular int formatting
+                fmt::Display::fmt(&ts, f)?;
+            }
+        }
+        Ok(())
     }
 }
 
 impl fmt::Display for Px {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&fmt_px(self.0))
+        const DIVISORS: [i64; 9] = [
+            0,
+            100_000_000,
+            10_000_000,
+            1_000_000,
+            100_000,
+            10_000,
+            1_000,
+            100,
+            10,
+        ];
+        let px = self.0;
+        if px == crate::UNDEF_PRICE {
+            f.write_str("UNDEF_PRICE")
+        } else {
+            let (is_nonnegative, px_abs) = if px < 0 { (false, -px) } else { (true, px) };
+            let px_integer = px_abs / FIXED_PRICE_SCALE;
+            let px_fraction = px_abs % FIXED_PRICE_SCALE;
+            match f.precision() {
+                Some(0) => f.pad_integral(is_nonnegative, "", itoa::Buffer::new().format(px_abs)),
+                Some(precision @ ..9) => f.pad_integral(
+                    is_nonnegative,
+                    "",
+                    &format!(
+                        "{px_integer}.{:0precision$}",
+                        px_fraction / DIVISORS[precision]
+                    ),
+                ),
+                Some(_) | None => f.pad_integral(
+                    is_nonnegative,
+                    "",
+                    &format!("{px_integer}.{px_fraction:09}"),
+                ),
+            }
+        }
     }
 }
 
-/// Converts a fixed-precision price to a decimal string.
+/// Converts a fixed-precision price to a decimal string with all 9 decimal places
+/// printed. Use [`Px`] to customize the number of printed decimal places, alignment,
+/// fill, and other formatting options.
 pub fn fmt_px(px: i64) -> String {
+    let mut out = String::new();
+    fmt_px_into(&mut out, px)
+        // Writing to a string is infallible
+        .unwrap();
+    out
+}
+
+pub(crate) fn fmt_px_into<W: fmt::Write>(mut out: W, px: i64) -> fmt::Result {
     if px == crate::UNDEF_PRICE {
-        "UNDEF_PRICE".to_owned()
+        write!(out, "UNDEF_PRICE")
     } else {
         let (sign, px_abs) = if px < 0 { ("-", -px) } else { ("", px) };
         let px_integer = px_abs / FIXED_PRICE_SCALE;
         let px_fraction = px_abs % FIXED_PRICE_SCALE;
-        format!("{sign}{px_integer}.{px_fraction:09}")
+        write!(
+            out,
+            "{sign}{}.{:0>9}",
+            itoa::Buffer::new().format(px_integer),
+            itoa::Buffer::new().format(px_fraction)
+        )
     }
 }
 
 /// Converts a nanosecond UNIX timestamp to a human-readable string in the format
 /// `[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z`.
+///
+/// Note: this function does not check for [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP).
 pub fn fmt_ts(ts: u64) -> String {
-    const TS_FORMAT: &[BorrowedFormatItem<'static>] = time::macros::format_description!(
-        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
-    );
-    if ts == 0 {
-        String::new()
-    } else {
-        time::OffsetDateTime::from_unix_timestamp_nanos(ts as i128)
-            .map_err(|_| ())
-            .and_then(|dt| dt.format(TS_FORMAT).map_err(|_| ()))
-            .unwrap_or_else(|_| ts.to_string())
-    }
+    format!("{}", Ts(ts))
 }
 
 /// Converts a fixed-precision price to a floating point.
@@ -94,45 +167,138 @@ pub fn px_to_f64(px: i64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::UNDEF_PRICE;
+    use rstest::*;
+
+    use crate::{UNDEF_PRICE, UNDEF_TIMESTAMP};
 
     use super::*;
 
-    #[test]
-    fn test_fmt_px_negative() {
-        assert_eq!(fmt_px(-100_000), "-0.000100000");
+    #[rstest]
+    #[case::negative(-100_000, "-0.000100000")]
+    #[case::positive(32_500_000_000, "32.500000000")]
+    #[case::leading_zero(101_005_000_000, "101.005000000")]
+    #[case::zero(0, "0.000000000")]
+    #[case::undef(UNDEF_PRICE, "UNDEF_PRICE")]
+    fn test_pretty_px(#[case] num: i64, #[case] exp: &str) {
+        assert_eq!(fmt_px(num), exp);
+        assert_eq!(format!("{}", Px(num)), exp);
+    }
+
+    #[rstest]
+    #[case::negative(-100_000, "-0.000100000")]
+    #[case::positive(300_000, "+0.000300000")]
+    #[case::positive(32_500_000_000, "+32.500000000")]
+    #[case::zero(0, "+0.000000000")]
+    fn test_sign(#[case] num: i64, #[case] exp: &str) {
+        let num = Px(num);
+        assert_eq!(format!("{num:+}"), exp);
+    }
+
+    #[rstest]
+    #[case::positive(32_500_000_000, 3, "32.500")]
+    #[case::leading_zero(101_005_000_000, 5, "101.00500")]
+    #[case::leading_zero(75_000_000, 6, "0.075000")]
+    #[case::trunc(32_123_456_789, 2, "32.12")]
+    fn test_precision(#[case] num: i64, #[case] precision: usize, #[case] exp: &str) {
+        let num = Px(num);
+        assert_eq!(format!("{num:.precision$}"), exp);
+    }
+
+    #[rstest]
+    #[case::positive(32_500_000_000, 4, 3, "32.500", "32.500", "32.500")]
+    #[case::positive(32_500_000_000, 8, 3, "  32.500", " 32.500 ", "32.500  ")]
+    // Center-aligned defaults to trailing padding when there's an odd number of padding spaces
+    #[case::leading_zero(101_005_000_000, 10, 5, " 101.00500", "101.00500 ", "101.00500 ")]
+    #[case::leading_zero(75_000_000, 13, 6, "     0.075000", "  0.075000   ", "0.075000     ")]
+    #[case::trunc(32_123_456_789, 7, 2, "  32.12", " 32.12 ", "32.12  ")]
+    #[case::trunc(
+        32_123_456_789,
+        16,
+        8,
+        "     32.12345678",
+        "  32.12345678   ",
+        "32.12345678     "
+    )]
+    fn test_alignment_width_precision(
+        #[case] num: i64,
+        #[case] width: usize,
+        #[case] precision: usize,
+        #[case] exp_right: &str,
+        #[case] exp_center: &str,
+        #[case] exp_left: &str,
+    ) {
+        let num = Px(num);
+        assert_eq!(format!("{num:width$.precision$}"), exp_right);
+        assert_eq!(format!("{num:>width$.precision$}"), exp_right);
+        assert_eq!(format!("{num:^width$.precision$}"), exp_center);
+        assert_eq!(format!("{num:<width$.precision$}"), exp_left);
+    }
+
+    #[rstest]
+    #[case::signed_zero(format!("{:+}", 0), "+0")]
+    #[case::uneven_center_align(format!("{:^5}", 12), " 12  ")]
+    #[case::high_width_truncating_precision(format!("{0:0<8.2}", 0.125), "0.120000")]
+    fn confirm_std_behavior(#[case] out: String, #[case] exp: &str) {
+        assert_eq!(out, exp);
+    }
+
+    #[rstest]
+    #[case::positive(32_500_000_000, 4, 3, "32.500", "32.500", "32.500")]
+    #[case::positive(32_500_000_000, 8, 3, "0032.500", "032.5000", "32.50000")]
+    // Center-aligned defaults to trailing padding when there's an odd number of padding spaces
+    #[case::leading_zero(101_005_000_000, 10, 5, "0101.00500", "101.005000", "101.005000")]
+    #[case::leading_zero(75_000_000, 13, 6, "000000.075000", "000.075000000", "0.07500000000")]
+    #[case::trunc(32_123_456_789, 7, 2, "0032.12", "032.120", "32.1200")]
+    #[case::trunc(
+        32_123_456_789,
+        16,
+        8,
+        "0000032.12345678",
+        "0032.12345678000",
+        "32.1234567800000"
+    )]
+    fn test_zero_fill_alignment_width_precision(
+        #[case] num: i64,
+        #[case] width: usize,
+        #[case] precision: usize,
+        #[case] exp_right: &str,
+        #[case] exp_center: &str,
+        #[case] exp_left: &str,
+    ) {
+        let num = Px(num);
+        assert_eq!(format!("{num:0width$.precision$}"), exp_right);
+        assert_eq!(format!("{num:0>width$.precision$}"), exp_right);
+        assert_eq!(format!("{num:0^width$.precision$}"), exp_center);
+        assert_eq!(format!("{num:0<width$.precision$}"), exp_left);
+    }
+
+    #[rstest]
+    #[case::zero(0, "")]
+    #[case::one(1, "1970-01-01T00:00:00.000000001Z")]
+    #[case::recent(1622838300000000000, "2021-06-04T20:25:00.000000000Z")]
+    #[case::max(UNDEF_TIMESTAMP - 1, "2554-07-21T23:34:33.709551614Z")]
+    fn test_fmt_ts(#[case] ts: u64, #[case] exp: &str) {
+        assert_eq!(fmt_ts(ts), exp);
     }
 
     #[test]
-    fn test_fmt_px_positive() {
-        assert_eq!(fmt_px(32_500_000_000), "32.500000000");
-    }
-
-    #[test]
-    fn test_fmt_px_zero() {
-        assert_eq!(fmt_px(0), "0.000000000");
-    }
-
-    #[test]
-    fn test_fmt_px_undef() {
-        assert_eq!(fmt_px(UNDEF_PRICE), "UNDEF_PRICE");
-    }
-
-    #[test]
-    fn test_fmt_ts_0() {
-        assert!(fmt_ts(0).is_empty());
-    }
-
-    #[test]
-    fn test_fmt_ts_1() {
-        assert_eq!(fmt_ts(1), "1970-01-01T00:00:00.000000001Z");
-    }
-
-    #[test]
-    fn test_fmt_ts_future() {
+    fn test_ts_alignment_and_fill() {
+        let ts = 1622838300000000000;
         assert_eq!(
-            fmt_ts(1622838300000000000),
-            "2021-06-04T20:25:00.000000000Z"
+            format!("{:33}", Ts(ts)),
+            "2021-06-04T20:25:00.000000000Z   "
+        );
+        assert_eq!(
+            format!("{:<33}", Ts(ts)),
+            "2021-06-04T20:25:00.000000000Z   "
+        );
+        assert_eq!(
+            format!("{:^33}", Ts(ts)),
+            " 2021-06-04T20:25:00.000000000Z  "
+        );
+        assert_eq!(
+            format!("{:>33}", Ts(ts)),
+            "   2021-06-04T20:25:00.000000000Z"
         );
     }
 }

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -603,13 +603,13 @@ pub enum Publisher {
     EqusAllFiny = 69,
     /// Databento US Equities (All Feeds) - FINRA/Nasdaq TRF Chicago
     EqusAllFinc = 70,
-    /// Databento US Equities (All Feeds) - CBOE BZX
+    /// Databento US Equities (All Feeds) - Cboe BZX
     EqusAllBats = 71,
-    /// Databento US Equities (All Feeds) - CBOE BYX
+    /// Databento US Equities (All Feeds) - Cboe BYX
     EqusAllBaty = 72,
-    /// Databento US Equities (All Feeds) - CBOE EDGA
+    /// Databento US Equities (All Feeds) - Cboe EDGA
     EqusAllEdga = 73,
-    /// Databento US Equities (All Feeds) - CBOE EDGX
+    /// Databento US Equities (All Feeds) - Cboe EDGX
     EqusAllEdgx = 74,
     /// Databento US Equities (All Feeds) - Nasdaq BX
     EqusAllXbos = 75,

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -51,7 +51,7 @@ pub struct RecordHeader {
     pub rtype: u8,
     /// The publisher ID assigned by Databento, which denotes the dataset and venue.
     ///
-    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues).
     #[pyo3(set)]
     pub publisher_id: u16,
     /// The numeric instrument ID. See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
@@ -60,7 +60,7 @@ pub struct RecordHeader {
     /// The matching-engine-received timestamp expressed as the number of nanoseconds
     /// since the UNIX epoch.
     ///
-    /// See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-event).
+    /// See [ts_event](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-event).
     #[dbn(encode_order(0), unix_nanos)]
     #[pyo3(set)]
     pub ts_event: u64,
@@ -202,7 +202,7 @@ pub struct ConsolidatedBidAskPair {
     pub ask_sz: u32,
     /// The publisher ID indicating the venue containing the best bid.
     ///
-    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues).
     #[dbn(fmt_method)]
     pub bid_pb: u16,
     // Reserved for later usage.
@@ -211,7 +211,7 @@ pub struct ConsolidatedBidAskPair {
     pub _reserved1: [c_char; 2],
     /// The publisher ID indicating the venue containing the best ask.
     ///
-    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+    /// See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues).
     #[dbn(fmt_method)]
     pub ask_pb: u16,
     // Reserved for later usage.


### PR DESCRIPTION
### Enhancements
- Added support for width, fill, and padding when formatting `pretty::Ts`
- Added support for sign, precision, width, fill, and padding when formatting
  `pretty::Px`
- Optimized pretty formatting of prices and timestamps

### Breaking changes
- Moved core async decoding and encoding functionality to new traits to
  match the sync interface and present a standardized interface
  - Decoding: `AsyncDecodeRecordRef` and `AsyncDecodeRecord`
  - Encoding: `AsyncEncodeRecord`, `AsyncEncodeRecordRef`, and
    `AsyncEncodeRecordTextExt`

### Bug fixes
- Added missing Python type stubs for several leg properties of `InstrumentDefMsg`

