### PR TITLE
VER: Release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added more floating-point price getters to `ImbalanceMsg`
 - Added floating-point price getter to `StatMsg` and `v1::StatMsg`
 - Standardize Python `__init__` type signatures
+- Upgraded `async-compression` dependency version to 0.4.27
 
 ### Breaking changes
 - Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.39.1 - TBD
+
+### Bug fixes
+- Fixed a regression where some enum constructors no longer raised a `DBNError` in
+  Python
+
 ## 0.39.0 - TBD
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.39.0 - TBD
+
+### Enhancements
+- Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields
+  of the same name to the `Side` enum
+- Added `pretty_auction_time` property in Python for `ImbalanceMsg`
+
+### Breaking changes
+- Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
+  instead of an `Option` to be consistent with other enum conversion methods
+- Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp
+
 ## 0.38.0 - 2025-07-22
 
 ### Breaking changes
@@ -7,6 +19,9 @@
 - Removed duplicated `flags` constants in `enums` module. Use the top-level `flags`
   constants instead
 - Renamed to `SCHEMA_COUNT` to `Schema::COUNT`
+- Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
+  instead of an `Option` to be consistent with other enum conversion methods
+- Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp
 
 ### Bug fixes
 - Relaxed requirement of `input_version` parameter to the Python `Transcoder` to only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,32 @@
 # Changelog
 
-## 0.39.1 - TBD
-
-### Bug fixes
-- Fixed a regression where some enum constructors no longer raised a `DBNError` in
-  Python
-
 ## 0.39.0 - TBD
 
 ### Enhancements
 - Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields
   of the same name to the `Side` enum
 - Added `pretty_auction_time` property in Python for `ImbalanceMsg`
+- Added `Default` implementation for `StatUpdateAction`
+- Added warnings to the floating-point getter methods' docstrings
+- Added `action` and `ts_in_delta` getters to `BboMsg`
+- Added `ts_recv` getter to `StatusMsg`
+- Added missing floating-point price getters to `InstrumentDefMsg` record types from all
+  DBN versions
+- Added more floating-point price getters to `ImbalanceMsg`
+- Added floating-point price getter to `StatMsg` and `v1::StatMsg`
+- Standardize Python `__init__` type signatures
 
 ### Breaking changes
 - Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
   instead of an `Option` to be consistent with other enum conversion methods
 - Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp
+
+### Bug fixes
+- Fixed a regression where some enum constructors no longer raised a `DBNError` in
+  Python
+- Fixed typo in `RecordHeader`'s `rtype` docstring
+- Removed error documentation from `ErrorMsg::new` because the function never returns an
+  error
 
 ## 0.38.0 - 2025-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.38.0 - TBD
+## 0.38.0 - 2025-07-22
 
 ### Breaking changes
 - Renamed `Compression::ZStd` to `Zstd` for consistency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.39.0 - TBD
+## 0.39.0 - 2025-07-29
 
 ### Enhancements
 - Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "futures-core",
  "memchr",
@@ -171,7 +171,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.100",
  "tempfile",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "csv",
  "dbn",
@@ -824,21 +824,20 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -935,6 +934,15 @@ name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -1135,9 +1143,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -1150,6 +1173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,16 +1189,31 @@ checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
  "winnow",
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.105"
+name = "toml_parser"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "trybuild"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
 dependencies = [
  "glob",
  "serde",
@@ -1174,7 +1221,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 0.9.3",
 ]
 
 [[package]]
@@ -1318,9 +1365,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.38.0"
+version = "0.39.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ anyhow = "1.0.98"
 csv = "1.3"
 pyo3 = "0.25.1"
 pyo3-build-config = "0.25.1"
-rstest = "0.25.0"
+rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
 time = "0.3.41"
 zstd = "0.13"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.38.0"
+version = "0.39.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.38.0"
+version = "0.39.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -4945,6 +4945,17 @@ class SystemMsg(Record):
         msg,
         code,
     ) -> None: ...
+    def is_heartbeat(self) -> bool:
+        """
+        Return `true` if this message is a heartbeat, used to indicate the connection
+        with the gateway is still open.
+
+        Returns
+        -------
+        bool
+
+        """
+
     @property
     def msg(self) -> str:
         """
@@ -6284,6 +6295,17 @@ class SystemMsgV1(Record):
         ts_event,
         msg,
     ) -> None: ...
+    def is_heartbeat(self) -> bool:
+        """
+        Return `true` if this message is a heartbeat, used to indicate the connection
+        with the gateway is still open.
+
+        Returns
+        -------
+        bool
+
+        """
+
     @property
     def msg(self) -> str:
         """

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: UP007 PYI021 PYI011
+# ruff: noqa: UP007 PYI021 PYI011 PYI014
 from __future__ import annotations
 
 import datetime as dt
@@ -7,7 +7,6 @@ from collections.abc import Sequence
 from enum import Enum
 from typing import BinaryIO
 from typing import ClassVar
-from typing import Optional
 from typing import SupportsBytes
 from typing import TextIO
 from typing import Union
@@ -25,870 +24,32 @@ UNDEF_TIMESTAMP: int
 _DBNRecord = Union[
     Metadata,
     MBOMsg,
+    TradeMsg,
     MBP1Msg,
+    MBP10Msg,
     BBOMsg,
     CMBP1Msg,
     CBBOMsg,
-    MBP10Msg,
     OHLCVMsg,
-    TradeMsg,
-    InstrumentDefMsgV1,
-    InstrumentDefMsgV2,
+    StatusMsg,
     InstrumentDefMsg,
     ImbalanceMsg,
-    ErrorMsg,
-    ErrorMsgV1,
-    SymbolMappingMsg,
-    SymbolMappingMsgV1,
-    SystemMsg,
-    SystemMsgV1,
-    StatMsgV1,
     StatMsg,
-    StatusMsg,
+    ErrorMsg,
+    SymbolMappingMsg,
+    SystemMsg,
+    ErrorMsgV1,
+    InstrumentDefMsgV1,
+    StatMsgV1,
+    SymbolMappingMsgV1,
+    SystemMsgV1,
+    InstrumentDefMsgV2,
 ]
 
 class DBNError(Exception):
     """
     An exception from databento_dbn Rust code.
     """
-
-class Side(Enum):
-    """
-    A side of the market. The side of the market for resting orders, or the side
-    of the aggressor for trades.
-
-    ASK
-        A sell order or sell aggressor in a trade.
-    BID
-        A buy order or a buy aggressor in a trade.
-    NONE
-        No side specified by the original source.
-
-    """
-
-    ASK: str
-    BID: str
-    NONE: str
-
-    @classmethod
-    def from_str(cls, value: str) -> Side: ...
-    @classmethod
-    def variants(cls) -> Iterable[Side]: ...
-
-class Action(Enum):
-    """
-    A tick action.
-
-    MODIFY
-        An existing order was modified.
-    TRADE
-        A trade executed.
-    FILL
-        An existing order was filled.
-    CANCEL
-        An order was cancelled.
-    ADD
-        A new order was added.
-    CLEAR
-        Reset the book; clear all orders for an instrument.
-    NONE
-        Has no effect on the book, but may carry `flags` or other information.
-    """
-
-    MODIFY: str
-    TRADE: str
-    FILL: str
-    CANCEL: str
-    ADD: str
-    CLEAR: str
-    NONE: str
-
-    @classmethod
-    def from_str(cls, value: str) -> Action: ...
-    @classmethod
-    def variants(cls) -> Iterable[Action]: ...
-
-class InstrumentClass(Enum):
-    """
-    The class of instrument.
-
-    BOND
-        A bond.
-    CALL
-        A call option.
-    FUTURE
-        A future.
-    STOCK
-        A stock.
-    MIXED_SPREAD
-        A spread composed of multiple instrument classes.
-    PUT
-        A put option.
-    FUTURE_SPREAD
-        A spread composed of futures.
-    OPTION_SPREAD
-        A spread composed of options.
-    FX_SPOT
-        A foreign exchange spot.
-    COMMODITY_SPOT
-        A commodity being traded for immediate delivery.
-
-    """
-
-    BOND: str
-    CALL: str
-    FUTURE: str
-    STOCK: str
-    MIXED_SPREAD: str
-    PUT: str
-    FUTURE_SPREAD: str
-    OPTION_SPREAD: str
-    FX_SPOT: str
-    COMMODITY_SPOT: str
-
-    @classmethod
-    def from_str(cls, value: str) -> InstrumentClass: ...
-    @classmethod
-    def variants(cls) -> Iterable[InstrumentClass]: ...
-
-class MatchAlgorithm(Enum):
-    """
-    The type of matching algorithm used for the instrument at the exchange.
-
-
-    UNDEFINED
-        No matching algorithm was specified.
-    FIFO
-        First-in-first-out matching.
-    CONFIGURABLE
-        A configurable match algorithm.
-    PRO_RATA
-        Trade quantity is allocated to resting orders based on a pro-rata percentage: resting order quantity divided by total quantity.
-    FIFO_LMM
-        Like `FIFO` but with LMM allocations prior to FIFO allocations.
-    THRESHOLD_PRO_RATA
-        Like `PRO_RATA` but includes a configurable allocation to the first order that improves the market.
-    FIFO_TOP_LMM
-        Like `FIFO_LMM` but includes a configurable allocation to the first order that improves the market.
-    THRESHOLD_PRO_RATA_LMM
-        Like `THRESHOLD_PRO_RATA` but includes a special priority to LMMs.
-    EURODOLLAR_FUTURES
-        Special variant used only for Eurodollar futures on CME.
-    TIME_PRO_RATA
-        Trade quantity is shared between all orders at the best price. Orders with the
-        highest time priority receive a higher matched quantity.
-    INSTITUTIONAL_PRIORITIZATION
-        A two-pass FIFO algorithm. The first pass fills the Institutional Group the aggressing
-        order is associated with. The second pass matches orders without an Institutional Group
-        association.
-    """
-
-    UNDEFINED: str
-    FIFO: str
-    CONFIGURABLE: str
-    PRO_RATA: str
-    FIFO_LMM: str
-    THRESHOLD_PRO_RATA: str
-    FIFO_TOP_LMM: str
-    THRESHOLD_PRO_RATA_LMM: str
-    EURODOLLAR_FUTURES: str
-    TIME_PRO_RATA: str
-    INSTITUTIONAL_PRIORITIZATION: str
-
-    @classmethod
-    def from_str(cls, value: str) -> MatchAlgorithm: ...
-    @classmethod
-    def variants(cls) -> Iterable[MatchAlgorithm]: ...
-
-class UserDefinedInstrument(Enum):
-    """
-    Whether the instrument is user-defined.
-
-    NO
-        The instrument is not user-defined.
-    YES
-        The instrument is user-defined.
-
-    """
-
-    NO: str
-    YES: str
-
-    @classmethod
-    def from_str(cls, value: str) -> UserDefinedInstrument: ...
-    @classmethod
-    def variants(cls) -> Iterable[UserDefinedInstrument]: ...
-
-class SType(Enum):
-    """
-    A DBN symbology type.
-
-    INSTRUMENT_ID
-        Symbology using a unique numeric ID.
-    RAW_SYMBOL
-        Symbology using the original symbols provided by the publisher.
-    CONTINUOUS
-        A Databento-specific symbology where one symbol may point to different
-        instruments at different points of time, e.g. to always refer to the front month
-        future.
-    PARENT
-        A Databento-specific symbology for referring to a group of symbols by one
-        "parent" symbol, e.g. ES.FUT to refer to all ES futures.
-    NASDAQ_SYMBOL
-        Symbology for US equities using NASDAQ Integrated suffix conventions.
-    CMS_SYMBOL
-        Symbology for US equities using CMS suffix conventions.
-    ISIN
-        Symbology using International Security Identification Numbers (ISIN) - ISO 6166.
-    US_CODE
-        Symbology using US domestic Committee on Uniform Securities Identification Procedure (CUSIP) codes.
-    BBG_COMP_ID
-        Symbology using Bloomberg composite global IDs.
-    BBG_COMP_TICKER
-        Symbology using Bloomberg composite tickers.
-    FIGI
-        Symbology using Bloomberg FIGI exchange level IDs.
-    FIGI_TICKER
-        Symbology using Bloomberg exchange level tickers.
-
-    """
-
-    INSTRUMENT_ID: str
-    RAW_SYMBOL: str
-    CONTINUOUS: str
-    PARENT: str
-    NASDAQ_SYMBOL: str
-    CMS_SYMBOL: str
-    ISIN: str
-    US_CODE: str
-    BBG_COMP_ID: str
-    BBG_COMP_TICKER: str
-    FIGI: str
-    FIGI_TICKER: str
-
-    @classmethod
-    def from_str(cls, value: str) -> SType: ...
-    @classmethod
-    def variants(cls) -> Iterable[SType]: ...
-
-class RType(Enum):
-    """
-    A DBN record type.
-
-    MBP_0
-        Denotes a market-by-price record with a book depth of 0 (used for the `Trades` schema).
-    MBP_1
-        Denotes a market-by-price record with a book depth of 1 (also used for the
-        `Tbbo` schema).
-    MBP_10
-        Denotes a market-by-price record with a book depth of 10.
-    OHLCV_DEPRECATED
-        Denotes an open, high, low, close, and volume record at an unspecified cadence.
-    OHLCV_1S
-        Denotes an open, high, low, close, and volume record at a 1-second cadence.
-    OHLCV_1M
-        Denotes an open, high, low, close, and volume record at a 1-minute cadence.
-    OHLCV_1H
-        Denotes an open, high, low, close, and volume record at an hourly cadence.
-    OHLCV_1D
-        Denotes an open, high, low, close, and volume record at a daily cadence
-        based on the UTC date.
-    OHLCV_EOD
-        Denotes an open, high, low, close, and volume record at a daily cadence
-        based on the end of the trading session.
-    STATUS
-        Denotes an exchange status record.
-    INSTRUMENT_DEF
-        Denotes an instrument definition record.
-    IMBALANCE
-        Denotes an order imbalance record.
-    ERROR
-        Denotes an error from gateway.
-    SYMBOL_MAPPING
-        Denotes a symbol mapping record.
-    SYSTEM
-        Denotes a non-error message from the gateway. Also used for heartbeats.
-    STATISTICS
-        Denotes a statistics record from the publisher (not calculated by Databento).
-    MBO
-        Denotes a market by order record.
-    CMBP_1
-        Denotes a consolidated best bid and offer record.
-    CBBO_1S
-        Denotes a consolidated best bid and offer record.
-    CBBO_1M
-        Denotes a consolidated best bid and offer record subsampled on a one-minute
-        interval.
-    TCBBO
-        Denotes a consolidated best bid and offer trade record containing the
-        consolidated BBO before the trade.
-    BBO_1S
-        Denotes a best bid and offer record subsampled on a one-second interval.
-    BBO_1M
-        Denotes a best bid and offer record subsampled on a one-minute interval.
-
-    """  # noqa: D405, D411
-
-    MBP_0: int
-    MBP_1: int
-    MBP_10: int
-    OHLCV_DEPRECATED: int
-    OHLCV_1S: int
-    OHLCV_1M: int
-    OHLCV_1H: int
-    OHLCV_1D: int
-    OHLCV_EOD: int
-    STATUS: int
-    INSTRUMENT_DEF: int
-    IMBALANCE: int
-    ERROR: int
-    SYMBOL_MAPPING: int
-    SYSTEM: int
-    STATISTICS: int
-    MBO: int
-    CMBP_1: int
-    CBBO_1S: int
-    CBBO_1M: int
-    TCBBO: int
-    BBO_1S: int
-    BBO_1M: int
-
-    @classmethod
-    def from_int(cls, value: int) -> RType: ...
-    @classmethod
-    def from_schema(cls, value: Schema) -> RType: ...
-    @classmethod
-    def from_str(cls, value: str) -> RType: ...
-    @classmethod
-    def variants(cls) -> Iterable[RType]: ...
-
-class Schema(Enum):
-    """
-    A DBN record schema.
-
-    MBO
-        Market by order.
-    MBP_1
-        Market by price with a book depth of 1.
-    MBP_10
-        Market by price with a book depth of 10.
-    TBBO
-        All trade events with the best bid and offer (BBO) immediately before the effect of the trade.
-    TRADES
-        All trade events.
-    OHLCV_1S
-        Open, high, low, close, and volume at a one-second interval.
-    OHLCV_1M
-        Open, high, low, close, and volume at a one-minute interval.
-    OHLCV_1H
-        Open, high, low, close, and volume at an hourly interval.
-    OHLCV_1D
-        Open, high, low, close, and volume at a daily interval.
-    OHLCV_EOD
-        Open, high, low, close, and volume at a daily cadence based on the end of the trading session.
-    DEFINITION
-        Instrument definitions.
-    STATISTICS
-        Additional data disseminated by publishers.
-    STATUS
-        Exchange status.
-    IMBALANCE
-        Auction imbalance events.
-    CMBP_1
-        Consolidated best bid and offer.
-    CBBO_1S
-        Consolidated best bid and offer record.
-    CBBO_1M
-        Consolidated best bid and offer record subsampled on a one-second interval.
-    TCBBO
-        Consolidated best bid and offer record subsampled on a one-minute interval.
-    BBO_1S
-        Consolidated best bid and offer trade record containing the consolidated BBO before the trade.
-    BBO_1M
-        Best bid and offer record subsampled on a one-second interval.
-
-    """
-
-    MBO: str
-    MBP_1: str
-    MBP_10: str
-    TBBO: str
-    TRADES: str
-    OHLCV_1S: str
-    OHLCV_1M: str
-    OHLCV_1H: str
-    OHLCV_1D: str
-    OHLCV_EOD: str
-    DEFINITION: str
-    STATISTICS: str
-    STATUS: str
-    IMBALANCE: str
-    CMBP_1: str
-    CBBO_1S: str
-    CBBO_1M: str
-    TCBBO: str
-    BBO_1S: str
-    BBO_1M: str
-
-    @classmethod
-    def from_str(cls, value: str) -> Schema: ...
-    @classmethod
-    def variants(cls) -> Iterable[Schema]: ...
-
-class Encoding(Enum):
-    """
-    Data output encoding.
-
-    DBN
-        Databento Binary Encoding.
-    CSV
-        Comma-separated values.
-    JSON
-        JavaScript object notation.
-
-    """
-
-    DBN: str
-    CSV: str
-    JSON: str
-
-    @classmethod
-    def from_str(cls, value: str) -> Encoding: ...
-    @classmethod
-    def from_int(cls, value: int) -> Encoding: ...
-    @classmethod
-    def variants(cls) -> Iterable[Encoding]: ...
-
-class Compression(Enum):
-    """
-    Data compression format.
-
-    NONE
-        Uncompressed.
-    ZSTD
-        Zstandard compressed.
-
-    """
-
-    NONE: str
-    ZSTD: str
-
-    @classmethod
-    def from_str(cls, value: str) -> Compression: ...
-    @classmethod
-    def from_int(cls, value: int) -> Compression: ...
-    @classmethod
-    def variants(cls) -> Iterable[Compression]: ...
-
-class SecurityUpdateAction(Enum):
-    """
-    The type of definition update.
-
-    ADD
-        A new instrument definition.
-    MODIFY
-        A modified instrument definition of an existing one.
-    DELETE
-        Removal of an instrument definition.
-    INVALID
-        Deprecated
-
-    """
-
-    ADD: str
-    MODIFY: str
-    DELETE: str
-    INVALID: str
-
-    @classmethod
-    def from_str(cls, value: str) -> SecurityUpdateAction: ...
-    @classmethod
-    def variants(cls) -> Iterable[SecurityUpdateAction]: ...
-
-class StatType(Enum):
-    """
-    The type of statistic contained in a `StatMsg`.
-
-    OPENING_PRICE
-        The price of the first trade of an instrument. `price` will be set.
-        `quantity` will be set when provided by the venue.
-    INDICATIVE_OPENING_PRICE
-        The probable price of the first trade of an instrument published during pre- open. Both
-        `price` and `quantity` will be set.
-    SETTLEMENT_PRICE
-        The settlement price of an instrument. `price` will be set and `flags` indicate whether the
-        price is final or preliminary and actual or theoretical. `ts_ref` will indicate the trading
-        date of the settlement price.
-    TRADING_SESSION_LOW_PRICE
-        The lowest trade price of an instrument during the trading session. `price` will be set.
-    TRADING_SESSION_HIGH_PRICE
-        The highest trade price of an instrument during the trading session. `price` will be set.
-    CLEARED_VOLUME
-        The number of contracts cleared for an instrument on the previous trading date. `quantity`
-        will be set. `ts_ref` will indicate the trading date of the volume.
-    LOWEST_OFFER
-        The lowest offer price for an instrument during the trading session. `price` will be set.
-    HIGHEST_BID
-        The highest bid price for an instrument during the trading session. `price` will be set.
-    OPEN_INTEREST
-        The current number of outstanding contracts of an instrument. `quantity` will be set.
-        `ts_ref` will indicate the trading date for which the open interest was calculated.
-    FIXING_PRICE
-        The volume-weighted average price (VWAP) for a fixing period. `price` will be set.
-    CLOSE_PRICE
-        The last trade price during a trading session. `price` will be set.
-        `quantity` will be set when provided by the venue.
-    NET_CHANGE
-        The change in price from the close price of the previous trading session to the most recent
-        trading session. `price` will be set.
-    VWAP
-        The volume-weighted average price (VWAP) during the trading session. `price` will be set to
-        the VWAP while `quantity` will be the traded volume.
-    VOLATILITY
-        The implied volatility associated with the settlement price.
-    DELTA
-        The option delta associated with the settlement price.
-    UNCROSSING_PRICE
-        The auction uncrossing price. This is used for auctions that are neither the
-        official opening auction nor the official closing auction. `price` will be set.
-        `quantity` will be set when provided by the venue.
-
-    """
-
-    OPENING_PRICE: int
-    INDICATIVE_OPENING_PRICE: int
-    SETTLEMENT_PRICE: int
-    TRADING_SESSION_LOW_PRICE: int
-    TRADING_SESSION_HIGH_PRICE: int
-    CLEARED_VOLUME: int
-    LOWEST_OFFER: int
-    HIGHEST_BID: int
-    OPEN_INTEREST: int
-    FIXING_PRICE: int
-    CLOSE_PRICE: int
-    NET_CHANGE: int
-    VWAP: int
-    VOLATILITY: int
-    DELTA: int
-    UNCROSSING_PRICE: int
-
-    @classmethod
-    def variants(cls) -> Iterable[StatType]: ...
-
-class StatUpdateAction(Enum):
-    """
-    The type of `StatMsg` update.
-
-    NEW
-        A new statistic.
-    DELETE
-        A removal of a statistic.
-
-    """
-
-    NEW: str
-    DELETE: str
-
-    @classmethod
-    def from_str(cls, value: str) -> StatUpdateAction: ...
-    @classmethod
-    def variants(cls) -> Iterable[StatUpdateAction]: ...
-
-class StatusAction(Enum):
-    """
-    The primary enum for the type of `StatusMsg` update.
-
-    NONE
-        No change.
-    PRE_OPEN
-        The instrument is in a pre-open period.
-    PRE_CROSS
-        The instrument is in a pre-cross period.
-    QUOTING
-        The instrument is quoting but not trading.
-    CROSS
-        The instrument is in a cross/auction.
-    ROTATION
-        The instrument is being opened through a trading rotation.
-    NEW_PRICE_INDICATION
-        A new price indication is available for the instrument.
-    TRADING
-        The instrument is trading.
-    HALT
-        Trading in the instrument has been halted.
-    PAUSE
-        Trading in the instrument has been paused.
-    SUSPEND
-        Trading in the instrument has been suspended.
-    PRE_CLOSE
-        The instrument is in a pre-close period.
-    CLOSE
-        Trading in the instrument has closed.
-    POST_CLOSE
-        The instrument is in a post-close period.
-    SSR_CHANGE
-        A change in short-selling restrictions.
-    NOT_AVAILABLE_FOR_TRADING
-        The instrument is not available for trading, either trading has closed or been halted.
-
-    """
-
-    NONE: int
-    PRE_OPEN: int
-    PRE_CROSS: int
-    QUOTING: int
-    CROSS: int
-    ROTATION: int
-    NEW_PRICE_INDICATION: int
-    TRADING: int
-    HALT: int
-    PAUSE: int
-    SUSPEND: int
-    PRE_CLOSE: int
-    CLOSE: int
-    POST_CLOSE: int
-    SSR_CHANGE: int
-    NOT_AVAILABLE_FOR_TRADING: int
-
-    @classmethod
-    def variants(cls) -> Iterable[StatusAction]: ...
-
-class StatusReason(Enum):
-    """
-    The secondary enum for a `StatusMsg` update, explains the cause of a halt or other change in
-    `action`.
-
-    NONE
-        No reason is given.
-    SCHEDULED
-        The change in status occurred as scheduled.
-    SURVEILLANCE_INTERVENTION
-        The instrument stopped due to a market surveillance intervention.
-    MARKET_EVENT
-        The status changed due to activity in the market.
-    INSTRUMENT_ACTIVATION
-        The derivative instrument began trading.
-    INSTRUMENT_EXPIRATION
-        The derivative instrument expired.
-    RECOVERY_IN_PROCESS
-        Recovery in progress.
-    REGULATORY
-        The status change was caused by a regulatory action.
-    ADMINISTRATIVE
-        The status change was caused by an administrative action.
-    NON_COMPLIANCE
-        The status change was caused by the issuer not being compliance with regulatory
-        requirements.
-    FILINGS_NOT_CURRENT
-        Trading halted because the issuer's filings are not current.
-    SEC_TRADING_SUSPENSION
-        Trading halted due to an SEC trading suspension.
-    NEW_ISSUE
-        The status changed because a new issue is available.
-    ISSUE_AVAILABLE
-        The status changed because an issue is available.
-    ISSUES_REVIEWED
-        The status changed because the issue(s) were reviewed.
-    FILING_REQS_SATISFIED
-        The status changed because the filing requirements were satisfied.
-    NEWS_PENDING
-        Relevant news is pending.
-    NEWS_RELEASED
-        Relevant news was released.
-    NEWS_AND_RESUMPTION_TIMES
-        The news has been fully disseminated and times are available for the resumption in quoting
-        and trading.
-    NEWS_NOT_FORTHCOMING
-        The relevant news was not forthcoming.
-    ORDER_IMBALANCE
-        Halted for order imbalance.
-    LULD_PAUSE
-        The instrument hit limit up or limit down.
-    OPERATIONAL
-        An operational issue occurred with the venue.
-    ADDITIONAL_INFORMATION_REQUESTED
-        The status changed until the exchange receives additional information.
-    MERGER_EFFECTIVE
-        Trading halted due to merger becoming effective.
-    ETF
-        Trading is halted in an ETF due to conditions with the component securities.
-    CORPORATE_ACTION
-        Trading is halted for a corporate action.
-    NEW_SECURITY_OFFERING
-        Trading is halted because the instrument is a new offering.
-    MARKET_WIDE_HALT_LEVEL1
-        Halted due to the market-wide circuit breaker level 1.
-    MARKET_WIDE_HALT_LEVEL2
-        Halted due to the market-wide circuit breaker level 2.
-    MARKET_WIDE_HALT_LEVEL3
-        Halted due to the market-wide circuit breaker level 3.
-    MARKET_WIDE_HALT_CARRYOVER
-        Halted due to the carryover of a market-wide circuit breaker from the previous trading day.
-    MARKET_WIDE_HALT_RESUMPTION
-        Resumption due to the end of a market-wide circuit breaker halt.
-    QUOTATION_NOT_AVAILABLE
-        Halted because quotation is not available.
-
-    """
-
-    NONE: int
-    SCHEDULED: int
-    SURVEILLANCE_INTERVENTION: int
-    MARKET_EVENT: int
-    INSTRUMENT_ACTIVATION: int
-    INSTRUMENT_EXPIRATION: int
-    RECOVERY_IN_PROCESS: int
-    REGULATORY: int
-    ADMINISTRATIVE: int
-    NON_COMPLIANCE: int
-    FILINGS_NOT_CURRENT: int
-    SEC_TRADING_SUSPENSION: int
-    NEW_ISSUE: int
-    ISSUE_AVAILABLE: int
-    ISSUES_REVIEWED: int
-    FILING_REQS_SATISFIED: int
-    NEWS_PENDING: int
-    NEWS_RELEASED: int
-    NEWS_AND_RESUMPTION_TIMES: int
-    NEWS_NOT_FORTHCOMING: int
-    ORDER_IMBALANCE: int
-    LULD_PAUSE: int
-    OPERATIONAL: int
-    ADDITIONAL_INFORMATION_REQUESTED: int
-    MERGER_EFFECTIVE: int
-    ETF: int
-    CORPORATE_ACTION: int
-    NEW_SECURITY_OFFERING: int
-    MARKET_WIDE_HALT_CARRYOVER: int
-    MARKET_WIDE_HALT_RESUMPTION: int
-    QUOTATION_NOT_AVAILABLE: int
-
-    @classmethod
-    def variants(cls) -> Iterable[StatusReason]: ...
-
-class TradingEvent(Enum):
-    """
-    Further information about a status update.
-
-
-    NONE
-        No additional information given.
-    NO_CANCEL
-        Order entry and modification are not allowed.
-    CHANGE_TRADING_SESSION
-        A change of trading session occurred. Daily statistics are reset.
-    IMPLIED_MATCHING_ON
-        Implied matching is available.
-    IMPLIED_MATCHING_OFF
-        Implied matching is not available.
-
-    """
-
-    NONE: int
-    NO_CANCEL: int
-    CHANGE_TRADING_SESSION: int
-    IMPLIED_MATCHING_ON: int
-    IMPLIED_MATCHING_OFF: int
-
-    @classmethod
-    def variants(cls) -> Iterable[TradingEvent]: ...
-
-class TriState(Enum):
-    """
-    An enum for representing unknown, true, or false values. Equivalent to `Optional[bool]`.
-
-    NOT_AVAILABLE
-        The value is not applicable or not known.
-    NO
-        False
-    YES
-        True
-
-    """
-
-    NOT_AVAILABLE: str
-    NO: str
-    YES: str
-
-    @classmethod
-    def from_str(cls, value: str) -> TriState: ...
-    @classmethod
-    def variants(cls) -> Iterable[TriState]: ...
-    def opt_bool(self) -> Optional[bool]: ...
-
-class VersionUpgradePolicy(Enum):
-    """
-    How to handle decoding a DBN data from a prior version.
-
-    AS_IS
-        Decode data from previous versions as-is.
-    UPGRADE_TO_V2
-        Decode and convert data from DBN versions prior to version 2 to that version.
-        Attempting to decode data from newer versions will fail.
-    UPGRADE_TO_V3
-        Decode and convert data from DBN versions prior to version 3 to that version.
-        Attempting to decode data from newer versions (when they're introduced) will
-        fail.
-
-    """
-
-    AS_IS: int
-    UPGRADE_TO_V2: int
-    UPGRADE_TO_V3: int
-
-class ErrorCode(Enum):
-    """
-    An error code from the live subscription gateway.
-
-    AUTH_FAILED
-        The authentication step failed.
-    API_KEY_DEACTIVATED
-        The user account or API key were deactivated.
-    CONNECTION_LIMIT_EXCEEDED
-        The user has exceeded their open connection limit
-    SYMBOL_RESOLUTION_FAILED
-        One or more symbols failed to resolve.
-    INVALID_SUBSCRIPTION
-        There was an issue with a subscription request (other than symbol resolution).
-     INTERNAL_ERROR
-        An error occurred in the gateway.
-
-    """
-
-    AUTH_FAILED: int
-    API_KEY_DEACTIVATED: int
-    CONNECTION_LIMIT_EXCEEDED: int
-    SYMBOL_RESOLUTION_FAILED: int
-    INVALID_SUBSCRIPTION: int
-    INTERNAL_ERROR: int
-
-    @classmethod
-    def variants(cls) -> Iterable[ErrorCode]: ...
-
-class SystemCode(Enum):
-    """
-    A `SystemMsg` code indicating the type of message from the live subscription
-    gateway.
-
-    HEARTBEAT
-        A message sent in the absence of other records to indicate the connection
-        remains open.
-    SUBSCRIPTION_ACK
-        An acknowledgement of a subscription request.
-    SLOW_READER_WARNING
-        The gateway has detected this session is falling behind real-time.
-    REPLAY_COMPLETED
-        Indicates a replay subscription has caught up with real-time data.
-
-    """
-
-    HEARTBEAT: int
-    SUBSCRIPTION_ACK: int
-    SLOW_READER_WARNING: int
-    REPLAY_COMPLETED: int
-
-    @classmethod
-    def variants(cls) -> Iterable[ErrorCode]: ...
 
 class Metadata(SupportsBytes):
     """
@@ -1102,7 +263,7 @@ class Metadata(SupportsBytes):
 
 class RecordHeader:
     """
-    DBN Record Header.
+    DBN record header.
     """
 
     @property
@@ -1283,11 +444,931 @@ class Record(SupportsBytes):
 
         """
 
-class _MBOBase:
+class RType(Enum):
     """
-    Base for market-by-order messages.
+    A record type sentinel.
+
+    MBP_0
+        none
+    MBP_1
+        none
+    MBP_10
+        Denotes a market-by-price record with a book depth of 10.
+    OHLCV_DEPRECATED
+        Denotes an open, high, low, close, and volume record at an unspecified cadence.
+    OHLCV_1S
+        Denotes an open, high, low, close, and volume record at a 1-second cadence.
+    OHLCV_1M
+        Denotes an open, high, low, close, and volume record at a 1-minute cadence.
+    OHLCV_1H
+        Denotes an open, high, low, close, and volume record at an hourly cadence.
+    OHLCV_1D
+        Denotes an open, high, low, close, and volume record at a daily cadence
+        based on the UTC date.
+    OHLCV_EOD
+        Denotes an open, high, low, close, and volume record at a daily cadence
+        based on the end of the trading session.
+    STATUS
+        Denotes an exchange status record.
+    INSTRUMENT_DEF
+        Denotes an instrument definition record.
+    IMBALANCE
+        Denotes an order imbalance record.
+    ERROR
+        Denotes an error from gateway.
+    SYMBOL_MAPPING
+        Denotes a symbol mapping record.
+    SYSTEM
+        Denotes a non-error message from the gateway. Also used for heartbeats.
+    STATISTICS
+        Denotes a statistics record from the publisher (not calculated by Databento).
+    MBO
+        Denotes a market-by-order record.
+    CMBP_1
+        Denotes a consolidated best bid and offer record.
+    CBBO_1S
+        Denotes a consolidated best bid and offer record subsampled on a one-second
+        interval.
+    CBBO_1M
+        Denotes a consolidated best bid and offer record subsampled on a one-minute
+        interval.
+    TCBBO
+        Denotes a consolidated best bid and offer trade record containing the
+        consolidated BBO before the trade
+    BBO_1S
+        Denotes a best bid and offer record subsampled on a one-second interval.
+    BBO_1M
+        Denotes a best bid and offer record subsampled on a one-minute interval.
+
+    """  # noqa: D405, D411
+
+    MBP_0: int
+    MBP_1: int
+    MBP_10: int
+    OHLCV_DEPRECATED: int
+    OHLCV_1S: int
+    OHLCV_1M: int
+    OHLCV_1H: int
+    OHLCV_1D: int
+    OHLCV_EOD: int
+    STATUS: int
+    INSTRUMENT_DEF: int
+    IMBALANCE: int
+    ERROR: int
+    SYMBOL_MAPPING: int
+    SYSTEM: int
+    STATISTICS: int
+    MBO: int
+    CMBP_1: int
+    CBBO_1S: int
+    CBBO_1M: int
+    TCBBO: int
+    BBO_1S: int
+    BBO_1M: int
+
+    @classmethod
+    def from_str(cls, value: str) -> RType: ...
+    @classmethod
+    def from_int(cls, value: int) -> RType: ...
+    @classmethod
+    def from_schema(cls, value: Schema) -> RType: ...
+    @classmethod
+    def variants(cls) -> Iterable[RType]: ...
+
+class Side(Enum):
+    """
+    A [side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types)
+    of the market. The side of the market for resting orders, or the side of the
+    aggressor for trades.
+
+    ASK
+        A sell order or sell aggressor in a trade.
+    BID
+        A buy order or a buy aggressor in a trade.
+    NONE
+        No side specified by the original source.
+
     """
 
+    ASK: str
+    BID: str
+    NONE: str
+
+    @classmethod
+    def from_str(cls, value: str) -> Side: ...
+    @classmethod
+    def variants(cls) -> Iterable[Side]: ...
+
+class Action(Enum):
+    """
+    An [order event or order book operation](https://databento.com/docs/api-reference-historical/basics/schemas-and-conventions).
+
+    For example usage see:
+    - [Order actions](https://databento.com/docs/examples/order-book/order-actions)
+    - [Order tracking](https://databento.com/docs/examples/order-book/order-tracking)
+
+    MODIFY
+        An existing order was modified: price and/or size.
+    TRADE
+        An aggressing order traded. Does not affect the book.
+    FILL
+        An existing order was filled. Does not affect the book.
+    CANCEL
+        An order was fully or partially cancelled.
+    ADD
+        A new order was added to the book.
+    CLEAR
+        Reset the book; clear all orders for an instrument.
+    NONE
+        Has no effect on the book, but may carry `flags` or other information.
+
+    """
+
+    MODIFY: str
+    TRADE: str
+    FILL: str
+    CANCEL: str
+    ADD: str
+    CLEAR: str
+    NONE: str
+
+    @classmethod
+    def from_str(cls, value: str) -> Action: ...
+    @classmethod
+    def variants(cls) -> Iterable[Action]: ...
+
+class InstrumentClass(Enum):
+    """
+    The class of instrument.
+
+    For example usage see
+    [Getting options with their underlying](https://databento.com/docs/examples/options/options-and-futures).
+
+    BOND
+        A bond.
+    CALL
+        A call option.
+    FUTURE
+        A future.
+    STOCK
+        A stock.
+    MIXED_SPREAD
+        A spread composed of multiple instrument classes.
+    PUT
+        A put option.
+    FUTURE_SPREAD
+        A spread composed of futures.
+    OPTION_SPREAD
+        A spread composed of options.
+    FX_SPOT
+        A foreign exchange spot.
+    COMMODITY_SPOT
+        A commodity being traded for immediate delivery.
+
+    """
+
+    BOND: str
+    CALL: str
+    FUTURE: str
+    STOCK: str
+    MIXED_SPREAD: str
+    PUT: str
+    FUTURE_SPREAD: str
+    OPTION_SPREAD: str
+    FX_SPOT: str
+    COMMODITY_SPOT: str
+
+    @classmethod
+    def from_str(cls, value: str) -> InstrumentClass: ...
+    @classmethod
+    def variants(cls) -> Iterable[InstrumentClass]: ...
+
+class MatchAlgorithm(Enum):
+    """
+    The type of matching algorithm used for the instrument at the exchange.
+
+    UNDEFINED
+        No matching algorithm was specified.
+    FIFO
+        First-in-first-out matching.
+    CONFIGURABLE
+        A configurable match algorithm.
+    PRO_RATA
+        Trade quantity is allocated to resting orders based on a pro-rata percentage:
+        resting order quantity divided by total quantity.
+    FIFO_LMM
+        Like `FIFO` but with LMM allocations prior to FIFO allocations.
+    THRESHOLD_PRO_RATA
+        Like `PRO_RATA` but includes a configurable allocation to the first order that
+        improves the market.
+    FIFO_TOP_LMM
+        Like `FIFO_LMM` but includes a configurable allocation to the first order that
+        improves the market.
+    THRESHOLD_PRO_RATA_LMM
+        Like `THRESHOLD_PRO_RATA` but includes a special priority to LMMs.
+    EURODOLLAR_FUTURES
+        Special variant used only for Eurodollar futures on CME.
+    TIME_PRO_RATA
+        Trade quantity is shared between all orders at the best price. Orders with the
+        highest time priority receive a higher matched quantity.
+    INSTITUTIONAL_PRIORITIZATION
+        A two-pass FIFO algorithm. The first pass fills the Institutional Group the aggressing
+        order is associated with. The second pass matches orders without an Institutional Group
+        association. See [CME documentation](https://cmegroupclientsite.atlassian.net/wiki/spaces/EPICSANDBOX/pages/457217267#InstitutionalPrioritizationMatchAlgorithm).
+
+    """
+
+    UNDEFINED: str
+    FIFO: str
+    CONFIGURABLE: str
+    PRO_RATA: str
+    FIFO_LMM: str
+    THRESHOLD_PRO_RATA: str
+    FIFO_TOP_LMM: str
+    THRESHOLD_PRO_RATA_LMM: str
+    EURODOLLAR_FUTURES: str
+    TIME_PRO_RATA: str
+    INSTITUTIONAL_PRIORITIZATION: str
+
+    @classmethod
+    def from_str(cls, value: str) -> MatchAlgorithm: ...
+    @classmethod
+    def variants(cls) -> Iterable[MatchAlgorithm]: ...
+
+class UserDefinedInstrument(Enum):
+    """
+    Whether the instrument is user-defined.
+
+    For example usage see
+    [Getting options with their underlying](https://databento.com/docs/examples/options/options-and-futures).
+
+    NO
+        The instrument is not user-defined.
+    YES
+        The instrument is user-defined.
+
+    """
+
+    NO: str
+    YES: str
+
+    @classmethod
+    def from_str(cls, value: str) -> UserDefinedInstrument: ...
+    @classmethod
+    def variants(cls) -> Iterable[UserDefinedInstrument]: ...
+
+class SecurityUpdateAction(Enum):
+    """
+    The type of `InstrumentDefMsg` update.
+
+    ADD
+        A new instrument definition.
+    MODIFY
+        A modified instrument definition of an existing one.
+    DELETE
+        Removal of an instrument definition.
+    INVALID
+        none
+
+    """
+
+    ADD: str
+    MODIFY: str
+    DELETE: str
+    INVALID: str
+
+    @classmethod
+    def from_str(cls, value: str) -> SecurityUpdateAction: ...
+    @classmethod
+    def variants(cls) -> Iterable[SecurityUpdateAction]: ...
+
+class SType(Enum):
+    """
+    A symbology type. Refer to the
+    [symbology documentation](https://databento.com/docs/api-reference-historical/basics/symbology)
+    for more information.
+
+    INSTRUMENT_ID
+        Symbology using a unique numeric ID.
+    RAW_SYMBOL
+        Symbology using the original symbols provided by the publisher.
+    SMART
+        A set of Databento-specific symbologies for referring to groups of symbols.
+    CONTINUOUS
+        A Databento-specific symbology where one symbol may point to different
+        instruments at different points of time, e.g. to always refer to the front month
+        future.
+    PARENT
+        A Databento-specific symbology for referring to a group of symbols by one
+        "parent" symbol, e.g. ES.FUT to refer to all ES futures.
+    NASDAQ_SYMBOL
+        Symbology for US equities using NASDAQ Integrated suffix conventions.
+    CMS_SYMBOL
+        Symbology for US equities using CMS suffix conventions.
+    ISIN
+        Symbology using International Security Identification Numbers (ISIN) - ISO 6166.
+    US_CODE
+        Symbology using US domestic Committee on Uniform Securities Identification Procedure (CUSIP) codes.
+    BBG_COMP_ID
+        Symbology using Bloomberg composite global IDs.
+    BBG_COMP_TICKER
+        Symbology using Bloomberg composite tickers.
+    FIGI
+        Symbology using Bloomberg FIGI exchange level IDs.
+    FIGI_TICKER
+        Symbology using Bloomberg exchange level tickers.
+
+    """
+
+    INSTRUMENT_ID: str
+    RAW_SYMBOL: str
+    SMART: str
+    CONTINUOUS: str
+    PARENT: str
+    NASDAQ_SYMBOL: str
+    CMS_SYMBOL: str
+    ISIN: str
+    US_CODE: str
+    BBG_COMP_ID: str
+    BBG_COMP_TICKER: str
+    FIGI: str
+    FIGI_TICKER: str
+
+    @classmethod
+    def from_str(cls, value: str) -> SType: ...
+    @classmethod
+    def from_int(cls, value: int) -> SType: ...
+    @classmethod
+    def variants(cls) -> Iterable[SType]: ...
+
+class Schema(Enum):
+    """
+    A data record schema.
+
+    Each schema has a particular record type associated with it.
+
+    See [List of supported market data schemas](https://databento.com/docs/schemas-and-data-formats/whats-a-schema)
+    for an overview of the differences and use cases of each schema.
+
+    MBO
+        Market by order.
+    MBP_1
+        Market by price with a book depth of 1.
+    MBP_10
+        Market by price with a book depth of 10.
+    TBBO
+        All trade events with the best bid and offer (BBO) immediately **before** the effect of
+        the trade.
+    TRADES
+        All trade events.
+    OHLCV_1S
+        Open, high, low, close, and volume at a one-second interval.
+    OHLCV_1M
+        Open, high, low, close, and volume at a one-minute interval.
+    OHLCV_1H
+        Open, high, low, close, and volume at an hourly interval.
+    OHLCV_1D
+        Open, high, low, close, and volume at a daily interval based on the UTC date.
+    DEFINITION
+        Instrument definitions.
+    STATISTICS
+        Additional data disseminated by publishers.
+    STATUS
+        Trading status events.
+    IMBALANCE
+        Auction imbalance events.
+    OHLCV_EOD
+        Open, high, low, close, and volume at a daily cadence based on the end of the trading
+        session.
+    CMBP_1
+        Consolidated best bid and offer.
+    CBBO_1S
+        Consolidated best bid and offer subsampled at one-second intervals, in addition to
+        trades.
+    CBBO_1M
+        Consolidated best bid and offer subsampled at one-minute intervals, in addition to
+        trades.
+    TCBBO
+        All trade events with the consolidated best bid and offer (CBBO) immediately **before**
+        the effect of the trade.
+    BBO_1S
+        Best bid and offer subsampled at one-second intervals, in addition to trades.
+    BBO_1M
+        Best bid and offer subsampled at one-minute intervals, in addition to trades.
+
+    """
+
+    MBO: str
+    MBP_1: str
+    MBP_10: str
+    TBBO: str
+    TRADES: str
+    OHLCV_1S: str
+    OHLCV_1M: str
+    OHLCV_1H: str
+    OHLCV_1D: str
+    DEFINITION: str
+    STATISTICS: str
+    STATUS: str
+    IMBALANCE: str
+    OHLCV_EOD: str
+    CMBP_1: str
+    CBBO_1S: str
+    CBBO_1M: str
+    TCBBO: str
+    BBO_1S: str
+    BBO_1M: str
+
+    @classmethod
+    def from_str(cls, value: str) -> Schema: ...
+    @classmethod
+    def from_int(cls, value: int) -> Schema: ...
+    @classmethod
+    def variants(cls) -> Iterable[Schema]: ...
+
+class Encoding(Enum):
+    """
+    A data encoding format.
+
+    DBN
+        Databento Binary Encoding.
+    CSV
+        Comma-separated values.
+    JSON
+        JavaScript object notation.
+
+    """
+
+    DBN: str
+    CSV: str
+    JSON: str
+
+    @classmethod
+    def from_str(cls, value: str) -> Encoding: ...
+    @classmethod
+    def from_int(cls, value: int) -> Encoding: ...
+    @classmethod
+    def variants(cls) -> Iterable[Encoding]: ...
+
+class Compression(Enum):
+    """
+    A compression format or none if uncompressed.
+
+    NONE
+        Uncompressed.
+    ZSTD
+        Zstandard compressed.
+
+    """
+
+    NONE: str
+    ZSTD: str
+
+    @classmethod
+    def from_str(cls, value: str) -> Compression: ...
+    @classmethod
+    def from_int(cls, value: int) -> Compression: ...
+    @classmethod
+    def variants(cls) -> Iterable[Compression]: ...
+
+class StatType(Enum):
+    """
+    The type of statistic contained in a `StatMsg`.
+
+    OPENING_PRICE
+        The price of the first trade of an instrument. `price` will be set.
+        `quantity` will be set when provided by the venue.
+    INDICATIVE_OPENING_PRICE
+        The probable price of the first trade of an instrument published during pre-
+        open. Both `price` and `quantity` will be set.
+    SETTLEMENT_PRICE
+        The settlement price of an instrument. `price` will be set and `flags` indicate
+        whether the price is final or preliminary and actual or theoretical. `ts_ref`
+        will indicate the trading date of the settlement price.
+    TRADING_SESSION_LOW_PRICE
+        The lowest trade price of an instrument during the trading session. `price` will
+        be set.
+    TRADING_SESSION_HIGH_PRICE
+        The highest trade price of an instrument during the trading session. `price` will
+        be set.
+    CLEARED_VOLUME
+        The number of contracts cleared for an instrument on the previous trading date.
+        `quantity` will be set. `ts_ref` will indicate the trading date of the volume.
+    LOWEST_OFFER
+        The lowest offer price for an instrument during the trading session. `price`
+        will be set.
+    HIGHEST_BID
+        The highest bid price for an instrument during the trading session. `price`
+        will be set.
+    OPEN_INTEREST
+        The current number of outstanding contracts of an instrument. `quantity` will
+        be set. `ts_ref` will indicate the trading date for which the open interest was
+        calculated.
+    FIXING_PRICE
+        The volume-weighted average price (VWAP) for a fixing period. `price` will be
+        set.
+    CLOSE_PRICE
+        The last trade price during a trading session. `price` will be set.
+        `quantity` will be set when provided by the venue.
+    NET_CHANGE
+        The change in price from the close price of the previous trading session to the
+        most recent trading session. `price` will be set.
+    VWAP
+        The volume-weighted average price (VWAP) during the trading session.
+        `price` will be set to the VWAP while `quantity` will be the traded
+        volume.
+    VOLATILITY
+        The implied volatility associated with the settlement price. `price` will be set
+        with the standard precision.
+    DELTA
+        The option delta associated with the settlement price. `price` will be set with
+        the standard precision.
+    UNCROSSING_PRICE
+        The auction uncrossing price. This is used for auctions that are neither the
+        official opening auction nor the official closing auction. `price` will be set.
+        `quantity` will be set when provided by the venue.
+
+    """
+
+    OPENING_PRICE: int
+    INDICATIVE_OPENING_PRICE: int
+    SETTLEMENT_PRICE: int
+    TRADING_SESSION_LOW_PRICE: int
+    TRADING_SESSION_HIGH_PRICE: int
+    CLEARED_VOLUME: int
+    LOWEST_OFFER: int
+    HIGHEST_BID: int
+    OPEN_INTEREST: int
+    FIXING_PRICE: int
+    CLOSE_PRICE: int
+    NET_CHANGE: int
+    VWAP: int
+    VOLATILITY: int
+    DELTA: int
+    UNCROSSING_PRICE: int
+
+    @classmethod
+    def from_int(cls, value: int) -> StatType: ...
+    @classmethod
+    def variants(cls) -> Iterable[StatType]: ...
+
+class StatUpdateAction(Enum):
+    """
+    The type of `StatMsg` update.
+
+    NEW
+        A new statistic.
+    DELETE
+        A removal of a statistic.
+
+    """
+
+    NEW: int
+    DELETE: int
+
+    @classmethod
+    def from_int(cls, value: int) -> StatUpdateAction: ...
+    @classmethod
+    def variants(cls) -> Iterable[StatUpdateAction]: ...
+
+class StatusAction(Enum):
+    """
+    The primary enum for the type of `StatusMsg` update.
+
+    NONE
+        No change.
+    PRE_OPEN
+        The instrument is in a pre-open period.
+    PRE_CROSS
+        The instrument is in a pre-cross period.
+    QUOTING
+        The instrument is quoting but not trading.
+    CROSS
+        The instrument is in a cross/auction.
+    ROTATION
+        The instrument is being opened through a trading rotation.
+    NEW_PRICE_INDICATION
+        A new price indication is available for the instrument.
+    TRADING
+        The instrument is trading.
+    HALT
+        Trading in the instrument has been halted.
+    PAUSE
+        Trading in the instrument has been paused.
+    SUSPEND
+        Trading in the instrument has been suspended.
+    PRE_CLOSE
+        The instrument is in a pre-close period.
+    CLOSE
+        Trading in the instrument has closed.
+    POST_CLOSE
+        The instrument is in a post-close period.
+    SSR_CHANGE
+        A change in short-selling restrictions.
+    NOT_AVAILABLE_FOR_TRADING
+        The instrument is not available for trading, either trading has closed or been halted.
+
+    """
+
+    NONE: int
+    PRE_OPEN: int
+    PRE_CROSS: int
+    QUOTING: int
+    CROSS: int
+    ROTATION: int
+    NEW_PRICE_INDICATION: int
+    TRADING: int
+    HALT: int
+    PAUSE: int
+    SUSPEND: int
+    PRE_CLOSE: int
+    CLOSE: int
+    POST_CLOSE: int
+    SSR_CHANGE: int
+    NOT_AVAILABLE_FOR_TRADING: int
+
+    @classmethod
+    def from_int(cls, value: int) -> StatusAction: ...
+    @classmethod
+    def variants(cls) -> Iterable[StatusAction]: ...
+
+class StatusReason(Enum):
+    """
+    The secondary enum for a `StatusMsg` update, explains
+    the cause of a halt or other change in `action`.
+
+    NONE
+        No reason is given.
+    SCHEDULED
+        The change in status occurred as scheduled.
+    SURVEILLANCE_INTERVENTION
+        The instrument stopped due to a market surveillance intervention.
+    MARKET_EVENT
+        The status changed due to activity in the market.
+    INSTRUMENT_ACTIVATION
+        The derivative instrument began trading.
+    INSTRUMENT_EXPIRATION
+        The derivative instrument expired.
+    RECOVERY_IN_PROCESS
+        Recovery in progress.
+    REGULATORY
+        The status change was caused by a regulatory action.
+    ADMINISTRATIVE
+        The status change was caused by an administrative action.
+    NON_COMPLIANCE
+        The status change was caused by the issuer not being compliance with regulatory
+        requirements.
+    FILINGS_NOT_CURRENT
+        Trading halted because the issuer's filings are not current.
+    SEC_TRADING_SUSPENSION
+        Trading halted due to an SEC trading suspension.
+    NEW_ISSUE
+        The status changed because a new issue is available.
+    ISSUE_AVAILABLE
+        The status changed because an issue is available.
+    ISSUES_REVIEWED
+        The status changed because the issue(s) were reviewed.
+    FILING_REQS_SATISFIED
+        The status changed because the filing requirements were satisfied.
+    NEWS_PENDING
+        Relevant news is pending.
+    NEWS_RELEASED
+        Relevant news was released.
+    NEWS_AND_RESUMPTION_TIMES
+        The news has been fully disseminated and times are available for the resumption
+        in quoting and trading.
+    NEWS_NOT_FORTHCOMING
+        The relevant news was not forthcoming.
+    ORDER_IMBALANCE
+        Halted for order imbalance.
+    LULD_PAUSE
+        The instrument hit limit up or limit down.
+    OPERATIONAL
+        An operational issue occurred with the venue.
+    ADDITIONAL_INFORMATION_REQUESTED
+        The status changed until the exchange receives additional information.
+    MERGER_EFFECTIVE
+        Trading halted due to merger becoming effective.
+    ETF
+        Trading is halted in an ETF due to conditions with the component securities.
+    CORPORATE_ACTION
+        Trading is halted for a corporate action.
+    NEW_SECURITY_OFFERING
+        Trading is halted because the instrument is a new offering.
+    MARKET_WIDE_HALT_LEVEL1
+        Halted due to the market-wide circuit breaker level 1.
+    MARKET_WIDE_HALT_LEVEL2
+        Halted due to the market-wide circuit breaker level 2.
+    MARKET_WIDE_HALT_LEVEL3
+        Halted due to the market-wide circuit breaker level 3.
+    MARKET_WIDE_HALT_CARRYOVER
+        Halted due to the carryover of a market-wide circuit breaker from the previous
+        trading day.
+    MARKET_WIDE_HALT_RESUMPTION
+        Resumption due to the end of a market-wide circuit breaker halt.
+    QUOTATION_NOT_AVAILABLE
+        Halted because quotation is not available.
+
+    """
+
+    NONE: int
+    SCHEDULED: int
+    SURVEILLANCE_INTERVENTION: int
+    MARKET_EVENT: int
+    INSTRUMENT_ACTIVATION: int
+    INSTRUMENT_EXPIRATION: int
+    RECOVERY_IN_PROCESS: int
+    REGULATORY: int
+    ADMINISTRATIVE: int
+    NON_COMPLIANCE: int
+    FILINGS_NOT_CURRENT: int
+    SEC_TRADING_SUSPENSION: int
+    NEW_ISSUE: int
+    ISSUE_AVAILABLE: int
+    ISSUES_REVIEWED: int
+    FILING_REQS_SATISFIED: int
+    NEWS_PENDING: int
+    NEWS_RELEASED: int
+    NEWS_AND_RESUMPTION_TIMES: int
+    NEWS_NOT_FORTHCOMING: int
+    ORDER_IMBALANCE: int
+    LULD_PAUSE: int
+    OPERATIONAL: int
+    ADDITIONAL_INFORMATION_REQUESTED: int
+    MERGER_EFFECTIVE: int
+    ETF: int
+    CORPORATE_ACTION: int
+    NEW_SECURITY_OFFERING: int
+    MARKET_WIDE_HALT_LEVEL1: int
+    MARKET_WIDE_HALT_LEVEL2: int
+    MARKET_WIDE_HALT_LEVEL3: int
+    MARKET_WIDE_HALT_CARRYOVER: int
+    MARKET_WIDE_HALT_RESUMPTION: int
+    QUOTATION_NOT_AVAILABLE: int
+
+    @classmethod
+    def from_int(cls, value: int) -> StatusReason: ...
+    @classmethod
+    def variants(cls) -> Iterable[StatusReason]: ...
+
+class TradingEvent(Enum):
+    """
+    Further information about a status update.
+
+    NONE
+        No additional information given.
+    NO_CANCEL
+        Order entry and modification are not allowed.
+    CHANGE_TRADING_SESSION
+        A change of trading session occurred. Daily statistics are reset.
+    IMPLIED_MATCHING_ON
+        Implied matching is available.
+    IMPLIED_MATCHING_OFF
+        Implied matching is not available.
+
+    """
+
+    NONE: int
+    NO_CANCEL: int
+    CHANGE_TRADING_SESSION: int
+    IMPLIED_MATCHING_ON: int
+    IMPLIED_MATCHING_OFF: int
+
+    @classmethod
+    def from_int(cls, value: int) -> TradingEvent: ...
+    @classmethod
+    def variants(cls) -> Iterable[TradingEvent]: ...
+
+class TriState(Enum):
+    """
+    An enum for representing unknown, true, or false values.
+
+    NOT_AVAILABLE
+        The value is not applicable or not known.
+    NO
+        False.
+    YES
+        True.
+
+    """
+
+    NOT_AVAILABLE: str
+    NO: str
+    YES: str
+
+    @classmethod
+    def from_str(cls, value: str) -> TriState: ...
+    @classmethod
+    def variants(cls) -> Iterable[TriState]: ...
+
+class VersionUpgradePolicy(Enum):
+    """
+    How to handle decoding DBN data from other versions.
+
+    AS_IS
+        Decode data from all supported versions (less than or equal to
+        `DBN_VERSION`) as-is.
+    UPGRADE_TO_V2
+        Decode and convert data from DBN versions prior to version 2 to that version.
+        Attempting to decode data from newer versions will fail.
+    UPGRADE_TO_V3
+        Decode and convert data from DBN versions prior to version 3 to that version.
+        Attempting to decode data from newer versions (when they're introduced) will
+        fail.
+
+    """
+
+    AS_IS: int
+    UPGRADE_TO_V2: int
+    UPGRADE_TO_V3: int
+
+    @classmethod
+    def variants(cls) -> Iterable[VersionUpgradePolicy]: ...
+
+class ErrorCode(Enum):
+    """
+    An error code from the live subscription gateway.
+
+    AUTH_FAILED
+        The authentication step failed.
+    API_KEY_DEACTIVATED
+        The user account or API key were deactivated.
+    CONNECTION_LIMIT_EXCEEDED
+        The user has exceeded their open connection limit.
+    SYMBOL_RESOLUTION_FAILED
+        One or more symbols failed to resolve.
+    INVALID_SUBSCRIPTION
+        There was an issue with a subscription request (other than symbol resolution).
+    INTERNAL_ERROR
+        An error occurred in the gateway.
+
+    """
+
+    AUTH_FAILED: str
+    API_KEY_DEACTIVATED: str
+    CONNECTION_LIMIT_EXCEEDED: str
+    SYMBOL_RESOLUTION_FAILED: str
+    INVALID_SUBSCRIPTION: str
+    INTERNAL_ERROR: str
+
+    @classmethod
+    def from_str(cls, value: str) -> ErrorCode: ...
+    @classmethod
+    def from_int(cls, value: int) -> ErrorCode: ...
+    @classmethod
+    def variants(cls) -> Iterable[ErrorCode]: ...
+
+class SystemCode(Enum):
+    """
+    A `SystemMsg` code indicating the type of message from the live
+    subscription gateway.
+
+    HEARTBEAT
+        A message sent in the absence of other records to indicate the connection
+        remains open.
+    SUBSCRIPTION_ACK
+        An acknowledgement of a subscription request.
+    SLOW_READER_WARNING
+        The gateway has detected this session is falling behind real-time.
+    REPLAY_COMPLETED
+        Indicates a replay subscription has caught up with real-time data.
+
+    """
+
+    HEARTBEAT: str
+    SUBSCRIPTION_ACK: str
+    SLOW_READER_WARNING: str
+    REPLAY_COMPLETED: str
+
+    @classmethod
+    def from_str(cls, value: str) -> SystemCode: ...
+    @classmethod
+    def from_int(cls, value: int) -> SystemCode: ...
+    @classmethod
+    def variants(cls) -> Iterable[SystemCode]: ...
+
+class MBOMsg(Record):
+    """
+    A market-by-order (MBO) tick message. The record of the MBO schema.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        order_id,
+        price,
+        size,
+        action,
+        side,
+        ts_recv,
+        flags=None,
+        channel_id=0,
+        ts_in_delta=0,
+        sequence=0,
+    ) -> None: ...
     @property
     def order_id(self) -> int:
         """
@@ -1320,7 +1401,7 @@ class _MBOBase:
         The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1357,8 +1438,7 @@ class _MBOBase:
     @property
     def channel_id(self) -> int:
         """
-        The channel ID assigned by Databento as an incrementing integer starting at
-        zero.
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
 
         Returns
         -------
@@ -1367,31 +1447,29 @@ class _MBOBase:
         """
 
     @property
-    def action(self) -> str:
+    def action(self) -> Action:
         """
-        The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book, **T**rade,
-        **F**ill, or **N**one.
+        The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book, **T**rade, **F**ill, or **N**one.
 
-        See `Action` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action.
+        See [Action](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action).
 
         Returns
         -------
-        str
+        Action
 
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
-        The side that initiates the event. Can be **A**sk for a sell order
-        (or sell aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade),
-        or **N**one where no side is specified.
+        The side that initiates the event. Can be **A**sk for a sell order (or sell aggressor in
+        a trade), **B**id for a buy order (or buy aggressor in a trade), or **N**one where no side is specified.
 
-        See `Side` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side.
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -1413,7 +1491,7 @@ class _MBOBase:
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -1427,7 +1505,7 @@ class _MBOBase:
         The matching-engine-sending timestamp expressed as the number of nanoseconds before
         `ts_recv`.
 
-        See `ts_in_delta` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta.
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
 
         Returns
         -------
@@ -1446,41 +1524,20 @@ class _MBOBase:
 
         """
 
-class MBOMsg(Record, _MBOBase):
+class BidAskPair(Record):
     """
-    A market-by-order (MBO) tick message.
+    A price level.
+
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        order_id: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        ts_recv: int,
-        flags: int | None = None,
-        channel_id: int | None = None,
-        ts_in_delta: int | None = None,
-        sequence: int | None = None,
-    ) -> None: ...
-
-class BidAskPair:
-    """
-    A book level.
-    """
-
-    def __init__(
-        self,
-        bid_px: int = UNDEF_PRICE,
-        ask_px: int = UNDEF_PRICE,
-        bid_sz: int = 0,
-        ask_sz: int = 0,
-        bid_ct: int = 0,
-        ask_ct: int = 0,
+        bid_px=UNDEF_PRICE,
+        ask_px=UNDEF_PRICE,
+        bid_sz=0,
+        ask_sz=0,
+        bid_ct=0,
+        ask_ct=0,
     ) -> None: ...
     @property
     def pretty_bid_px(self) -> float:
@@ -1503,7 +1560,7 @@ class BidAskPair:
         The bid price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1536,7 +1593,7 @@ class BidAskPair:
         The ask price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1592,19 +1649,20 @@ class BidAskPair:
 
         """
 
-class ConsolidatedBidAskPair:
+class ConsolidatedBidAskPair(Record):
     """
-    A consolidated book level.
+    A price level consolidated from multiple venues.
+
     """
 
     def __init__(
         self,
-        bid_px: int = UNDEF_PRICE,
-        ask_px: int = UNDEF_PRICE,
-        bid_sz: int = 0,
-        ask_sz: int = 0,
-        bid_pb: int = 0,
-        ask_pb: int = 0,
+        bid_px=UNDEF_PRICE,
+        ask_px=UNDEF_PRICE,
+        bid_sz=0,
+        ask_sz=0,
+        bid_pb=0,
+        ask_pb=0,
     ) -> None: ...
     @property
     def pretty_bid_px(self) -> float:
@@ -1627,7 +1685,7 @@ class ConsolidatedBidAskPair:
         The bid price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1660,7 +1718,7 @@ class ConsolidatedBidAskPair:
         The ask price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1699,22 +1757,11 @@ class ConsolidatedBidAskPair:
         """
         The publisher ID indicating the venue containing the best bid.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
+        See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues).
 
         Returns
         -------
         int
-
-        """
-
-    @property
-    def pretty_bid_pb(self) -> Optional[str]:
-        """
-        The human-readable bid publisher.
-
-        Returns
-        -------
-        Optional[str]
 
         """
 
@@ -1723,7 +1770,7 @@ class ConsolidatedBidAskPair:
         """
         The publisher ID indicating the venue containing the best ask.
 
-        See `Publishers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues.
+        See [Publishers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#publishers-datasets-and-venues).
 
         Returns
         -------
@@ -1731,26 +1778,31 @@ class ConsolidatedBidAskPair:
 
         """
 
-    @property
-    def pretty_ask_pb(self) -> Optional[str]:
-        """
-        The human-readable ask publisher.
-
-        Returns
-        -------
-        Optional[str]
-
-        """
-
-class _MBPBase:
+class TradeMsg(Record):
     """
-    Base for market-by-price messages.
+    Market-by-price implementation with a book depth of 0. Equivalent to MBP-0. The record of the Trades schema.
+
     """
 
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        action,
+        side,
+        depth,
+        ts_recv,
+        flags=None,
+        ts_in_delta=0,
+        sequence=0,
+    ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
-        The order price as a float.
+        The price as a float.
 
         Returns
         -------
@@ -1765,10 +1817,9 @@ class _MBPBase:
     @property
     def price(self) -> int:
         """
-        The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
-        0.000000001.
+        The trade price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -1792,30 +1843,28 @@ class _MBPBase:
         """
 
     @property
-    def action(self) -> str:
+    def action(self) -> Action:
         """
-        The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book or **T**rade.
+        The event action. Always **T**rade in the trades schema.
 
-        See `Action` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action.
+        See [Action](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action).
 
         Returns
         -------
-        str
+        Action
 
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
-        The side that initiates the event. Can be **A**sk for a sell order
-        (or sell aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade),
-        or **N**one where no side is specified.
+        The side that initiates the trade. Can be **A**sk for a sell aggressor in a trade, **B**id for a buy aggressor in a trade, or **N**one where no side is specified.
 
-        See `Side` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side.
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -1833,7 +1882,7 @@ class _MBPBase:
     @property
     def depth(self) -> int:
         """
-        The depth of actual book change.
+        The book level where the update event occurred.
 
         Returns
         -------
@@ -1859,7 +1908,7 @@ class _MBPBase:
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -1873,7 +1922,7 @@ class _MBPBase:
         The matching-engine-sending timestamp expressed as the number of nanoseconds before
         `ts_recv`.
 
-        See `ts_in_delta` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta.
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
 
         Returns
         -------
@@ -1892,51 +1941,173 @@ class _MBPBase:
 
         """
 
-class TradeMsg(Record, _MBPBase):
+class MBP1Msg(Record):
     """
-    Market by price implementation with a book depth of 0.
+    Market-by-price implementation with a known book depth of 1. The record of the MBP-1
+    schema.
 
-    Equivalent to MBP-0. The record of the `Trades` schema.
-
-    """
-
-    def __init__(
-        self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        depth: int,
-        ts_recv: int,
-        flags: int | None = None,
-        ts_in_delta: int | None = None,
-        sequence: int | None = None,
-    ) -> None: ...
-
-class MBP1Msg(Record, _MBPBase):
-    """
-    Market by price implementation with a known book depth of 1.
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        depth: int,
-        ts_recv: int,
-        flags: int | None = None,
-        ts_in_delta: int | None = None,
-        sequence: int | None = None,
-        levels: BidAskPair | None = None,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        action,
+        side,
+        depth,
+        ts_recv,
+        flags=None,
+        ts_in_delta=0,
+        sequence=0,
+        levels=None,
     ) -> None: ...
+    @property
+    def pretty_price(self) -> float:
+        """
+        The order price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price
+
+        """
+
+    @property
+    def price(self) -> int:
+        """
+        The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
+        0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price
+
+        """
+
+    @property
+    def size(self) -> int:
+        """
+        The order quantity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def action(self) -> Action:
+        """
+        The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book, or **T**rade.
+
+        See [Action](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action).
+
+        Returns
+        -------
+        Action
+
+        """
+
+    @property
+    def side(self) -> Side:
+        """
+        The side that initiates the event. Can be **A**sk for a sell order (or sell aggressor in
+        a trade), **B**id for a buy order (or buy aggressor in a trade), or **N**one where no side is specified.
+
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
+
+        Returns
+        -------
+        Side
+
+        """
+
+    @property
+    def flags(self) -> int:
+        """
+        A bit field indicating event end, message characteristics, and data quality.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def depth(self) -> int:
+        """
+        The book level where the update event occurred.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def ts_in_delta(self) -> int:
+        """
+        The matching-engine-sending timestamp expressed as the number of nanoseconds before
+        `ts_recv`.
+
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sequence(self) -> int:
+        """
+        The message sequence number assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+
     @property
     def levels(self) -> list[BidAskPair]:
         """
@@ -1952,30 +2123,33 @@ class MBP1Msg(Record, _MBPBase):
 
         """
 
-class BBOMsg(Record):
+class MBP10Msg(Record):
     """
-    Subsampled market by price with a known book depth of 1.
+    Market-by-price implementation with a known book depth of 10. The record of the MBP-10
+    schema.
+
     """
 
     def __init__(
         self,
-        rtype: int,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        ts_recv: int,
-        flags: int | None = None,
-        sequence: int | None = None,
-        levels: BidAskPair | None = None,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        action,
+        side,
+        depth,
+        ts_recv,
+        flags=None,
+        ts_in_delta=0,
+        sequence=0,
+        levels=None,
     ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
-        The price of the last trade as a float.
+        The order price as a float.
 
         Returns
         -------
@@ -1990,10 +2164,190 @@ class BBOMsg(Record):
     @property
     def price(self) -> int:
         """
-        The order price of the last trade where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
+        The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
+        0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price
+
+        """
+
+    @property
+    def size(self) -> int:
+        """
+        The order quantity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def action(self) -> Action:
+        """
+        The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book, or **T**rade.
+
+        See [Action](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action).
+
+        Returns
+        -------
+        Action
+
+        """
+
+    @property
+    def side(self) -> Side:
+        """
+        The side that initiates the event. Can be **A**sk for a sell order (or sell aggressor in
+        a trade), **B**id for a buy order (or buy aggressor in a trade), or **N**one where no side is specified.
+
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
+
+        Returns
+        -------
+        Side
+
+        """
+
+    @property
+    def flags(self) -> int:
+        """
+        A bit field indicating event end, message characteristics, and data quality.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def depth(self) -> int:
+        """
+        The book level where the update event occurred.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def ts_in_delta(self) -> int:
+        """
+        The matching-engine-sending timestamp expressed as the number of nanoseconds before
+        `ts_recv`.
+
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sequence(self) -> int:
+        """
+        The message sequence number assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def levels(self) -> list[BidAskPair]:
+        """
+        The top 10 levels of the order book.
+
+        Returns
+        -------
+        list[BidAskPair]
+
+        Notes
+        -----
+        MBP10Msg contains 10 levels of BidAskPair.
+
+        """
+
+class BBOMsg(Record):
+    """
+    Subsampled market by price with a known book depth of 1. The record of the BBO-1s and
+    BBO-1m schemas.
+
+    """
+
+    def __init__(
+        self,
+        rtype,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        side,
+        ts_recv,
+        flags=None,
+        sequence=0,
+        levels=None,
+    ) -> None: ...
+    @property
+    def pretty_price(self) -> float:
+        """
+        The last trade price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price
+
+        """
+
+    @property
+    def price(self) -> int:
+        """
+        The last trade price price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
+        or 0.000000001. Will be `UNDEF_PRICE` if there was no last trade in the session.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2017,16 +2371,17 @@ class BBOMsg(Record):
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
-        The side that initiated the last trade. Can be **A**sk for a sell aggressor in a trade,
-        **B**id for a buy aggressor in a trade, or **N**one where no side is specified.
+        The side that initiated the last trade. Can be **A**sk for a sell order (or sell
+        aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
+        **N**one where no side is specified.
 
-        See `Side` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side.
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -2044,8 +2399,8 @@ class BBOMsg(Record):
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
         """
-        The end timestamp of the interval, clamped to the second/minute boundary, expressed as
-        a datetime or`pandas.Timestamp`, if available.
+        The end timestamp of the interval capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -2056,8 +2411,10 @@ class BBOMsg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The end timestamp of the interval, clamped to the second/minute boundary,
-        expressed as the number of nanoseconds since the UNIX epoch.
+        The end timestamp of the interval capture-server-received timestamp expressed as the
+        number of nanoseconds since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -2093,23 +2450,25 @@ class BBOMsg(Record):
 
 class CMBP1Msg(Record):
     """
-    Consolidated best bid and offer implementation.
+    Consolidated market-by-price implementation with a known book depth of 1. The record of
+    the CMBP-1 schema.
+
     """
 
     def __init__(
         self,
-        rtype: int,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        ts_recv: int,
-        flags: int | None = None,
-        ts_in_delta: int | None = None,
-        levels: ConsolidatedBidAskPair | None = None,
+        rtype,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        action,
+        side,
+        ts_recv,
+        flags=None,
+        ts_in_delta=0,
+        levels=None,
     ) -> None: ...
     @property
     def pretty_price(self) -> float:
@@ -2132,7 +2491,7 @@ class CMBP1Msg(Record):
         The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
         0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2156,30 +2515,29 @@ class CMBP1Msg(Record):
         """
 
     @property
-    def action(self) -> str:
+    def action(self) -> Action:
         """
         The event action. Can be **A**dd, **C**ancel, **M**odify, clea**R** book, or **T**rade.
 
-        See `Action` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action.
+        See [Action](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#action).
 
         Returns
         -------
-        str
+        Action
 
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
-        The side that initiates the event. Can be **A**sk for a sell order
-        (or sell aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade),
-        or **N**one where no side is specified.
+        The side that initiates the event. Can be **A**sk for a sell order (or sell aggressor in
+        a trade), **B**id for a buy order (or buy aggressor in a trade), or **N**one where no side is specified.
 
-        See `Side` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side.
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -2197,8 +2555,8 @@ class CMBP1Msg(Record):
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
         """
-        The capture-server-received timestamp expressed as a datetime or `pandas.Timestamp`
-        if available.
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -2212,7 +2570,7 @@ class CMBP1Msg(Record):
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -2226,7 +2584,7 @@ class CMBP1Msg(Record):
         The matching-engine-sending timestamp expressed as the number of nanoseconds before
         `ts_recv`.
 
-        See `ts_in_delta` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta.
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
 
         Returns
         -------
@@ -2237,7 +2595,7 @@ class CMBP1Msg(Record):
     @property
     def levels(self) -> list[ConsolidatedBidAskPair]:
         """
-        The top of the consolidated order book.
+        The top of the order book.
 
         Returns
         -------
@@ -2251,26 +2609,27 @@ class CMBP1Msg(Record):
 
 class CBBOMsg(Record):
     """
-    Subsampled consolidated best bid and offer.
+    Subsampled consolidated market by price with a known book depth of 1. The record of the CBBO-1s and CBBO-1m schemas.
+
     """
 
     def __init__(
         self,
-        rtype: int,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        side: str,
-        ts_recv: int,
-        flags: int | None = None,
-        levels: ConsolidatedBidAskPair | None = None,
+        rtype,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        price,
+        size,
+        side,
+        ts_recv,
+        flags=None,
+        levels=None,
     ) -> None: ...
     @property
     def pretty_price(self) -> float:
         """
-        The order price of the last trade as a float.
+        The last trade price as a float.
 
         Returns
         -------
@@ -2285,10 +2644,10 @@ class CBBOMsg(Record):
     @property
     def price(self) -> int:
         """
-        The order price of the last trade where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
+        The last trade price price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
+        or 0.000000001. Will be `UNDEF_PRICE` if there was no last trade in the session.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2312,15 +2671,17 @@ class CBBOMsg(Record):
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
         The side that initiated the last trade. Can be **A**sk for a sell order (or sell
         aggressor in a trade), **B**id for a buy order (or buy aggressor in a trade), or
-        **N**one where no side is specified by the original source.
+        **N**one where no side is specified.
+
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -2338,8 +2699,8 @@ class CBBOMsg(Record):
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
         """
-        The end timestamp of the interval, clamped to the second/minute boundary,
-        expressed as a datetime or `pandas.Timestamp`, if available.
+        The end timestamp of the interval capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -2350,8 +2711,10 @@ class CBBOMsg(Record):
     @property
     def ts_recv(self) -> int:
         """
-        The end timestamp of the interval, clamped to the second/minute boundary,
-        expressed as the number of nanoseconds since the UNIX epoch.
+        The end timestamp of the interval capture-server-received timestamp expressed as the
+        number of nanoseconds since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -2366,71 +2729,53 @@ class CBBOMsg(Record):
 
         Returns
         -------
-        list[BidAskPair]
+        list[ConsolidatedBidAskPair]
 
         Notes
         -----
-        BBOMsg contains 1 level of ConsolidatedBidAskPair.
+        CBBOMsg contains 1 level of ConsolidatedBidAskPair.
 
         """
 
-class MBP10Msg(Record, _MBPBase):
-    """
-    Market by price implementation with a known book depth of 10.
-    """
+TBBOMsg = MBP1Msg
 
-    def __init__(
-        self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        price: int,
-        size: int,
-        action: str,
-        side: str,
-        depth: int,
-        ts_recv: int,
-        flags: int | None = None,
-        ts_in_delta: int | None = None,
-        sequence: int | None = None,
-        levels: list[BidAskPair] | None = None,
-    ) -> None: ...
-    @property
-    def levels(self) -> list[BidAskPair]:
-        """
-        The top 10 levels.
+BBO1SMsg = BBOMsg
 
-        Returns
-        -------
-        list[BidAskPair]
+BBO1MMsg = BBOMsg
 
-        Notes
-        -----
-        MBP10Msg contains 10 levels of BidAskPairs.
+TCBBOMsg = CMBP1Msg
 
-        """
+CBBO1SMsg = CBBOMsg
+
+CBBO1MMsg = CBBOMsg
 
 class OHLCVMsg(Record):
     """
-    Open, high, low, close, and volume message.
+    Open, high, low, close, and volume. The record of the following schemas:
+    - OHLCV-1s
+    - OHLCV-1m
+    - OHLCV-1h
+    - OHLCV-1d
+    - OHLCV-eod
+
     """
 
     def __init__(
         self,
-        rtype: int,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        open: int,
-        high: int,
-        low: int,
-        close: int,
-        volume: int,
+        rtype,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        open,
+        high,
+        low,
+        close,
+        volume,
     ) -> None: ...
     @property
     def pretty_open(self) -> float:
         """
-        The open price for the bar as a float.
+        The open price as a float.
 
         Returns
         -------
@@ -2448,7 +2793,7 @@ class OHLCVMsg(Record):
         The open price for the bar where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
         or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2463,7 +2808,7 @@ class OHLCVMsg(Record):
     @property
     def pretty_high(self) -> float:
         """
-        The high price for the bar as a float.
+        The high price as a float.
 
         Returns
         -------
@@ -2481,7 +2826,7 @@ class OHLCVMsg(Record):
         The high price for the bar where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
         or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2496,7 +2841,7 @@ class OHLCVMsg(Record):
     @property
     def pretty_low(self) -> float:
         """
-        The low price for the bar as a float.
+        The low price as a float.
 
         Returns
         -------
@@ -2514,7 +2859,7 @@ class OHLCVMsg(Record):
         The low price for the bar where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
         or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2529,7 +2874,7 @@ class OHLCVMsg(Record):
     @property
     def pretty_close(self) -> float:
         """
-        The close price for the bar as a float.
+        The close price as a float.
 
         Returns
         -------
@@ -2547,7 +2892,7 @@ class OHLCVMsg(Record):
         The close price for the bar where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000
         or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2570,85 +2915,24 @@ class OHLCVMsg(Record):
 
         """
 
-class InstrumentDefMsg(Record):
+class StatusMsg(Record):
     """
-    Definition of an instrument in DBN version 3.
+    A trading status update message. The record of the status schema.
+
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        ts_recv: int,
-        min_price_increment: int,
-        display_factor: int,
-        min_lot_size_round_lot: int,
-        raw_symbol: str,
-        group: str,
-        exchange: str,
-        instrument_class: str,
-        match_algorithm: str,
-        security_update_action: str,
-        expiration: int = UNDEF_TIMESTAMP,
-        activation: int = UNDEF_TIMESTAMP,
-        high_limit_price: int = UNDEF_PRICE,
-        low_limit_price: int = UNDEF_PRICE,
-        max_price_variation: int = UNDEF_PRICE,
-        unit_of_measure_qty: int = UNDEF_PRICE,
-        min_price_increment_amount: int = UNDEF_PRICE,
-        price_ratio: int = UNDEF_PRICE,
-        inst_attrib_value: int | None = None,
-        underlying_id: int | None = None,
-        raw_instrument_id: int | None = None,
-        market_depth_implied: int | None = None,
-        market_depth: int | None = None,
-        market_segment_id: int | None = None,
-        max_trade_vol: int | None = None,
-        min_lot_size: int | None = None,
-        min_lot_size_block: int | None = None,
-        min_trade_vol: int | None = None,
-        contract_multiplier: int | None = None,
-        decay_quantity: int | None = None,
-        original_contract_size: int | None = None,
-        appl_id: int | None = None,
-        maturity_year: int | None = None,
-        decay_start_date: int | None = None,
-        channel_id: int | None = None,
-        currency: str = "",
-        settl_currency: str = "",
-        secsubtype: str = "",
-        asset: str = "",
-        cfi: str = "",
-        security_type: str = "",
-        unit_of_measure: str = "",
-        underlying: str = "",
-        strike_price_currency: str = "",
-        strike_price: int = UNDEF_PRICE,
-        main_fraction: int | None = None,
-        price_display_format: int | None = None,
-        sub_fraction: int | None = None,
-        underlying_product: int | None = None,
-        maturity_month: int | None = None,
-        maturity_day: int | None = None,
-        maturity_week: int | None = None,
-        user_defined_instrument: str | None = None,
-        contract_multiplier_unit: int | None = None,
-        flow_schedule_type: int | None = None,
-        tick_rule: int | None = None,
-        leg_count: int = 0,
-        leg_index: int = 0,
-        leg_price: int = UNDEF_PRICE,
-        leg_delta: int = UNDEF_PRICE,
-        leg_instrument_id: int = 0,
-        leg_ratio_price_numerator: int = 0,
-        leg_ratio_price_denominator: int = 0,
-        leg_ratio_qty_numerator: int = 0,
-        leg_ratio_qty_denominator: int = 0,
-        leg_underlying_id: int = 0,
-        leg_raw_symbol: str = "",
-        leg_instrument_class: str | None = None,
-        leg_side: str | None = None,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        action=None,
+        reason=None,
+        trading_event=None,
+        is_trading=None,
+        is_quoting=None,
+        is_short_sell_restricted=None,
     ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
@@ -2668,7 +2952,180 @@ class InstrumentDefMsg(Record):
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def action(self) -> StatusAction:
+        """
+        The type of status change.
+
+        Returns
+        -------
+        StatusAction
+
+        """
+
+    @property
+    def reason(self) -> StatusReason:
+        """
+        Additional details about the cause of the status change.
+
+        Returns
+        -------
+        StatusReason
+
+        """
+
+    @property
+    def trading_event(self) -> TradingEvent:
+        """
+        Further information about the status change and its effect on trading.
+
+        Returns
+        -------
+        TradingEvent
+
+        """
+
+    @property
+    def is_trading(self) -> bool | None:
+        """
+        The best-efforts state of trading in the instrument, either `Y`, `N` or `~`.
+
+        Returns
+        -------
+        bool | None
+
+        """
+
+    @property
+    def is_quoting(self) -> bool | None:
+        """
+        The best-efforts state of quoting in the instrument, either `Y`, `N` or `~`.
+
+        Returns
+        -------
+        bool | None
+
+        """
+
+    @property
+    def is_short_sell_restricted(self) -> bool | None:
+        """
+        The best-efforts state of short sell restrictions for the instrument (if applicable), either `Y`, `N` or `~`.
+
+        Returns
+        -------
+        bool | None
+
+        """
+
+class InstrumentDefMsg(Record):
+    """
+    A definition of an instrument. The record of the definition schema.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        min_price_increment,
+        display_factor,
+        raw_symbol,
+        asset,
+        security_type,
+        instrument_class,
+        security_update_action,
+        expiration=UNDEF_TIMESTAMP,
+        activation=UNDEF_TIMESTAMP,
+        high_limit_price=UNDEF_PRICE,
+        low_limit_price=UNDEF_PRICE,
+        max_price_variation=UNDEF_PRICE,
+        unit_of_measure_qty=UNDEF_PRICE,
+        min_price_increment_amount=UNDEF_PRICE,
+        price_ratio=UNDEF_PRICE,
+        strike_price=UNDEF_PRICE,
+        raw_instrument_id=0,
+        leg_price=UNDEF_PRICE,
+        leg_delta=UNDEF_PRICE,
+        inst_attrib_value=0,
+        underlying_id=0,
+        market_depth_implied=None,
+        market_depth=None,
+        market_segment_id=None,
+        max_trade_vol=None,
+        min_lot_size=None,
+        min_lot_size_block=None,
+        min_lot_size_round_lot=None,
+        min_trade_vol=None,
+        contract_multiplier=None,
+        decay_quantity=None,
+        original_contract_size=None,
+        leg_instrument_id=0,
+        leg_ratio_price_numerator=0,
+        leg_ratio_price_denominator=0,
+        leg_ratio_qty_numerator=0,
+        leg_ratio_qty_denominator=0,
+        leg_underlying_id=0,
+        appl_id=None,
+        maturity_year=None,
+        decay_start_date=None,
+        channel_id=0,
+        leg_count=0,
+        leg_index=0,
+        currency="",
+        settl_currency="",
+        secsubtype="",
+        group="",
+        exchange="",
+        cfi="",
+        unit_of_measure="",
+        underlying="",
+        strike_price_currency="",
+        leg_raw_symbol="",
+        match_algorithm=None,
+        main_fraction=None,
+        price_display_format=None,
+        sub_fraction=None,
+        underlying_product=None,
+        maturity_month=None,
+        maturity_day=None,
+        maturity_week=None,
+        user_defined_instrument=None,
+        contract_multiplier_unit=None,
+        flow_schedule_type=None,
+        tick_rule=None,
+        leg_instrument_class=None,
+        leg_side=None,
+    ) -> None: ...
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -2679,7 +3136,7 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_min_price_increment(self) -> float:
         """
-        The minimum constant tick for the instrument as a float.
+        The minimum constant tick as a float.
 
         Returns
         -------
@@ -2697,7 +3154,7 @@ class InstrumentDefMsg(Record):
         The minimum constant tick for the instrument where every 1 unit corresponds to 1e-9, i.e.
         1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2710,26 +3167,41 @@ class InstrumentDefMsg(Record):
         """
 
     @property
+    def pretty_display_factor(self) -> float:
+        """
+        The display factor as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        display_factor
+
+        """
+
+    @property
     def display_factor(self) -> int:
         """
-        The multiplier to convert the venue’s display price to the conventional price where every
+        The multiplier to convert the venue's display price to the conventional price where every
         1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
 
         Returns
         -------
         int
+
+        See Also
+        --------
+        pretty_display_factor
 
         """
 
     @property
     def pretty_expiration(self) -> dt.datetime | None:
         """
-        The last eligible trade time expressed as a datetime or
+        The last eligible trade time as a datetime or
         `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
 
         Returns
         -------
@@ -2740,8 +3212,8 @@ class InstrumentDefMsg(Record):
     @property
     def expiration(self) -> int:
         """
-        The last eligible trade time expressed as a number of nanoseconds since
-        the UNIX epoch.
+        The last eligible trade time expressed as the number of nanoseconds since the
+        UNIX epoch.
 
         Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
         only provide date-level granularity.
@@ -2755,10 +3227,8 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_activation(self) -> dt.datetime | None:
         """
-        The time of instrument activation expressed as a datetime or
+        The time of instrument activation as a datetime or
         `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
 
         Returns
         -------
@@ -2769,8 +3239,8 @@ class InstrumentDefMsg(Record):
     @property
     def activation(self) -> int:
         """
-        The time of instrument activation expressed as a number of nanoseconds
-        since the UNIX epoch.
+        The time of instrument activation expressed as the number of nanoseconds since the
+        UNIX epoch.
 
         Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
         only provide date-level granularity.
@@ -2784,7 +3254,7 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_high_limit_price(self) -> float:
         """
-        The allowable high limit price for the trading day as a float.
+        The high limit price as a float.
 
         Returns
         -------
@@ -2802,7 +3272,7 @@ class InstrumentDefMsg(Record):
         The allowable high limit price for the trading day where every 1 unit corresponds to
         1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2817,7 +3287,7 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_low_limit_price(self) -> float:
         """
-        The allowable low limit price for the trading day as a float.
+        The low limit price as a float.
 
         Returns
         -------
@@ -2835,7 +3305,7 @@ class InstrumentDefMsg(Record):
         The allowable low limit price for the trading day where every 1 unit corresponds to
         1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2850,7 +3320,7 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_max_price_variation(self) -> float:
         """
-        The differential value for price banding in units as a float.
+        The differential value for price banding as a float.
 
         Returns
         -------
@@ -2868,7 +3338,7 @@ class InstrumentDefMsg(Record):
         The differential value for price banding where every 1 unit corresponds to 1e-9,
         i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2881,23 +3351,40 @@ class InstrumentDefMsg(Record):
         """
 
     @property
+    def pretty_unit_of_measure_qty(self) -> float:
+        """
+        The contract size for each instrument as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        unit_of_measure_qty
+
+        """
+
+    @property
     def unit_of_measure_qty(self) -> int:
         """
         The contract size for each instrument, in combination with `unit_of_measure`, where every
         1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
         Returns
         -------
         int
+
+        See Also
+        --------
+        pretty_unit_of_measure_qty
 
         """
 
     @property
     def pretty_min_price_increment_amount(self) -> float:
         """
-        The value currently under development by the venue as a float.
+        The min price increment amount as a float.
 
         Returns
         -------
@@ -2915,7 +3402,7 @@ class InstrumentDefMsg(Record):
         The value currently under development by the venue where every 1 unit corresponds to 1e-9,
         i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -2930,8 +3417,7 @@ class InstrumentDefMsg(Record):
     @property
     def pretty_price_ratio(self) -> float:
         """
-        The value used for price calculation in spread and leg pricing as a
-        float.
+        The price ratio as a float.
 
         Returns
         -------
@@ -2949,8 +3435,6 @@ class InstrumentDefMsg(Record):
         The value used for price calculation in spread and leg pricing where every 1 unit
         corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
         Returns
         -------
         int
@@ -2958,6 +3442,112 @@ class InstrumentDefMsg(Record):
         See Also
         --------
         pretty_price_ratio
+
+        """
+
+    @property
+    def pretty_strike_price(self) -> float:
+        """
+        The strike price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        strike_price
+
+        """
+
+    @property
+    def strike_price(self) -> int:
+        """
+        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_strike_price
+
+        """
+
+    @property
+    def raw_instrument_id(self) -> int:
+        """
+        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers)
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_leg_price(self) -> float:
+        """
+        The leg price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        leg_price
+
+        """
+
+    @property
+    def leg_price(self) -> int:
+        """
+        The tied price (if any) of the leg.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_leg_price
+
+        """
+
+    @property
+    def pretty_leg_delta(self) -> float:
+        """
+        The leg delta as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        leg_delta
+
+        """
+
+    @property
+    def leg_delta(self) -> int:
+        """
+        The associated delta (if any) of the leg.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_leg_delta
 
         """
 
@@ -2977,20 +3567,7 @@ class InstrumentDefMsg(Record):
         """
         The `instrument_id` of the first underlying instrument.
 
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def raw_instrument_id(self) -> int:
-        """
-        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
-
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
 
         Returns
         -------
@@ -3067,8 +3644,8 @@ class InstrumentDefMsg(Record):
     @property
     def min_lot_size_round_lot(self) -> int:
         """
-        The minimum quantity required for a round lot of the instrument.
-        Multiples of this quantity are also round lots.
+        The minimum quantity required for a round lot of the instrument. Multiples of this
+        quantity are also round lots.
 
         Returns
         -------
@@ -3101,8 +3678,7 @@ class InstrumentDefMsg(Record):
     @property
     def decay_quantity(self) -> int:
         """
-        The quantity that a contract will decay daily, after `decay_start_date`
-        has been reached.
+        The quantity that a contract will decay daily, after `decay_start_date` has been reached.
 
         Returns
         -------
@@ -3114,6 +3690,76 @@ class InstrumentDefMsg(Record):
     def original_contract_size(self) -> int:
         """
         The fixed contract value assigned to each instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_instrument_id(self) -> int:
+        """
+        The numeric ID assigned to the leg instrument.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_ratio_price_numerator(self) -> int:
+        """
+        The numerator of the price ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_ratio_price_denominator(self) -> int:
+        """
+        The denominator of the price ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_ratio_qty_numerator(self) -> int:
+        """
+        The numerator of the quantity ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_ratio_qty_denominator(self) -> int:
+        """
+        The denominator of the quantity ratio of the leg within the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_underlying_id(self) -> int:
+        """
+        The numeric ID of the leg instrument's underlying instrument.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
 
         Returns
         -------
@@ -3157,8 +3803,29 @@ class InstrumentDefMsg(Record):
     @property
     def channel_id(self) -> int:
         """
-        The channel ID assigned by Databento as an incrementing integer
-        starting at zero.
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_count(self) -> int:
+        """
+        The number of legs in the strategy or spread. Will be 0 for outrights.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_index(self) -> int:
+        """
+        The 0-based index of the leg.
 
         Returns
         -------
@@ -3259,7 +3926,7 @@ class InstrumentDefMsg(Record):
         """
         The security type of the instrument, e.g. FUT for future or future spread.
 
-        See `Security Type` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type.
+        See [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type).
 
         Returns
         -------
@@ -3270,8 +3937,7 @@ class InstrumentDefMsg(Record):
     @property
     def unit_of_measure(self) -> str:
         """
-        The unit of measure for the instrument’s original contract size, e.g.
-        USD or LBS.
+        The unit of measure for the instrument’s original contract size, e.g. USD or LBS.
 
         Returns
         -------
@@ -3298,388 +3964,6 @@ class InstrumentDefMsg(Record):
         Returns
         -------
         str
-
-        """
-
-    @property
-    def instrument_class(self) -> str:
-        """
-        The classification of the instrument.
-
-        See `Instrument class` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def pretty_strike_price(self) -> float:
-        """
-        The strike price of the option as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        strike_price
-
-        """
-
-    @property
-    def strike_price(self) -> int:
-        """
-        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_strike_price
-
-        """
-
-    @property
-    def match_algorithm(self) -> str:
-        """
-        The matching algorithm used for the instrument, typically **F**IFO.
-
-        See `Matching algorithm` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def main_fraction(self) -> int:
-        """
-        The price denominator of the main fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def price_display_format(self) -> int:
-        """
-        The number of digits to the right of the tick mark, to display
-        fractional prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def sub_fraction(self) -> int:
-        """
-        The price denominator of the sub fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def underlying_product(self) -> int:
-        """
-        The product complex of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def security_update_action(self) -> str:
-        """
-        Indicates if the instrument definition has been added, modified, or
-        deleted.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def maturity_month(self) -> int:
-        """
-        The calendar month reflected in the instrument symbol.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_day(self) -> int:
-        """
-        The calendar day reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_week(self) -> int:
-        """
-        The calendar week reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def user_defined_instrument(self) -> str:
-        """
-        Indicates if the instrument is user defined: **Y**es or **N**o.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def contract_multiplier_unit(self) -> int:
-        """
-        The type of `contract_multiplier`. Either `1` for hours, or `2` for
-        days.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def flow_schedule_type(self) -> int:
-        """
-        The schedule for delivering electricity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def tick_rule(self) -> int:
-        """
-        The tick rule of the spread.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def leg_count(self) -> int:
-        """
-        The number of legs in the strategy or spread. Will be 0 for outrights.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_index
-
-        """
-
-    @property
-    def leg_index(self) -> int:
-        """
-        The 0-based index of the leg.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_count
-
-        """
-
-    @property
-    def pretty_leg_price(self) -> float:
-        """
-        The leg price as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        leg_price
-
-        """
-
-    @property
-    def leg_price(self) -> int:
-        """
-        The leg price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
-        0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_leg_price
-
-        """
-
-    @property
-    def pretty_leg_delta(self) -> float:
-        """
-        The leg delta as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        leg_delta
-
-        """
-
-    @property
-    def leg_delta(self) -> int:
-        """
-        The leg delta where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
-        0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_delta
-
-        """
-
-    @property
-    def leg_instrument_id(self) -> int:
-        """
-        The numeric ID assigned to the leg instrument.
-        See [Instrument identifiers] https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_raw_symbol
-
-        """
-
-    @property
-    def leg_ratio_price_numerator(self) -> int:
-        """
-        The numerator of the price ratio of the leg within the spread.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_ratio_price_denominator
-
-        """
-
-    @property
-    def leg_ratio_price_denominator(self) -> int:
-        """
-        The denominator of the price ratio of the leg within the spread.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_ratio_price_numerator
-
-        """
-
-    @property
-    def leg_ratio_qty_numerator(self) -> int:
-        """
-        The numerator of the quantity ratio of the leg within the spread.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_ratio_qty_denominator
-
-        """
-
-    @property
-    def leg_ratio_qty_denominator(self) -> int:
-        """
-        The denominator of the quantity ratio of the leg within the spread.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        leg_ratio_qty_numerator
-
-        """
-
-    @property
-    def leg_underlying_id(self) -> int:
-        """
-        The numeric ID of the leg instrument's underlying instrument.
-        See [Instrument identifiers] https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        instrument_id
 
         """
 
@@ -3692,2020 +3976,219 @@ class InstrumentDefMsg(Record):
         -------
         str
 
-        See Also
-        --------
-        leg_instrument_id
-
         """
 
     @property
-    def leg_instrument_class(self) -> str | None:
+    def instrument_class(self) -> InstrumentClass:
         """
-        The matching algorithm used for the instrument, typically **F**IFO.
-        See `Matching algorithm` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm.
+        The classification of the instrument.
+
+        See [Instrument class](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class).
 
         Returns
         -------
-        str | None
+        InstrumentClass
 
         """
 
     @property
-    def leg_side(self) -> str | None:
+    def match_algorithm(self) -> MatchAlgorithm:
+        """
+        The matching algorithm used for the instrument, typically **F**IFO.
+
+        See [Matching algorithm](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm).
+
+        Returns
+        -------
+        MatchAlgorithm
+
+        """
+
+    @property
+    def main_fraction(self) -> int:
+        """
+        The price denominator of the main fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def price_display_format(self) -> int:
+        """
+        The number of digits to the right of the tick mark, to display fractional prices.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sub_fraction(self) -> int:
+        """
+        The price denominator of the sub fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def underlying_product(self) -> int:
+        """
+        The product complex of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def security_update_action(self) -> SecurityUpdateAction:
+        """
+        Indicates if the instrument definition has been added, modified, or deleted.
+
+        Returns
+        -------
+        SecurityUpdateAction
+
+        """
+
+    @property
+    def maturity_month(self) -> int:
+        """
+        The calendar month reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_day(self) -> int:
+        """
+        The calendar day reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_week(self) -> int:
+        """
+        The calendar week reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def user_defined_instrument(self) -> UserDefinedInstrument:
+        """
+        Indicates if the instrument is user defined: **Y**es or **N**o.
+
+        Returns
+        -------
+        UserDefinedInstrument
+
+        """
+
+    @property
+    def contract_multiplier_unit(self) -> int:
+        """
+        The type of `contract_multiplier`. Either `1` for hours, or `2` for days.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def flow_schedule_type(self) -> int:
+        """
+        The schedule for delivering electricity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def tick_rule(self) -> int:
+        """
+        The tick rule of the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def leg_instrument_class(self) -> InstrumentClass:
+        """
+        The classification of the leg instrument.
+
+        Returns
+        -------
+        InstrumentClass
+
+        """
+
+    @property
+    def leg_side(self) -> Side:
         """
         The side taken for the leg when purchasing the spread.
 
         Returns
         -------
-        str | None
-
-        """
-
-class InstrumentDefMsgV2(Record):
-    """
-    Definition of an instrument in DBN version 2.
-    """
-
-    def __init__(
-        self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        ts_recv: int,
-        min_price_increment: int,
-        display_factor: int,
-        min_lot_size_round_lot: int,
-        raw_symbol: str,
-        group: str,
-        exchange: str,
-        instrument_class: str,
-        match_algorithm: str,
-        md_security_trading_status: str,
-        security_update_action: str,
-        expiration: int = UNDEF_TIMESTAMP,
-        activation: int = UNDEF_TIMESTAMP,
-        high_limit_price: int = UNDEF_PRICE,
-        low_limit_price: int = UNDEF_PRICE,
-        max_price_variation: int = UNDEF_PRICE,
-        trading_reference_price: int = UNDEF_PRICE,
-        unit_of_measure_qty: int = UNDEF_PRICE,
-        min_price_increment_amount: int = UNDEF_PRICE,
-        price_ratio: int = UNDEF_PRICE,
-        inst_attrib_value: int | None = None,
-        underlying_id: int | None = None,
-        raw_instrument_id: int | None = None,
-        market_depth_implied: int | None = None,
-        market_depth: int | None = None,
-        market_segment_id: int | None = None,
-        max_trade_vol: int | None = None,
-        min_lot_size: int | None = None,
-        min_lot_size_block: int | None = None,
-        min_trade_vol: int | None = None,
-        contract_multiplier: int | None = None,
-        decay_quantity: int | None = None,
-        original_contract_size: int | None = None,
-        trading_reference_date: int | None = None,
-        appl_id: int | None = None,
-        maturity_year: int | None = None,
-        decay_start_date: int | None = None,
-        channel_id: int | None = None,
-        currency: str = "",
-        settl_currency: str = "",
-        secsubtype: str = "",
-        asset: str = "",
-        cfi: str = "",
-        security_type: str = "",
-        unit_of_measure: str = "",
-        underlying: str = "",
-        strike_price_currency: str = "",
-        strike_price: int = UNDEF_PRICE,
-        main_fraction: int | None = None,
-        price_display_format: int | None = None,
-        settl_price_type: int | None = None,
-        sub_fraction: int | None = None,
-        underlying_product: int | None = None,
-        maturity_month: int | None = None,
-        maturity_day: int | None = None,
-        maturity_week: int | None = None,
-        user_defined_instrument: str | None = None,
-        contract_multiplier_unit: int | None = None,
-        flow_schedule_type: int | None = None,
-        tick_rule: int | None = None,
-    ) -> None: ...
-    @property
-    def pretty_ts_recv(self) -> dt.datetime | None:
-        """
-        The capture-server-received timestamp as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def ts_recv(self) -> int:
-        """
-        The capture-server-received timestamp expressed as the number of nanoseconds
-        since the UNIX epoch.
-
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_min_price_increment(self) -> float:
-        """
-        The minimum constant tick for the instrument as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        min_price_increment
-
-        """
-
-    @property
-    def min_price_increment(self) -> int:
-        """
-        The minimum constant tick for the instrument where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_min_price_increment
-
-        """
-
-    @property
-    def display_factor(self) -> int:
-        """
-        The multiplier to convert the venue’s display price to the conventional price where every
-        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_expiration(self) -> dt.datetime | None:
-        """
-        The last eligible trade time expressed as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def expiration(self) -> int:
-        """
-        The last eligible trade time expressed as a number of nanoseconds since
-        the UNIX epoch.
-
-        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
-        only provide date-level granularity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_activation(self) -> dt.datetime | None:
-        """
-        The time of instrument activation expressed as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def activation(self) -> int:
-        """
-        The time of instrument activation expressed as a number of nanoseconds
-        since the UNIX epoch.
-
-        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
-        only provide date-level granularity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_high_limit_price(self) -> float:
-        """
-        The allowable high limit price for the trading day as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        high_limit_price
-
-        """
-
-    @property
-    def high_limit_price(self) -> int:
-        """
-        The allowable high limit price for the trading day where every 1 unit corresponds to
-        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_high_limit_price
-
-        """
-
-    @property
-    def pretty_low_limit_price(self) -> float:
-        """
-        The allowable low limit price for the trading day as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        low_limit_price
-
-        """
-
-    @property
-    def low_limit_price(self) -> int:
-        """
-        The allowable low limit price for the trading day where every 1 unit corresponds to
-        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_low_limit_price
-
-        """
-
-    @property
-    def pretty_max_price_variation(self) -> float:
-        """
-        The differential value for price banding in units as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        max_price_variation
-
-        """
-
-    @property
-    def max_price_variation(self) -> int:
-        """
-        The differential value for price banding where every 1 unit corresponds to 1e-9,
-        i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_max_price_variation
-
-        """
-
-    @property
-    def pretty_trading_reference_price(self) -> float:
-        """
-        The trading session settlement price on `trading_reference_date` as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        trading_reference_price
-
-        """
-
-    @property
-    def trading_reference_price(self) -> int:
-        """
-        The trading session settlement price on `trading_reference_date` where every 1 unit
-        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_trading_reference_price
-
-        """
-
-    @property
-    def unit_of_measure_qty(self) -> int:
-        """
-        The contract size for each instrument, in combination with `unit_of_measure`, where every
-        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_min_price_increment_amount(self) -> float:
-        """
-        The value currently under development by the venue as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        min_price_increment_amount
-
-        """
-
-    @property
-    def min_price_increment_amount(self) -> int:
-        """
-        The value currently under development by the venue where every 1 unit corresponds to 1e-9,
-        i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_min_price_increment_amount
-
-        """
-
-    @property
-    def pretty_price_ratio(self) -> float:
-        """
-        The value used for price calculation in spread and leg pricing as a
-        float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        price_ratio
-
-        """
-
-    @property
-    def price_ratio(self) -> int:
-        """
-        The value used for price calculation in spread and leg pricing where every 1 unit
-        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_price_ratio
-
-        """
-
-    @property
-    def inst_attrib_value(self) -> int:
-        """
-        A bitmap of instrument eligibility attributes.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def underlying_id(self) -> int:
-        """
-        The `instrument_id` of the first underlying instrument.
-
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def raw_instrument_id(self) -> int:
-        """
-        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
-
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_depth_implied(self) -> int:
-        """
-        The implied book depth on the price level data feed.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_depth(self) -> int:
-        """
-        The (outright) book depth on the price level data feed.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_segment_id(self) -> int:
-        """
-        The market segment of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def max_trade_vol(self) -> int:
-        """
-        The maximum trading volume for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size(self) -> int:
-        """
-        The minimum order entry quantity for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size_block(self) -> int:
-        """
-        The minimum quantity required for a block trade of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size_round_lot(self) -> int:
-        """
-        The minimum quantity required for a round lot of the instrument.
-        Multiples of this quantity are also round lots.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_trade_vol(self) -> int:
-        """
-        The minimum trading volume for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def contract_multiplier(self) -> int:
-        """
-        The number of deliverables per instrument, i.e. peak days.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def decay_quantity(self) -> int:
-        """
-        The quantity that a contract will decay daily, after `decay_start_date`
-        has been reached.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def original_contract_size(self) -> int:
-        """
-        The fixed contract value assigned to each instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def trading_reference_date(self) -> int:
-        """
-        The trading session date corresponding to the settlement price in
-        `trading_reference_price`, in number of days since the UNIX epoch.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def appl_id(self) -> int:
-        """
-        The channel ID assigned at the venue.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_year(self) -> int:
-        """
-        The calendar year reflected in the instrument symbol.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def decay_start_date(self) -> int:
-        """
-        The date at which a contract will begin to decay.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def channel_id(self) -> int:
-        """
-        The channel ID assigned by Databento as an incrementing integer
-        starting at zero.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def currency(self) -> str:
-        """
-        The currency used for price fields.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def settl_currency(self) -> str:
-        """
-        The currency used for settlement, if different from `currency`.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def secsubtype(self) -> str:
-        """
-        The strategy type of the spread.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def raw_symbol(self) -> str:
-        """
-        The instrument name (symbol).
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def group(self) -> str:
-        """
-        The security group code of the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def exchange(self) -> str:
-        """
-        The exchange used to identify the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def asset(self) -> str:
-        """
-        The underlying asset code (product code) of the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def cfi(self) -> str:
-        """
-        The ISO standard instrument categorization code.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def security_type(self) -> str:
-        """
-        The security type of the instrument, e.g. FUT for future or future spread.
-
-        See `Security Type` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def unit_of_measure(self) -> str:
-        """
-        The unit of measure for the instrument’s original contract size, e.g.
-        USD or LBS.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def underlying(self) -> str:
-        """
-        The symbol of the first underlying instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def strike_price_currency(self) -> str:
-        """
-        The currency of `strike_price`.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def instrument_class(self) -> str:
-        """
-        The classification of the instrument.
-
-        See `Instrument class` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def pretty_strike_price(self) -> float:
-        """
-        The strike price of the option as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        strike_price
-
-        """
-
-    @property
-    def strike_price(self) -> int:
-        """
-        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_strike_price
-
-        """
-
-    @property
-    def match_algorithm(self) -> str:
-        """
-        The matching algorithm used for the instrument, typically **F**IFO.
-
-        See `Matching algorithm` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def md_security_trading_status(self) -> int:
-        """
-        The current trading state of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def main_fraction(self) -> int:
-        """
-        The price denominator of the main fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def price_display_format(self) -> int:
-        """
-        The number of digits to the right of the tick mark, to display
-        fractional prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def settl_price_type(self) -> int:
-        """
-        The type indicators for the settlement price, as a bitmap.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def sub_fraction(self) -> int:
-        """
-        The price denominator of the sub fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def underlying_product(self) -> int:
-        """
-        The product complex of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def security_update_action(self) -> str:
-        """
-        Indicates if the instrument definition has been added, modified, or
-        deleted.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def maturity_month(self) -> int:
-        """
-        The calendar month reflected in the instrument symbol.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_day(self) -> int:
-        """
-        The calendar day reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_week(self) -> int:
-        """
-        The calendar week reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def user_defined_instrument(self) -> str:
-        """
-        Indicates if the instrument is user defined: **Y**es or **N**o.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def contract_multiplier_unit(self) -> int:
-        """
-        The type of `contract_multiplier`. Either `1` for hours, or `2` for
-        days.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def flow_schedule_type(self) -> int:
-        """
-        The schedule for delivering electricity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def tick_rule(self) -> int:
-        """
-        The tick rule of the spread.
-
-        Returns
-        -------
-        int
-
-        """
-
-class InstrumentDefMsgV1(Record):
-    """
-    Definition of an instrument in DBN version 1.
-    """
-
-    def __init__(
-        self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        ts_recv: int,
-        min_price_increment: int,
-        display_factor: int,
-        min_lot_size_round_lot: int,
-        raw_symbol: str,
-        group: str,
-        exchange: str,
-        instrument_class: str,
-        match_algorithm: str,
-        md_security_trading_status: str,
-        security_update_action: str,
-        expiration: int = UNDEF_TIMESTAMP,
-        activation: int = UNDEF_TIMESTAMP,
-        high_limit_price: int = UNDEF_PRICE,
-        low_limit_price: int = UNDEF_PRICE,
-        max_price_variation: int = UNDEF_PRICE,
-        trading_reference_price: int = UNDEF_PRICE,
-        unit_of_measure_qty: int = UNDEF_PRICE,
-        min_price_increment_amount: int = UNDEF_PRICE,
-        price_ratio: int = UNDEF_PRICE,
-        inst_attrib_value: int | None = None,
-        underlying_id: int | None = None,
-        raw_instrument_id: int | None = None,
-        market_depth_implied: int | None = None,
-        market_depth: int | None = None,
-        market_segment_id: int | None = None,
-        max_trade_vol: int | None = None,
-        min_lot_size: int | None = None,
-        min_lot_size_block: int | None = None,
-        min_trade_vol: int | None = None,
-        contract_multiplier: int | None = None,
-        decay_quantity: int | None = None,
-        original_contract_size: int | None = None,
-        trading_reference_date: int | None = None,
-        appl_id: int | None = None,
-        maturity_year: int | None = None,
-        decay_start_date: int | None = None,
-        channel_id: int | None = None,
-        currency: str = "",
-        settl_currency: str = "",
-        secsubtype: str = "",
-        asset: str = "",
-        cfi: str = "",
-        security_type: str = "",
-        unit_of_measure: str = "",
-        underlying: str = "",
-        strike_price_currency: str = "",
-        strike_price: int = UNDEF_PRICE,
-        main_fraction: int | None = None,
-        price_display_format: int | None = None,
-        settl_price_type: int | None = None,
-        sub_fraction: int | None = None,
-        underlying_product: int | None = None,
-        maturity_month: int | None = None,
-        maturity_day: int | None = None,
-        maturity_week: int | None = None,
-        user_defined_instrument: str | None = None,
-        contract_multiplier_unit: int | None = None,
-        flow_schedule_type: int | None = None,
-        tick_rule: int | None = None,
-    ) -> None: ...
-    @property
-    def pretty_ts_recv(self) -> dt.datetime | None:
-        """
-        The capture-server-received timestamp as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def ts_recv(self) -> int:
-        """
-        The capture-server-received timestamp expressed as the number of nanoseconds
-        since the UNIX epoch.
-
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_min_price_increment(self) -> float:
-        """
-        The minimum constant tick for the instrument as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        min_price_increment
-
-        """
-
-    @property
-    def min_price_increment(self) -> int:
-        """
-        The minimum constant tick for the instrument where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_min_price_increment
-
-        """
-
-    @property
-    def display_factor(self) -> int:
-        """
-        The multiplier to convert the venue’s display price to the conventional price where every
-        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_expiration(self) -> dt.datetime | None:
-        """
-        The last eligible trade time expressed as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def expiration(self) -> int:
-        """
-        The last eligible trade time expressed as a number of nanoseconds since
-        the UNIX epoch.
-
-        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
-        only provide date-level granularity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_activation(self) -> dt.datetime | None:
-        """
-        The time of instrument activation expressed as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Some publishers only provide date-level granularity.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def activation(self) -> int:
-        """
-        The time of instrument activation expressed as a number of nanoseconds
-        since the UNIX epoch.
-
-        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
-        only provide date-level granularity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_high_limit_price(self) -> float:
-        """
-        The allowable high limit price for the trading day as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        high_limit_price
-
-        """
-
-    @property
-    def high_limit_price(self) -> int:
-        """
-        The allowable high limit price for the trading day where every 1 unit corresponds to
-        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_high_limit_price
-
-        """
-
-    @property
-    def pretty_low_limit_price(self) -> float:
-        """
-        The allowable low limit price for the trading day as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        low_limit_price
-
-        """
-
-    @property
-    def low_limit_price(self) -> int:
-        """
-        The allowable low limit price for the trading day where every 1 unit corresponds to
-        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_low_limit_price
-
-        """
-
-    @property
-    def pretty_max_price_variation(self) -> float:
-        """
-        The differential value for price banding in units as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        max_price_variation
-
-        """
-
-    @property
-    def max_price_variation(self) -> int:
-        """
-        The differential value for price banding where every 1 unit corresponds to 1e-9,
-        i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_max_price_variation
-
-        """
-
-    @property
-    def pretty_trading_reference_price(self) -> float:
-        """
-        The trading session settlement price on `trading_reference_date` as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        trading_reference_price
-
-        """
-
-    @property
-    def trading_reference_price(self) -> int:
-        """
-        The trading session settlement price on `trading_reference_date` where every 1 unit
-        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_trading_reference_price
-
-        """
-
-    @property
-    def unit_of_measure_qty(self) -> int:
-        """
-        The contract size for each instrument, in combination with `unit_of_measure`, where every
-        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def pretty_min_price_increment_amount(self) -> float:
-        """
-        The value currently under development by the venue as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        min_price_increment_amount
-
-        """
-
-    @property
-    def min_price_increment_amount(self) -> int:
-        """
-        The value currently under development by the venue where every 1 unit corresponds to 1e-9,
-        i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_min_price_increment_amount
-
-        """
-
-    @property
-    def pretty_price_ratio(self) -> float:
-        """
-        The value used for price calculation in spread and leg pricing as a
-        float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        price_ratio
-
-        """
-
-    @property
-    def price_ratio(self) -> int:
-        """
-        The value used for price calculation in spread and leg pricing where every 1 unit
-        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_price_ratio
-
-        """
-
-    @property
-    def inst_attrib_value(self) -> int:
-        """
-        A bitmap of instrument eligibility attributes.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def underlying_id(self) -> int:
-        """
-        The `instrument_id` of the first underlying instrument.
-
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def raw_instrument_id(self) -> int:
-        """
-        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
-
-        See `Instrument identifiers` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_depth_implied(self) -> int:
-        """
-        The implied book depth on the price level data feed.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_depth(self) -> int:
-        """
-        The (outright) book depth on the price level data feed.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def market_segment_id(self) -> int:
-        """
-        The market segment of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def max_trade_vol(self) -> int:
-        """
-        The maximum trading volume for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size(self) -> int:
-        """
-        The minimum order entry quantity for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size_block(self) -> int:
-        """
-        The minimum quantity required for a block trade of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_lot_size_round_lot(self) -> int:
-        """
-        The minimum quantity required for a round lot of the instrument.
-        Multiples of this quantity are also round lots.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def min_trade_vol(self) -> int:
-        """
-        The minimum trading volume for the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def contract_multiplier(self) -> int:
-        """
-        The number of deliverables per instrument, i.e. peak days.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def decay_quantity(self) -> int:
-        """
-        The quantity that a contract will decay daily, after `decay_start_date`
-        has been reached.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def original_contract_size(self) -> int:
-        """
-        The fixed contract value assigned to each instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def trading_reference_date(self) -> int:
-        """
-        The trading session date corresponding to the settlement price in
-        `trading_reference_price`, in number of days since the UNIX epoch.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def appl_id(self) -> int:
-        """
-        The channel ID assigned at the venue.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_year(self) -> int:
-        """
-        The calendar year reflected in the instrument symbol.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def decay_start_date(self) -> int:
-        """
-        The date at which a contract will begin to decay.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def channel_id(self) -> int:
-        """
-        The channel ID assigned by Databento as an incrementing integer
-        starting at zero.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def currency(self) -> str:
-        """
-        The currency used for price fields.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def settl_currency(self) -> str:
-        """
-        The currency used for settlement, if different from `currency`.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def secsubtype(self) -> str:
-        """
-        The strategy type of the spread.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def raw_symbol(self) -> str:
-        """
-        The instrument name (symbol).
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def group(self) -> str:
-        """
-        The security group code of the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def exchange(self) -> str:
-        """
-        The exchange used to identify the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def asset(self) -> str:
-        """
-        The underlying asset code (product code) of the instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def cfi(self) -> str:
-        """
-        The ISO standard instrument categorization code.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def security_type(self) -> str:
-        """
-        The security type of the instrument, e.g. FUT for future or future spread.
-
-        See `Security Type` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def unit_of_measure(self) -> str:
-        """
-        The unit of measure for the instrument’s original contract size, e.g.
-        USD or LBS.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def underlying(self) -> str:
-        """
-        The symbol of the first underlying instrument.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def strike_price_currency(self) -> str:
-        """
-        The currency of `strike_price`.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def instrument_class(self) -> str:
-        """
-        The classification of the instrument.
-
-        See `Instrument class` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def pretty_strike_price(self) -> float:
-        """
-        The strike price of the option as a float.
-
-        Returns
-        -------
-        float
-
-        See Also
-        --------
-        strike_price
-
-        """
-
-    @property
-    def strike_price(self) -> int:
-        """
-        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
-        1/1,000,000,000 or 0.000000001.
-
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
-
-        Returns
-        -------
-        int
-
-        See Also
-        --------
-        pretty_strike_price
-
-        """
-
-    @property
-    def match_algorithm(self) -> str:
-        """
-        The matching algorithm used for the instrument, typically **F**IFO.
-
-        See `Matching algorithm` https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def md_security_trading_status(self) -> int:
-        """
-        The current trading state of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def main_fraction(self) -> int:
-        """
-        The price denominator of the main fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def price_display_format(self) -> int:
-        """
-        The number of digits to the right of the tick mark, to display
-        fractional prices.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def settl_price_type(self) -> int:
-        """
-        The type indicators for the settlement price, as a bitmap.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def sub_fraction(self) -> int:
-        """
-        The price denominator of the sub fraction.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def underlying_product(self) -> int:
-        """
-        The product complex of the instrument.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def security_update_action(self) -> str:
-        """
-        Indicates if the instrument definition has been added, modified, or
-        deleted.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def maturity_month(self) -> int:
-        """
-        The calendar month reflected in the instrument symbol.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_day(self) -> int:
-        """
-        The calendar day reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def maturity_week(self) -> int:
-        """
-        The calendar week reflected in the instrument symbol, or 0.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def user_defined_instrument(self) -> str:
-        """
-        Indicates if the instrument is user defined: **Y**es or **N**o.
-
-        Returns
-        -------
-        str
-
-        """
-
-    @property
-    def contract_multiplier_unit(self) -> int:
-        """
-        The type of `contract_multiplier`. Either `1` for hours, or `2` for
-        days.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def flow_schedule_type(self) -> int:
-        """
-        The schedule for delivering electricity.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def tick_rule(self) -> int:
-        """
-        The tick rule of the spread.
-
-        Returns
-        -------
-        int
+        Side
 
         """
 
 class ImbalanceMsg(Record):
     """
     An auction imbalance message.
+
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        ts_recv: int,
-        ref_price: int,
-        cont_book_clr_price: int,
-        auct_interest_clr_price: int,
-        paired_qty: int,
-        total_imbalance_qty: int,
-        auction_type: str,
-        side: str,
-        significant_imbalance: str,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        ref_price,
+        auction_time,
+        cont_book_clr_price,
+        auct_interest_clr_price,
+        paired_qty,
+        total_imbalance_qty,
+        auction_type,
+        side,
+        significant_imbalance,
+        ssr_filling_price=UNDEF_PRICE,
+        ind_match_price=UNDEF_PRICE,
+        upper_collar=UNDEF_PRICE,
+        lower_collar=UNDEF_PRICE,
+        market_imbalance_qty=UNDEF_ORDER_SIZE,
+        unpaired_qty=UNDEF_ORDER_SIZE,
+        auction_status=0,
+        freeze_status=0,
+        num_extensions=0,
+        unpaired_side=None,
     ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
@@ -5725,7 +4208,7 @@ class ImbalanceMsg(Record):
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -5736,7 +4219,7 @@ class ImbalanceMsg(Record):
     @property
     def pretty_ref_price(self) -> float:
         """
-        The price at which the imbalance shares are calculated as a float.
+        The ref price as a float.
 
         Returns
         -------
@@ -5751,10 +4234,10 @@ class ImbalanceMsg(Record):
     @property
     def ref_price(self) -> int:
         """
-        The price at which the imbalance shares are calculated, where every 1
-        unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        The price at which the imbalance shares are calculated, where every 1 unit corresponds
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -5763,6 +4246,18 @@ class ImbalanceMsg(Record):
         See Also
         --------
         pretty_ref_price
+
+        """
+
+    @property
+    def pretty_auction_time(self) -> dt.datetime | None:
+        """
+        The auction time as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
 
         """
 
@@ -5780,8 +4275,7 @@ class ImbalanceMsg(Record):
     @property
     def pretty_cont_book_clr_price(self) -> float:
         """
-        The hypothetical auction-clearing price for both cross and continuous
-        orders as a float.
+        The cont book clr price as a float.
 
         Returns
         -------
@@ -5796,11 +4290,10 @@ class ImbalanceMsg(Record):
     @property
     def cont_book_clr_price(self) -> int:
         """
-        The hypothetical auction-clearing price for both cross and continuous
-        orders where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
-        0.000000001.
+        The hypothetical auction-clearing price for both cross and continuous orders where every
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -5815,8 +4308,7 @@ class ImbalanceMsg(Record):
     @property
     def pretty_auct_interest_clr_price(self) -> float:
         """
-        The hypothetical auction-clearing price for cross orders only as a
-        float.
+        The auct interest clr price as a float.
 
         Returns
         -------
@@ -5831,10 +4323,10 @@ class ImbalanceMsg(Record):
     @property
     def auct_interest_clr_price(self) -> int:
         """
-        The hypothetical auction-clearing price for cross orders only where
-        every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        The hypothetical auction-clearing price for cross orders only where every 1 unit corresponds
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -5847,6 +4339,21 @@ class ImbalanceMsg(Record):
         """
 
     @property
+    def pretty_ssr_filling_price(self) -> float:
+        """
+        The ssr filling price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        ssr_filling_price
+
+        """
+
+    @property
     def ssr_filling_price(self) -> int:
         """
         Reserved for future use.
@@ -5854,6 +4361,25 @@ class ImbalanceMsg(Record):
         Returns
         -------
         int
+
+        See Also
+        --------
+        pretty_ssr_filling_price
+
+        """
+
+    @property
+    def pretty_ind_match_price(self) -> float:
+        """
+        The ind match price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        ind_match_price
 
         """
 
@@ -5866,6 +4392,25 @@ class ImbalanceMsg(Record):
         -------
         int
 
+        See Also
+        --------
+        pretty_ind_match_price
+
+        """
+
+    @property
+    def pretty_upper_collar(self) -> float:
+        """
+        The upper collar as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        upper_collar
+
         """
 
     @property
@@ -5877,6 +4422,25 @@ class ImbalanceMsg(Record):
         -------
         int
 
+        See Also
+        --------
+        pretty_upper_collar
+
+        """
+
+    @property
+    def pretty_lower_collar(self) -> float:
+        """
+        The lower collar as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        lower_collar
+
         """
 
     @property
@@ -5887,6 +4451,10 @@ class ImbalanceMsg(Record):
         Returns
         -------
         int
+
+        See Also
+        --------
+        pretty_lower_collar
 
         """
 
@@ -5946,14 +4514,15 @@ class ImbalanceMsg(Record):
         """
 
     @property
-    def side(self) -> str:
+    def side(self) -> Side:
         """
-        The market side of the `total_imbalance_qty`. Can be **A**sk, **B**id, or
-        **N**one.
+        The market side of the `total_imbalance_qty`. Can be **A**sk, **B**id, or **N**one.
+
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
-        str
+        Side
 
         """
 
@@ -5991,21 +4560,20 @@ class ImbalanceMsg(Record):
         """
 
     @property
-    def unpaired_side(self) -> str:
+    def unpaired_side(self) -> Side:
         """
         Reserved for future use.
 
         Returns
         -------
-        str
+        Side
 
         """
 
     @property
     def significant_imbalance(self) -> str:
         """
-        Venue-specific character code. For Nasdaq, contains the raw Price
-        Variation Indicator.
+        Venue-specific character code. For Nasdaq, contains the raw Price Variation Indicator.
 
         Returns
         -------
@@ -6013,30 +4581,28 @@ class ImbalanceMsg(Record):
 
         """
 
-class StatMsgV1(Record):
+class StatMsg(Record):
     """
-    A statistics message.
-
-    A catchall for various data disseminated by publishers. The
-    `stat_type` field indicates the statistic contained in the message.
+    A statistics message. A catchall for various data disseminated by publishers. The
+    `stat_type` indicates the statistic contained in the message.
 
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        ts_recv: int,
-        ts_ref: int,
-        price: int,
-        quantity: int,
-        stat_type: int,
-        sequence: int | None = None,
-        ts_in_delta: int | None = None,
-        channel_id: int | None = None,
-        update_action: int | None = None,
-        stat_flags: int = 0,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        ts_ref,
+        price,
+        quantity,
+        stat_type,
+        sequence=0,
+        ts_in_delta=0,
+        channel_id=0,
+        update_action=None,
+        stat_flags=0,
     ) -> None: ...
     @property
     def pretty_ts_recv(self) -> dt.datetime | None:
@@ -6056,7 +4622,7 @@ class StatMsgV1(Record):
         The capture-server-received timestamp expressed as the number of nanoseconds
         since the UNIX epoch.
 
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
 
         Returns
         -------
@@ -6067,8 +4633,8 @@ class StatMsgV1(Record):
     @property
     def pretty_ts_ref(self) -> dt.datetime | None:
         """
-        Reference timestamp expressed as the number of nanoseconds since the
-        UNIX epoch as a datetime or `pandas.Timestamp`, if available.
+        The reference timestamp of the statistic value as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -6091,7 +4657,7 @@ class StatMsgV1(Record):
     @property
     def pretty_price(self) -> float:
         """
-        The value for price statistics as a float. Will be nan when unused.
+        The value for price statistics as a float.
 
         Returns
         -------
@@ -6106,10 +4672,10 @@ class StatMsgV1(Record):
     @property
     def price(self) -> int:
         """
-        The order price where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or
-        0.000000001.
+        The value for price statistics where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
 
-        See `Prices` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices.
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -6124,7 +4690,8 @@ class StatMsgV1(Record):
     @property
     def quantity(self) -> int:
         """
-        The value for non-price statistics. Will be undefined when unused.
+        The value for non-price statistics. Will be `UNDEF_STAT_QUANTITY`
+        when unused.
 
         Returns
         -------
@@ -6149,7 +4716,7 @@ class StatMsgV1(Record):
         The matching-engine-sending timestamp expressed as the number of nanoseconds before
         `ts_recv`.
 
-        See `ts_in_delta` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta.
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
 
         Returns
         -------
@@ -6158,20 +4725,21 @@ class StatMsgV1(Record):
         """
 
     @property
-    def stat_type(self) -> int:
+    def stat_type(self) -> StatType:
         """
-        The type of statistic value contained in the message.
+        The type of statistic value contained in the message. Refer to the
+        `StatType` enum for possible variants.
 
         Returns
         -------
-        int
+        StatType
 
         """
 
     @property
     def channel_id(self) -> int:
         """
-        A channel ID within the venue.
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
 
         Returns
         -------
@@ -6180,14 +4748,14 @@ class StatMsgV1(Record):
         """
 
     @property
-    def update_action(self) -> int:
+    def update_action(self) -> StatUpdateAction:
         """
-        Indicates if the statistic is newly added (1) or deleted (2). (Deleted
-        is only used with some stat types)
+        Indicates if the statistic is newly added (1) or deleted (2). (Deleted is only
+        used with some stat types).
 
         Returns
         -------
-        int
+        StatUpdateAction
 
         """
 
@@ -6202,129 +4770,41 @@ class StatMsgV1(Record):
 
         """
 
-class StatMsg(StatMsgV1):
-    """
-    A statistics message.
-
-    A catchall for various data disseminated by publishers. The
-    `stat_type` field indicates the statistic contained in the message.
-
-    """
-
-class StatusMsg(Record):
-    """
-    A trading status update message.
-    """
-
-    @property
-    def pretty_ts_recv(self) -> dt.datetime | None:
-        """
-        The capture-server-received timestamp as a datetime or
-        `pandas.Timestamp`, if available.
-
-        Returns
-        -------
-        datetime.datetime
-
-        """
-
-    @property
-    def ts_recv(self) -> int:
-        """
-        The capture-server-received timestamp expressed as the number of nanoseconds
-        since the UNIX epoch.
-
-        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def action(self) -> int:
-        """
-        The type of status change.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def reason(self) -> int:
-        """
-        Additional details about the cause of the status change.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def trading_event(self) -> int:
-        """
-        Further information about the status change and its effect on trading.
-
-        Returns
-        -------
-        int
-
-        """
-
-    @property
-    def is_trading(self) -> bool | None:
-        """
-        The best-efforts state of trading in the instrument, either `Y`, `N`, or `~`.
-
-        Returns
-        -------
-        bool | None
-
-        """
-
-    @property
-    def is_quoting(self) -> bool | None:
-        """
-        The best-efforts state of quoting in the instrument, either `Y`, `N`, or `~`.
-
-        Returns
-        -------
-        bool | None
-
-        """
-
-    @property
-    def is_short_sell_restricted(self) -> bool | None:
-        """
-        The best-efforts state of short sell restrictions for the instrument (if applicable),
-        either `Y`, `N`, or `~`.
-
-        Returns
-        -------
-        bool | None
-
-        """
-
-class ErrorMsg(ErrorMsgV1):
+class ErrorMsg(Record):
     """
     An error message from the Databento Live Subscription Gateway (LSG).
+
     """
 
     def __init__(
-        self, ts_event: int, err: str, is_last: bool = True, code: ErrorCode | None = None
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        err,
+        code,
+        is_last,
     ) -> None: ...
     @property
-    def code(self) -> ErrorCode | None:
+    def err(self) -> str:
         """
-        The error code, if any.
+        The error message.
 
         Returns
         -------
-        ErrorCode | None
+        str
+
+        """
+
+    @property
+    def code(self) -> ErrorCode:
+        """
+        The error code. See the `ErrorCode` enum for possible values.
+
+        Returns
+        -------
+        ErrorCode
+
         """
 
     @property
@@ -6339,44 +4819,29 @@ class ErrorMsg(ErrorMsgV1):
 
         """
 
-class ErrorMsgV1(Record):
-    """
-    A DBN version 1 error message from the Databento Live Subscription Gateway (LSG).
-    """
-
-    def __init__(self, ts_event: int, err: str, is_last: bool = True) -> None: ...
-    @property
-    def err(self) -> str:
-        """
-        The error message.
-
-        Returns
-        -------
-        str
-
-        """
-
 class SymbolMappingMsg(Record):
-    """A symbol mapping message which maps a symbol of one `SType` to
+    """
+    A symbol mapping message from the live API which maps a symbol from one `SType` to
     another.
+
     """
 
     def __init__(
         self,
-        publisher_id: int,
-        instrument_id: int,
-        ts_event: int,
-        stype_in: SType,
-        stype_in_symbol: str,
-        stype_out: SType,
-        stype_out_symbol: str,
-        start_ts: int,
-        end_ts: int,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        stype_in,
+        stype_in_symbol,
+        stype_out,
+        stype_out_symbol,
+        start_ts,
+        end_ts,
     ) -> None: ...
     @property
     def stype_in(self) -> SType:
         """
-        The input symbology type.
+        The input symbology type of `stype_in_symbol`.
 
         Returns
         -------
@@ -6398,7 +4863,7 @@ class SymbolMappingMsg(Record):
     @property
     def stype_out(self) -> SType:
         """
-        The output symbology type.
+        The output symbology type of `stype_out_symbol`.
 
         Returns
         -------
@@ -6420,8 +4885,8 @@ class SymbolMappingMsg(Record):
     @property
     def pretty_start_ts(self) -> dt.datetime | None:
         """
-        The start of the mapping interval expressed as a datetime
-        or `pandas.Timestamp`, if available.
+        The start of the mapping interval as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -6432,8 +4897,8 @@ class SymbolMappingMsg(Record):
     @property
     def start_ts(self) -> int:
         """
-        The start of the mapping interval expressed as the number of
-        nanoseconds since the UNIX epoch.
+        The start of the mapping interval expressed as the number of nanoseconds since
+        the UNIX epoch.
 
         Returns
         -------
@@ -6444,8 +4909,8 @@ class SymbolMappingMsg(Record):
     @property
     def pretty_end_ts(self) -> dt.datetime | None:
         """
-        The end of the mapping interval expressed as a datetime
-        or `pandas.Timestamp`, if available.
+        The end of the mapping interval as a datetime or
+        `pandas.Timestamp`, if available.
 
         Returns
         -------
@@ -6456,8 +4921,8 @@ class SymbolMappingMsg(Record):
     @property
     def end_ts(self) -> int:
         """
-        The end of the mapping interval expressed as the number of nanoseconds
-        since the UNIX epoch.
+        The end of the mapping interval expressed as the number of nanoseconds since
+        the UNIX epoch.
 
         Returns
         -------
@@ -6465,44 +4930,25 @@ class SymbolMappingMsg(Record):
 
         """
 
-class SymbolMappingMsgV1(SymbolMappingMsg):
-    """A DBN version 1 symbol mapping message which maps a symbol of one `SType`
-    to another.
+class SystemMsg(Record):
     """
-
-class SystemMsg(SystemMsgV1):
-    """
-    A non-error message from the Databento Live Subscription Gateway (LSG).
-
-    Also used for heartbeating.
+    A non-error message from the Databento Live Subscription Gateway (LSG). Also used
+    for heartbeating.
 
     """
 
-    def __init__(self, ts_event: int, msg: str, code: SystemCode | None = None) -> None: ...
-    @property
-    def code(self) -> SystemCode | None:
-        """
-        Type of system message, if any.
-
-        Returns
-        -------
-        SystemCode | None
-        """
-
-class SystemMsgV1(Record):
-    """
-    A DBN version 1 non-error message from the Databento Live Subscription Gateway
-    (LSG).
-
-    Also used for heartbeating.
-
-    """
-
-    def __init__(self, ts_event: int, msg: str) -> None: ...
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        msg,
+        code,
+    ) -> None: ...
     @property
     def msg(self) -> str:
         """
-        The message from the Databento Live Subscription Gateway (LSG).
+        The message from the Databento gateway.
 
         Returns
         -------
@@ -6510,14 +4956,2346 @@ class SystemMsgV1(Record):
 
         """
 
-    def is_heartbeat(self) -> bool:
+    @property
+    def code(self) -> SystemCode:
         """
-        Return `true` if this message is a heartbeat, used to indicate the connection
-        with the gateway is still open.
+        Type of system message. See the `SystemCode` enum for possible values.
 
         Returns
         -------
-        bool
+        SystemCode
+
+        """
+
+class ErrorMsgV1(Record):
+    """
+    An error message from the Databento Live Subscription Gateway (LSG) in DBN version 1.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        err,
+    ) -> None: ...
+    @property
+    def err(self) -> str:
+        """
+        The error message.
+
+        Returns
+        -------
+        str
+
+        """
+
+class InstrumentDefMsgV1(Record):
+    """
+    A definition of an instrument in DBN version 1. The record of the definition schema.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        min_price_increment,
+        display_factor,
+        expiration,
+        activation,
+        high_limit_price,
+        low_limit_price,
+        max_price_variation,
+        trading_reference_price,
+        unit_of_measure_qty,
+        min_price_increment_amount,
+        price_ratio,
+        inst_attrib_value,
+        underlying_id,
+        raw_instrument_id,
+        market_depth_implied,
+        market_depth,
+        market_segment_id,
+        max_trade_vol,
+        min_lot_size,
+        min_lot_size_block,
+        min_lot_size_round_lot,
+        min_trade_vol,
+        contract_multiplier,
+        decay_quantity,
+        original_contract_size,
+        trading_reference_date,
+        appl_id,
+        maturity_year,
+        decay_start_date,
+        channel_id,
+        currency,
+        settl_currency,
+        secsubtype,
+        raw_symbol,
+        group,
+        exchange,
+        asset,
+        cfi,
+        security_type,
+        unit_of_measure,
+        underlying,
+        strike_price_currency,
+        instrument_class,
+        strike_price,
+        match_algorithm,
+        md_security_trading_status,
+        main_fraction,
+        price_display_format,
+        settl_price_type,
+        sub_fraction,
+        underlying_product,
+        security_update_action,
+        maturity_month,
+        maturity_day,
+        maturity_week,
+        user_defined_instrument,
+        contract_multiplier_unit,
+        flow_schedule_type,
+        tick_rule,
+    ) -> None: ...
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_min_price_increment(self) -> float:
+        """
+        The minimum constant tick as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment
+
+        """
+
+    @property
+    def min_price_increment(self) -> int:
+        """
+        The minimum constant tick for the instrument where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment
+
+        """
+
+    @property
+    def pretty_display_factor(self) -> float:
+        """
+        The display factor as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        display_factor
+
+        """
+
+    @property
+    def display_factor(self) -> int:
+        """
+        The multiplier to convert the venue's display price to the conventional price where every
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_display_factor
+
+        """
+
+    @property
+    def pretty_expiration(self) -> dt.datetime | None:
+        """
+        The last eligible trade time as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def expiration(self) -> int:
+        """
+        The last eligible trade time expressed as the number of nanoseconds since the
+        UNIX epoch.
+
+        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
+        only provide date-level granularity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_activation(self) -> dt.datetime | None:
+        """
+        The time of instrument activation as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def activation(self) -> int:
+        """
+        The time of instrument activation expressed as the number of nanoseconds since the
+        UNIX epoch.
+
+        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
+        only provide date-level granularity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_high_limit_price(self) -> float:
+        """
+        The high limit price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        high_limit_price
+
+        """
+
+    @property
+    def high_limit_price(self) -> int:
+        """
+        The allowable high limit price for the trading day where every 1 unit corresponds to
+        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_high_limit_price
+
+        """
+
+    @property
+    def pretty_low_limit_price(self) -> float:
+        """
+        The low limit price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        low_limit_price
+
+        """
+
+    @property
+    def low_limit_price(self) -> int:
+        """
+        The allowable low limit price for the trading day where every 1 unit corresponds to
+        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_low_limit_price
+
+        """
+
+    @property
+    def pretty_max_price_variation(self) -> float:
+        """
+        The differential value for price banding as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        max_price_variation
+
+        """
+
+    @property
+    def max_price_variation(self) -> int:
+        """
+        The differential value for price banding where every 1 unit corresponds to 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_max_price_variation
+
+        """
+
+    @property
+    def pretty_trading_reference_price(self) -> float:
+        """
+        The trading session settlement price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        trading_reference_price
+
+        """
+
+    @property
+    def trading_reference_price(self) -> int:
+        """
+        The trading session settlement price on `trading_reference_date`.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_trading_reference_price
+
+        """
+
+    @property
+    def pretty_unit_of_measure_qty(self) -> float:
+        """
+        The contract size for each instrument as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        unit_of_measure_qty
+
+        """
+
+    @property
+    def unit_of_measure_qty(self) -> int:
+        """
+        The contract size for each instrument, in combination with `unit_of_measure`, where every
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_unit_of_measure_qty
+
+        """
+
+    @property
+    def pretty_min_price_increment_amount(self) -> float:
+        """
+        The min price increment amount as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment_amount
+
+        """
+
+    @property
+    def min_price_increment_amount(self) -> int:
+        """
+        The value currently under development by the venue where every 1 unit corresponds to 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment_amount
+
+        """
+
+    @property
+    def pretty_price_ratio(self) -> float:
+        """
+        The price ratio as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price_ratio
+
+        """
+
+    @property
+    def price_ratio(self) -> int:
+        """
+        The value used for price calculation in spread and leg pricing where every 1 unit
+        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price_ratio
+
+        """
+
+    @property
+    def inst_attrib_value(self) -> int:
+        """
+        A bitmap of instrument eligibility attributes.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def underlying_id(self) -> int:
+        """
+        The `instrument_id` of the first underlying instrument.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def raw_instrument_id(self) -> int:
+        """
+        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers)
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_depth_implied(self) -> int:
+        """
+        The implied book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_depth(self) -> int:
+        """
+        The (outright) book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_segment_id(self) -> int:
+        """
+        The market segment of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def max_trade_vol(self) -> int:
+        """
+        The maximum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size(self) -> int:
+        """
+        The minimum order entry quantity for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size_block(self) -> int:
+        """
+        The minimum quantity required for a block trade of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size_round_lot(self) -> int:
+        """
+        The minimum quantity required for a round lot of the instrument. Multiples of this
+        quantity are also round lots.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_trade_vol(self) -> int:
+        """
+        The minimum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def contract_multiplier(self) -> int:
+        """
+        The number of deliverables per instrument, i.e. peak days.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def decay_quantity(self) -> int:
+        """
+        The quantity that a contract will decay daily, after `decay_start_date` has been reached.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def original_contract_size(self) -> int:
+        """
+        The fixed contract value assigned to each instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def trading_reference_date(self) -> int:
+        """
+        The trading session date corresponding to the settlement price in
+        `trading_reference_price`, in number of days since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def appl_id(self) -> int:
+        """
+        The channel ID assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_year(self) -> int:
+        """
+        The calendar year reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def decay_start_date(self) -> int:
+        """
+        The date at which a contract will begin to decay.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def channel_id(self) -> int:
+        """
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def currency(self) -> str:
+        """
+        The currency used for price fields.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def settl_currency(self) -> str:
+        """
+        The currency used for settlement, if different from `currency`.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def secsubtype(self) -> str:
+        """
+        The strategy type of the spread.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def raw_symbol(self) -> str:
+        """
+        The instrument raw symbol assigned by the publisher.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def group(self) -> str:
+        """
+        The security group code of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def exchange(self) -> str:
+        """
+        The exchange used to identify the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def asset(self) -> str:
+        """
+        The underlying asset code (product code) of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def cfi(self) -> str:
+        """
+        The ISO standard instrument categorization code.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def security_type(self) -> str:
+        """
+        The security type of the instrument, e.g. FUT for future or future spread.
+
+        See [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type).
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def unit_of_measure(self) -> str:
+        """
+        The unit of measure for the instrument’s original contract size, e.g. USD or LBS.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def underlying(self) -> str:
+        """
+        The symbol of the first underlying instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def strike_price_currency(self) -> str:
+        """
+        The currency of `strike_price`.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def instrument_class(self) -> InstrumentClass:
+        """
+        The classification of the instrument.
+
+        See [Instrument class](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class).
+
+        Returns
+        -------
+        InstrumentClass
+
+        """
+
+    @property
+    def pretty_strike_price(self) -> float:
+        """
+        The strike price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        strike_price
+
+        """
+
+    @property
+    def strike_price(self) -> int:
+        """
+        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_strike_price
+
+        """
+
+    @property
+    def match_algorithm(self) -> MatchAlgorithm:
+        """
+        The matching algorithm used for the instrument, typically **F**IFO.
+
+        See [Matching algorithm](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm).
+
+        Returns
+        -------
+        MatchAlgorithm
+
+        """
+
+    @property
+    def md_security_trading_status(self) -> int:
+        """
+        The current trading state of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def main_fraction(self) -> int:
+        """
+        The price denominator of the main fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def price_display_format(self) -> int:
+        """
+        The number of digits to the right of the tick mark, to display fractional prices.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def settl_price_type(self) -> int:
+        """
+        The type indicators for the settlement price, as a bitmap.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sub_fraction(self) -> int:
+        """
+        The price denominator of the sub fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def underlying_product(self) -> int:
+        """
+        The product complex of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def security_update_action(self) -> SecurityUpdateAction:
+        """
+        Indicates if the instrument definition has been added, modified, or deleted.
+
+        Returns
+        -------
+        SecurityUpdateAction
+
+        """
+
+    @property
+    def maturity_month(self) -> int:
+        """
+        The calendar month reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_day(self) -> int:
+        """
+        The calendar day reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_week(self) -> int:
+        """
+        The calendar week reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def user_defined_instrument(self) -> UserDefinedInstrument:
+        """
+        Indicates if the instrument is user defined: **Y**es or **N**o.
+
+        Returns
+        -------
+        UserDefinedInstrument
+
+        """
+
+    @property
+    def contract_multiplier_unit(self) -> int:
+        """
+        The type of `contract_multiplier`. Either `1` for hours, or `2` for days.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def flow_schedule_type(self) -> int:
+        """
+        The schedule for delivering electricity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def tick_rule(self) -> int:
+        """
+        The tick rule of the spread.
+
+        Returns
+        -------
+        int
+
+        """
+
+class StatMsgV1(Record):
+    """
+    A statistics message in DBN versions 1 and 2. A catchall for various data disseminated
+    by publishers. The `stat_type` indicates the statistic contained in the message.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        ts_ref,
+        price,
+        quantity,
+        stat_type,
+        sequence=0,
+        ts_in_delta=0,
+        channel_id=0,
+        update_action=None,
+        stat_flags=0,
+    ) -> None: ...
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_ts_ref(self) -> dt.datetime | None:
+        """
+        The reference timestamp of the statistic value as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_ref(self) -> int:
+        """
+        The reference timestamp of the statistic value expressed as the number of
+        nanoseconds since the UNIX epoch. Will be `UNDEF_TIMESTAMP` when unused.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_price(self) -> float:
+        """
+        The value for price statistics as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price
+
+        """
+
+    @property
+    def price(self) -> int:
+        """
+        The value for price statistics where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price
+
+        """
+
+    @property
+    def quantity(self) -> int:
+        """
+        The value for non-price statistics. Will be `UNDEF_STAT_QUANTITY`
+        when unused.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sequence(self) -> int:
+        """
+        The message sequence number assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def ts_in_delta(self) -> int:
+        """
+        The matching-engine-sending timestamp expressed as the number of nanoseconds before
+        `ts_recv`.
+
+        See [ts_in_delta](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-in-delta).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def stat_type(self) -> StatType:
+        """
+        The type of statistic value contained in the message. Refer to the
+        `StatType` enum for possible variants.
+
+        Returns
+        -------
+        StatType
+
+        """
+
+    @property
+    def channel_id(self) -> int:
+        """
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def update_action(self) -> StatUpdateAction:
+        """
+        Indicates if the statistic is newly added (1) or deleted (2). (Deleted is only
+        used with some stat types).
+
+        Returns
+        -------
+        StatUpdateAction
+
+        """
+
+    @property
+    def stat_flags(self) -> int:
+        """
+        Additional flags associate with certain stat types.
+
+        Returns
+        -------
+        int
+
+        """
+
+class SymbolMappingMsgV1(Record):
+    """
+    A symbol mapping message from the live API in DBN version 1.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        stype_in_symbol,
+        stype_out_symbol,
+        start_ts,
+        end_ts,
+    ) -> None: ...
+    @property
+    def stype_in_symbol(self) -> str:
+        """
+        The input symbol.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def stype_out_symbol(self) -> str:
+        """
+        The output symbol.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def pretty_start_ts(self) -> dt.datetime | None:
+        """
+        The start of the mapping interval as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def start_ts(self) -> int:
+        """
+        The start of the mapping interval expressed as the number of nanoseconds since
+        the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_end_ts(self) -> dt.datetime | None:
+        """
+        The end of the mapping interval as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def end_ts(self) -> int:
+        """
+        The end of the mapping interval expressed as the number of nanoseconds since
+        the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+
+class SystemMsgV1(Record):
+    """
+    A non-error message from the Databento Live Subscription Gateway (LSG) in DBN version 1.
+    Also used for heartbeating.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        msg,
+    ) -> None: ...
+    @property
+    def msg(self) -> str:
+        """
+        The message from the Databento gateway.
+
+        Returns
+        -------
+        str
+
+        """
+
+class InstrumentDefMsgV2(Record):
+    """
+    A definition of an instrument in DBN version 2. The record of the definition schema.
+
+    """
+
+    def __init__(
+        self,
+        publisher_id,
+        instrument_id,
+        ts_event,
+        ts_recv,
+        min_price_increment,
+        display_factor,
+        expiration,
+        activation,
+        high_limit_price,
+        low_limit_price,
+        max_price_variation,
+        trading_reference_price,
+        unit_of_measure_qty,
+        min_price_increment_amount,
+        price_ratio,
+        strike_price,
+        inst_attrib_value,
+        underlying_id,
+        raw_instrument_id,
+        market_depth_implied,
+        market_depth,
+        market_segment_id,
+        max_trade_vol,
+        min_lot_size,
+        min_lot_size_block,
+        min_lot_size_round_lot,
+        min_trade_vol,
+        contract_multiplier,
+        decay_quantity,
+        original_contract_size,
+        trading_reference_date,
+        appl_id,
+        maturity_year,
+        decay_start_date,
+        channel_id,
+        currency,
+        settl_currency,
+        secsubtype,
+        raw_symbol,
+        group,
+        exchange,
+        asset,
+        cfi,
+        security_type,
+        unit_of_measure,
+        underlying,
+        strike_price_currency,
+        instrument_class,
+        match_algorithm,
+        md_security_trading_status,
+        main_fraction,
+        price_display_format,
+        settl_price_type,
+        sub_fraction,
+        underlying_product,
+        security_update_action,
+        maturity_month,
+        maturity_day,
+        maturity_week,
+        user_defined_instrument,
+        contract_multiplier_unit,
+        flow_schedule_type,
+        tick_rule,
+    ) -> None: ...
+    @property
+    def pretty_ts_recv(self) -> dt.datetime | None:
+        """
+        The capture-server-received timestamp as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def ts_recv(self) -> int:
+        """
+        The capture-server-received timestamp expressed as the number of nanoseconds
+        since the UNIX epoch.
+
+        See [ts_recv](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_min_price_increment(self) -> float:
+        """
+        The minimum constant tick as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment
+
+        """
+
+    @property
+    def min_price_increment(self) -> int:
+        """
+        The minimum constant tick for the instrument where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment
+
+        """
+
+    @property
+    def pretty_display_factor(self) -> float:
+        """
+        The display factor as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        display_factor
+
+        """
+
+    @property
+    def display_factor(self) -> int:
+        """
+        The multiplier to convert the venue's display price to the conventional price where every
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_display_factor
+
+        """
+
+    @property
+    def pretty_expiration(self) -> dt.datetime | None:
+        """
+        The last eligible trade time as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def expiration(self) -> int:
+        """
+        The last eligible trade time expressed as the number of nanoseconds since the
+        UNIX epoch.
+
+        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
+        only provide date-level granularity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_activation(self) -> dt.datetime | None:
+        """
+        The time of instrument activation as a datetime or
+        `pandas.Timestamp`, if available.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
+    def activation(self) -> int:
+        """
+        The time of instrument activation expressed as the number of nanoseconds since the
+        UNIX epoch.
+
+        Will be `UNDEF_TIMESTAMP` when null, such as for equities. Some publishers
+        only provide date-level granularity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_high_limit_price(self) -> float:
+        """
+        The high limit price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        high_limit_price
+
+        """
+
+    @property
+    def high_limit_price(self) -> int:
+        """
+        The allowable high limit price for the trading day where every 1 unit corresponds to
+        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_high_limit_price
+
+        """
+
+    @property
+    def pretty_low_limit_price(self) -> float:
+        """
+        The low limit price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        low_limit_price
+
+        """
+
+    @property
+    def low_limit_price(self) -> int:
+        """
+        The allowable low limit price for the trading day where every 1 unit corresponds to
+        1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_low_limit_price
+
+        """
+
+    @property
+    def pretty_max_price_variation(self) -> float:
+        """
+        The differential value for price banding as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        max_price_variation
+
+        """
+
+    @property
+    def max_price_variation(self) -> int:
+        """
+        The differential value for price banding where every 1 unit corresponds to 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_max_price_variation
+
+        """
+
+    @property
+    def pretty_trading_reference_price(self) -> float:
+        """
+        The trading session settlement price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        trading_reference_price
+
+        """
+
+    @property
+    def trading_reference_price(self) -> int:
+        """
+        The trading session settlement price on `trading_reference_date`.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_trading_reference_price
+
+        """
+
+    @property
+    def pretty_unit_of_measure_qty(self) -> float:
+        """
+        The contract size for each instrument as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        unit_of_measure_qty
+
+        """
+
+    @property
+    def unit_of_measure_qty(self) -> int:
+        """
+        The contract size for each instrument, in combination with `unit_of_measure`, where every
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_unit_of_measure_qty
+
+        """
+
+    @property
+    def pretty_min_price_increment_amount(self) -> float:
+        """
+        The min price increment amount as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        min_price_increment_amount
+
+        """
+
+    @property
+    def min_price_increment_amount(self) -> int:
+        """
+        The value currently under development by the venue where every 1 unit corresponds to 1e-9,
+        i.e. 1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_min_price_increment_amount
+
+        """
+
+    @property
+    def pretty_price_ratio(self) -> float:
+        """
+        The price ratio as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        price_ratio
+
+        """
+
+    @property
+    def price_ratio(self) -> int:
+        """
+        The value used for price calculation in spread and leg pricing where every 1 unit
+        corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_price_ratio
+
+        """
+
+    @property
+    def pretty_strike_price(self) -> float:
+        """
+        The strike price as a float.
+
+        Returns
+        -------
+        float
+
+        See Also
+        --------
+        strike_price
+
+        """
+
+    @property
+    def strike_price(self) -> int:
+        """
+        The strike price of the option where every 1 unit corresponds to 1e-9, i.e.
+        1/1,000,000,000 or 0.000000001.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        pretty_strike_price
+
+        """
+
+    @property
+    def inst_attrib_value(self) -> int:
+        """
+        A bitmap of instrument eligibility attributes.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def underlying_id(self) -> int:
+        """
+        The `instrument_id` of the first underlying instrument.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers).
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def raw_instrument_id(self) -> int:
+        """
+        The instrument ID assigned by the publisher. May be the same as `instrument_id`.
+
+        See [Instrument identifiers](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#instrument-identifiers)
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_depth_implied(self) -> int:
+        """
+        The implied book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_depth(self) -> int:
+        """
+        The (outright) book depth on the price level data feed.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def market_segment_id(self) -> int:
+        """
+        The market segment of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def max_trade_vol(self) -> int:
+        """
+        The maximum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size(self) -> int:
+        """
+        The minimum order entry quantity for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size_block(self) -> int:
+        """
+        The minimum quantity required for a block trade of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_lot_size_round_lot(self) -> int:
+        """
+        The minimum quantity required for a round lot of the instrument. Multiples of this
+        quantity are also round lots.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def min_trade_vol(self) -> int:
+        """
+        The minimum trading volume for the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def contract_multiplier(self) -> int:
+        """
+        The number of deliverables per instrument, i.e. peak days.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def decay_quantity(self) -> int:
+        """
+        The quantity that a contract will decay daily, after `decay_start_date` has been reached.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def original_contract_size(self) -> int:
+        """
+        The fixed contract value assigned to each instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def trading_reference_date(self) -> int:
+        """
+        The trading session date corresponding to the settlement price in
+        `trading_reference_price`, in number of days since the UNIX epoch.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def appl_id(self) -> int:
+        """
+        The channel ID assigned at the venue.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_year(self) -> int:
+        """
+        The calendar year reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def decay_start_date(self) -> int:
+        """
+        The date at which a contract will begin to decay.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def channel_id(self) -> int:
+        """
+        The channel ID assigned by Databento as an incrementing integer starting at zero.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def currency(self) -> str:
+        """
+        The currency used for price fields.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def settl_currency(self) -> str:
+        """
+        The currency used for settlement, if different from `currency`.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def secsubtype(self) -> str:
+        """
+        The strategy type of the spread.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def raw_symbol(self) -> str:
+        """
+        The instrument raw symbol assigned by the publisher.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def group(self) -> str:
+        """
+        The security group code of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def exchange(self) -> str:
+        """
+        The exchange used to identify the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def asset(self) -> str:
+        """
+        The underlying asset code (product code) of the instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def cfi(self) -> str:
+        """
+        The ISO standard instrument categorization code.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def security_type(self) -> str:
+        """
+        The security type of the instrument, e.g. FUT for future or future spread.
+
+        See [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type).
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def unit_of_measure(self) -> str:
+        """
+        The unit of measure for the instrument’s original contract size, e.g. USD or LBS.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def underlying(self) -> str:
+        """
+        The symbol of the first underlying instrument.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def strike_price_currency(self) -> str:
+        """
+        The currency of `strike_price`.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    def instrument_class(self) -> InstrumentClass:
+        """
+        The classification of the instrument.
+
+        See [Instrument class](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#instrument-class).
+
+        Returns
+        -------
+        InstrumentClass
+
+        """
+
+    @property
+    def match_algorithm(self) -> MatchAlgorithm:
+        """
+        The matching algorithm used for the instrument, typically **F**IFO.
+
+        See [Matching algorithm](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#matching-algorithm).
+
+        Returns
+        -------
+        MatchAlgorithm
+
+        """
+
+    @property
+    def md_security_trading_status(self) -> int:
+        """
+        The current trading state of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def main_fraction(self) -> int:
+        """
+        The price denominator of the main fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def price_display_format(self) -> int:
+        """
+        The number of digits to the right of the tick mark, to display fractional prices.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def settl_price_type(self) -> int:
+        """
+        The type indicators for the settlement price, as a bitmap.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def sub_fraction(self) -> int:
+        """
+        The price denominator of the sub fraction.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def underlying_product(self) -> int:
+        """
+        The product complex of the instrument.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def security_update_action(self) -> SecurityUpdateAction:
+        """
+        Indicates if the instrument definition has been added, modified, or deleted.
+
+        Returns
+        -------
+        SecurityUpdateAction
+
+        """
+
+    @property
+    def maturity_month(self) -> int:
+        """
+        The calendar month reflected in the instrument symbol.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_day(self) -> int:
+        """
+        The calendar day reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def maturity_week(self) -> int:
+        """
+        The calendar week reflected in the instrument symbol, or 0.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def user_defined_instrument(self) -> UserDefinedInstrument:
+        """
+        Indicates if the instrument is user defined: **Y**es or **N**o.
+
+        Returns
+        -------
+        UserDefinedInstrument
+
+        """
+
+    @property
+    def contract_multiplier_unit(self) -> int:
+        """
+        The type of `contract_multiplier`. Either `1` for hours, or `2` for days.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def flow_schedule_type(self) -> int:
+        """
+        The schedule for delivering electricity.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def tick_rule(self) -> int:
+        """
+        The tick rule of the spread.
+
+        Returns
+        -------
+        int
 
         """
 
@@ -6715,11 +7493,3 @@ def update_encoded_metadata(
         When the file update fails.
 
     """
-
-# Aliases
-TBBOMsg = MBOMsg
-BBO1SMsg = BBOMsg
-BBO1MMsg = BBOMsg
-TCBBOMsg = CMBP1Msg
-CBBO1SMsg = CBBOMsg
-CBBO1MMsg = CBBOMsg

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -103,13 +103,13 @@ mod tests {
         Dataset, MetadataBuilder,
     };
     use pyo3::{ffi::c_str, py_run, types::PyString};
+    use rstest::*;
 
     use super::*;
-    use crate::tests::setup;
+    use crate::tests::python;
 
-    #[test]
-    fn test_partial_metadata_and_records() {
-        setup();
+    #[rstest]
+    fn test_partial_metadata_and_records(_python: ()) {
         let mut target =
             DbnDecoder::new(true, false, None, VersionUpgradePolicy::default()).unwrap();
         let buffer = Vec::new();
@@ -149,9 +149,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_full_with_partial_record() {
-        setup();
+    #[rstest]
+    fn test_full_with_partial_record(_python: ()) {
         let mut decoder =
             DbnDecoder::new(true, false, None, VersionUpgradePolicy::default()).unwrap();
         let buffer = Vec::new();
@@ -198,9 +197,8 @@ mod tests {
         assert!(matches!(res2, Ok(recs) if recs.len() == 1));
     }
 
-    #[test]
-    fn test_dbn_decoder() {
-        setup();
+    #[rstest]
+    fn test_dbn_decoder(_python: ()) {
         Python::with_gil(|py| {
             let path = PyString::new(
                 py,
@@ -226,9 +224,8 @@ for record in records[1:]:
         });
     }
 
-    #[test]
-    fn test_dbn_decoder_decoding_error() {
-        setup();
+    #[rstest]
+    fn test_dbn_decoder_decoding_error(_python: ()) {
         Python::with_gil(|py| {
             Python::run(py,
                 c_str!(r#"from _lib import DBNDecoder, DBNError, Metadata, Schema, SType
@@ -265,9 +262,8 @@ except Exception:
         }).unwrap();
     }
 
-    #[test]
-    fn test_dbn_decoder_ts_out() {
-        setup();
+    #[rstest]
+    fn test_dbn_decoder_ts_out(_python: ()) {
         Python::with_gil(|py| {
             Python::run(
                 py,
@@ -303,9 +299,8 @@ for record in records:
         .unwrap();
     }
 
-    #[test]
-    fn test_dbn_decoder_no_metadata() {
-        setup();
+    #[rstest]
+    fn test_dbn_decoder_no_metadata(_python: ()) {
         Python::with_gil(|py| {
             Python::run(
                 py,
@@ -327,9 +322,8 @@ assert records[0] == record
         .unwrap();
     }
 
-    #[test]
-    fn test_decode_all_data_in_compat_situation() {
-        setup();
+    #[rstest]
+    fn test_decode_all_data_in_compat_situation(_python: ()) {
         Python::with_gil(|py| {
             Python::run(
                 py,

--- a/python/src/enums.rs
+++ b/python/src/enums.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+mod tests {
+    use pyo3::{ffi::c_str, Python};
+    use rstest::*;
+
+    use crate::tests::python;
+
+    #[rstest]
+    #[case("Compression")]
+    #[case("Encoding")]
+    #[case("Schema")]
+    #[case("SType")]
+    fn test_enum_name_coercion(_python: (), #[case] enum_name: &str) {
+        Python::with_gil(|py| {
+            pyo3::py_run!(
+                py,
+                enum_name,
+                r#"import _lib as db
+
+    enum_type = getattr(db, enum_name)
+    for variant in enum_type.variants():
+        assert variant == enum_type(variant.name)
+        assert variant == enum_type(variant.name.replace('_', '-'))
+        assert variant == enum_type(variant.name.lower())
+        assert variant == enum_type(variant.name.upper())
+        try:
+            enum_type("bar")     # sanity check
+            assert False, "did not raise an exception"
+        except db.DBNError:
+            pass"#
+            )
+        });
+    }
+
+    #[rstest]
+    fn test_compression_none_coercible(_python: ()) {
+        Python::with_gil(|py| {
+            py.run(
+                c_str!(
+                    r#"import _lib as db
+
+assert db.Compression(None) == db.Compression.NONE
+                "#
+                ),
+                None,
+                None,
+            )
+            .unwrap()
+        });
+    }
+
+    #[rstest]
+    #[case("Encoding")]
+    #[case("Schema")]
+    #[case("SType")]
+    fn test_enum_none_not_coercible(_python: (), #[case] enum_name: &str) {
+        Python::with_gil(|py| {
+            pyo3::py_run!(
+                py,
+                enum_name,
+                r#"import _lib as db
+
+enum_type = getattr(db, enum_name)
+try:
+    enum_type(None)
+    assert False, "did not raise an exception"
+except db.DBNError:
+    pass"#
+            )
+        });
+    }
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -20,6 +20,7 @@ use dbn::{
 
 mod dbn_decoder;
 mod encode;
+mod enums;
 mod transcoder;
 
 /// A Python module wrapping dbn functions
@@ -106,14 +107,16 @@ mod tests {
 
     use dbn::enums::SType;
     use pyo3::ffi::c_str;
+    use rstest::*;
 
     use super::*;
 
     pub const TEST_DATA_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data");
 
-    pub static INIT: Once = Once::new();
+    static INIT: Once = Once::new();
 
-    pub fn setup() {
+    #[fixture]
+    pub fn python() {
         INIT.call_once(|| {
             // add to available modules
             pyo3::append_to_inittab!(databento_dbn);
@@ -122,10 +125,8 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_metadata_identity() {
-        // initialize interpreter
-        setup();
+    #[rstest]
+    fn test_metadata_identity(_python: ()) {
         let stype_in = SType::RawSymbol as u8;
         let stype_out = SType::InstrumentId as u8;
         Python::with_gil(|py| {
@@ -160,9 +161,8 @@ assert metadata.ts_out is False"#
         });
     }
 
-    #[test]
-    fn test_dbn_decoder_metadata_error() {
-        setup();
+    #[rstest]
+    fn test_dbn_decoder_metadata_error(_python: ()) {
         Python::with_gil(|py| {
             py.run(
                 c_str!(

--- a/python/src/transcoder.rs
+++ b/python/src/transcoder.rs
@@ -402,19 +402,18 @@ mod tests {
         rtype, Dataset, ErrorMsg, MappingInterval, MetadataBuilder, OhlcvMsg, RecordHeader, SType,
         Schema, SymbolMapping, SymbolMappingMsg, WithTsOut, DBN_VERSION, UNDEF_TIMESTAMP,
     };
-    use rstest::rstest;
+    use rstest::*;
     use time::macros::{date, datetime};
 
     use crate::{
         encode::tests::MockPyFile,
-        tests::{setup, TEST_DATA_PATH},
+        tests::{python, TEST_DATA_PATH},
     };
 
     use super::*;
 
-    #[test]
-    fn test_partial_metadata_and_records() {
-        setup();
+    #[rstest]
+    fn test_partial_metadata_and_records(_python: ()) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
         let mut target = Python::with_gil(|py| {
@@ -483,9 +482,8 @@ mod tests {
         assert_eq!(output.chars().filter(|c| *c == '\n').count(), 1);
     }
 
-    #[test]
-    fn test_full_with_partial_record() {
-        setup();
+    #[rstest]
+    fn test_full_with_partial_record(_python: ()) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
         let mut transcoder = Python::with_gil(|py| {
@@ -555,8 +553,11 @@ mod tests {
     #[case::csv_map_symbols(Encoding::Csv, true)]
     #[case::json(Encoding::Json, false)]
     #[case::json_map_symbols(Encoding::Json, true)]
-    fn test_map_symbols_historical(#[case] encoding: Encoding, #[case] map_symbols: bool) {
-        setup();
+    fn test_map_symbols_historical(
+        _python: (),
+        #[case] encoding: Encoding,
+        #[case] map_symbols: bool,
+    ) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
         let mut transcoder = Python::with_gil(|py| {
@@ -683,8 +684,7 @@ mod tests {
     #[case::csv_map_symbols(Encoding::Csv, true)]
     #[case::json(Encoding::Json, false)]
     #[case::json_map_symbols(Encoding::Json, true)]
-    fn test_map_symbols_live(#[case] encoding: Encoding, #[case] map_symbols: bool) {
-        setup();
+    fn test_map_symbols_live(_python: (), #[case] encoding: Encoding, #[case] map_symbols: bool) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
         let mut transcoder = Python::with_gil(|py| {
@@ -811,9 +811,7 @@ mod tests {
     #[case::csv_mbo(Encoding::Csv, Schema::Mbo)]
     #[case::csv_definition(Encoding::Csv, Schema::Definition)]
     #[case::csv_trades(Encoding::Csv, Schema::Trades)]
-    fn test_from_test_data_file(#[case] encoding: Encoding, #[case] schema: Schema) {
-        setup();
-
+    fn test_from_test_data_file(_python: (), #[case] encoding: Encoding, #[case] schema: Schema) {
         let input = zstd::stream::decode_all(
             std::fs::File::open(format!("{TEST_DATA_PATH}/test_data.{schema}.v3.dbn.zst")).unwrap(),
         )
@@ -854,9 +852,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_skip_metadata_csv_header_still_written() {
-        setup();
-
+    fn test_skip_metadata_csv_header_still_written(_python: ()) {
         let mut input = Vec::new();
         let mut input_file =
             std::fs::File::open(format!("{TEST_DATA_PATH}/test_data.definition.v3.dbn.frag"))

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.38.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.39.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -19,4 +19,4 @@ syn = { version = "2.0", features = ["full"] }
 [dev-dependencies]
 csv = { workspace = true }
 dbn = { path = "../dbn" }
-trybuild = "1.0.105"
+trybuild = "1.0.106"

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,9 +25,9 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.38.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.39.0", path = "../dbn-macros" }
 
-async-compression = { version = "0.4.25", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "0.4.27", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }
 fallible-streaming-iterator = { version = "0.1.9", features = ["std"] }
 # Fast integer to string conversion

--- a/rust/dbn/src/compat.rs
+++ b/rust/dbn/src/compat.rs
@@ -501,7 +501,7 @@ pub struct SystemMsgV1 {
     /// The common header.
     #[pyo3(get)]
     pub hd: RecordHeader,
-    /// The message from the Databento Live Subscription Gateway (LSG).
+    /// The message from the Databento gateway.
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "crate::record::cstr_serde"))]
     pub msg: [c_char; 64],

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -278,7 +278,6 @@ pub enum Side {
     #[pyo3(name = "BID")]
     Bid = b'B',
     /// No side specified by the original source.
-
     #[default]
     #[pyo3(name = "NONE")]
     None = b'N',
@@ -336,7 +335,6 @@ pub enum Action {
     #[pyo3(name = "CLEAR")]
     Clear = b'R',
     /// Has no effect on the book, but may carry `flags` or other information.
-
     #[default]
     #[pyo3(name = "NONE")]
     None = b'N',
@@ -427,7 +425,6 @@ impl From<InstrumentClass> for char {
 #[repr(u8)]
 pub enum MatchAlgorithm {
     /// No matching algorithm was specified.
-
     #[default]
     #[pyo3(name = "UNDEFINED")]
     Undefined = b' ',
@@ -502,7 +499,6 @@ impl From<MatchAlgorithm> for char {
 #[repr(u8)]
 pub enum UserDefinedInstrument {
     /// The instrument is not user-defined.
-
     #[default]
     #[pyo3(name = "NO")]
     No = b'N',
@@ -1023,7 +1019,17 @@ pub enum StatType {
 
 /// The type of [`StatMsg`](crate::record::StatMsg) update.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, TryFromPrimitive, IntoPrimitive,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TryFromPrimitive,
+    IntoPrimitive,
 )]
 #[cfg_attr(
     feature = "python",
@@ -1035,6 +1041,7 @@ pub enum StatType {
 #[repr(u8)]
 pub enum StatUpdateAction {
     /// A new statistic.
+    #[default]
     #[pyo3(name = "NEW")]
     New = 1,
     /// A removal of a statistic.
@@ -1066,7 +1073,6 @@ pub enum StatUpdateAction {
 #[repr(u16)]
 pub enum StatusAction {
     /// No change.
-
     #[default]
     #[pyo3(name = "NONE")]
     None = 0,
@@ -1142,7 +1148,6 @@ pub enum StatusAction {
 #[repr(u16)]
 pub enum StatusReason {
     /// No reason is given.
-
     #[default]
     #[pyo3(name = "NONE")]
     None = 0,
@@ -1274,7 +1279,6 @@ pub enum StatusReason {
 #[repr(u16)]
 pub enum TradingEvent {
     /// No additional information given.
-
     #[default]
     #[pyo3(name = "NONE")]
     None = 0,
@@ -1317,7 +1321,6 @@ pub enum TradingEvent {
 #[repr(u8)]
 pub enum TriState {
     /// The value is not applicable or not known.
-
     #[default]
     #[pyo3(name = "NOT_AVAILABLE")]
     NotAvailable = b'~',
@@ -1355,7 +1358,6 @@ pub enum VersionUpgradePolicy {
     /// Decode and convert data from DBN versions prior to version 3 to that version.
     /// Attempting to decode data from newer versions (when they're introduced) will
     /// fail.
-
     #[default]
     #[pyo3(name = "UPGRADE_TO_V3")]
     UpgradeToV3,

--- a/rust/dbn/src/python.rs
+++ b/rust/dbn/src/python.rs
@@ -15,6 +15,7 @@ use strum::IntoEnumIterator;
 
 use crate::{Error, FlagSet};
 
+mod conversions;
 mod enums;
 mod metadata;
 mod record;

--- a/rust/dbn/src/python/conversions.rs
+++ b/rust/dbn/src/python/conversions.rs
@@ -1,0 +1,129 @@
+use std::ffi::c_char;
+
+use pyo3::{
+    conversion::IntoPyObjectExt,
+    intern,
+    prelude::*,
+    types::{PyDateTime, PyDict, PyTzInfo},
+};
+
+use crate::{
+    python::PyFieldDesc, BidAskPair, ConsolidatedBidAskPair, HasRType, WithTsOut, UNDEF_TIMESTAMP,
+};
+
+pub fn char_to_c_char(c: char) -> crate::Result<c_char> {
+    if c.is_ascii() {
+        Ok(c as c_char)
+    } else {
+        Err(crate::Error::Conversion {
+            input: c.to_string(),
+            desired_type: "c_char",
+        })
+    }
+}
+
+impl<const N: usize> PyFieldDesc for [BidAskPair; N] {
+    fn field_dtypes(_field_name: &str) -> Vec<(String, String)> {
+        let mut res = Vec::new();
+        let field_dtypes = BidAskPair::field_dtypes("");
+        for level in 0..N {
+            let mut dtypes = field_dtypes.clone();
+            for dtype in dtypes.iter_mut() {
+                dtype.0.push_str(&format!("_{level:02}"));
+            }
+            res.extend(dtypes);
+        }
+        res
+    }
+
+    fn price_fields(_field_name: &str) -> Vec<String> {
+        append_level_suffix::<N>(BidAskPair::price_fields(""))
+    }
+
+    fn ordered_fields(_field_name: &str) -> Vec<String> {
+        append_level_suffix::<N>(BidAskPair::ordered_fields(""))
+    }
+}
+
+impl<const N: usize> PyFieldDesc for [ConsolidatedBidAskPair; N] {
+    fn field_dtypes(_field_name: &str) -> Vec<(String, String)> {
+        let mut res = Vec::new();
+        let field_dtypes = ConsolidatedBidAskPair::field_dtypes("");
+        for level in 0..N {
+            let mut dtypes = field_dtypes.clone();
+            for dtype in dtypes.iter_mut() {
+                dtype.0.push_str(&format!("_{level:02}"));
+            }
+            res.extend(dtypes);
+        }
+        res
+    }
+
+    fn price_fields(_field_name: &str) -> Vec<String> {
+        append_level_suffix::<N>(ConsolidatedBidAskPair::price_fields(""))
+    }
+
+    fn ordered_fields(_field_name: &str) -> Vec<String> {
+        append_level_suffix::<N>(ConsolidatedBidAskPair::ordered_fields(""))
+    }
+
+    fn hidden_fields(_field_name: &str) -> Vec<String> {
+        append_level_suffix::<N>(ConsolidatedBidAskPair::hidden_fields(""))
+    }
+}
+
+pub fn append_level_suffix<const N: usize>(fields: Vec<String>) -> Vec<String> {
+    let mut res = Vec::new();
+    for level in 0..N {
+        let mut fields = fields.clone();
+        for field in fields.iter_mut() {
+            field.push_str(&format!("_{level:02}"));
+        }
+        res.extend(fields);
+    }
+    res
+}
+
+/// `WithTsOut` adds a `ts_out` field to the main record when converted to Python.
+impl<'py, R> IntoPyObject<'py> for WithTsOut<R>
+where
+    R: HasRType + IntoPyObject<'py>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let obj = self.rec.into_bound_py_any(py)?;
+        obj.setattr(intern!(py, "ts_out"), self.ts_out).unwrap();
+        Ok(obj)
+    }
+}
+
+pub fn new_py_timestamp_or_datetime(
+    py: Python<'_>,
+    timestamp: u64,
+) -> PyResult<Option<Bound<'_, PyAny>>> {
+    if timestamp == UNDEF_TIMESTAMP {
+        return Ok(None);
+    }
+    if let Ok(pandas) = PyModule::import(py, intern!(py, "pandas")) {
+        let kwargs = PyDict::new(py);
+        if kwargs.set_item(intern!(py, "utc"), true).is_ok()
+            && kwargs
+                .set_item(intern!(py, "errors"), intern!(py, "coerce"))
+                .is_ok()
+            && kwargs
+                .set_item(intern!(py, "unit"), intern!(py, "ns"))
+                .is_ok()
+        {
+            return pandas
+                .call_method(intern!(py, "to_datetime"), (timestamp,), Some(&kwargs))
+                .map(|o| Some(o.into_pyobject(py).unwrap()));
+        }
+    }
+    let utc_tz = PyTzInfo::utc(py)?;
+    let timestamp_ms = timestamp as f64 / 1_000_000.0;
+    PyDateTime::from_timestamp(py, timestamp_ms, Some(&utc_tz))
+        .map(|o| Some(o.into_pyobject(py).unwrap().into_any()))
+}

--- a/rust/dbn/src/python/enums.rs
+++ b/rust/dbn/src/python/enums.rs
@@ -79,17 +79,17 @@ impl RType {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('_', "-").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
     #[classmethod]
@@ -540,17 +540,17 @@ impl SType {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('-', "_").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -620,17 +620,17 @@ impl Schema {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('_', "-").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u16 = value.extract()?;
+        let value: u16 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -683,17 +683,17 @@ impl Encoding {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('-', "_").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -745,17 +745,17 @@ impl Compression {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('-', "_").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -817,7 +817,7 @@ impl StatType {
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u16 = value.extract()?;
+        let value: u16 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -865,7 +865,7 @@ impl StatUpdateAction {
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -927,7 +927,7 @@ impl StatusAction {
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u16 = value.extract()?;
+        let value: u16 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -1007,7 +1007,7 @@ impl StatusReason {
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u16 = value.extract()?;
+        let value: u16 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -1058,7 +1058,7 @@ impl TradingEvent {
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u16 = value.extract()?;
+        let value: u16 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -1207,17 +1207,17 @@ impl ErrorCode {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('-', "_").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }
@@ -1271,17 +1271,17 @@ impl SystemCode {
     #[classmethod]
     #[pyo3(name = "from_str")]
     fn py_from_str(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value_str: String = value.str().and_then(|s| s.extract())?;
+        let value_str: String = value.str().and_then(|s| s.extract()).map_err(to_py_err)?;
 
         let tokenized = value_str.replace('-', "_").to_lowercase();
 
-        Ok(Self::from_str(&tokenized)?)
+        Self::from_str(&tokenized).map_err(to_py_err)
     }
 
     #[classmethod]
     #[pyo3(name = "from_int")]
     fn py_from_int(_: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<Self> {
-        let value: u8 = value.extract()?;
+        let value: u8 = value.extract().map_err(to_py_err)?;
         Self::try_from(value).map_err(to_py_err)
     }
 }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -1,32 +1,19 @@
 use std::{ffi::c_char, mem};
 
-use pyo3::{
-    conversion::IntoPyObjectExt,
-    intern,
-    prelude::*,
-    types::{PyDateTime, PyDict, PyTzInfo},
-};
+use pyo3::prelude::*;
 
 use crate::{
     pretty::px_to_f64, record::str_to_c_chars, rtype, v1, v2, v3, BboMsg, BidAskPair, CbboMsg,
-    Cmbp1Msg, ConsolidatedBidAskPair, ErrorCode, FlagSet, HasRType, ImbalanceMsg, MboMsg, Mbp10Msg,
-    Mbp1Msg, OhlcvMsg, Record, RecordHeader, SType, SecurityUpdateAction, Side, StatUpdateAction,
+    Cmbp1Msg, ConsolidatedBidAskPair, ErrorCode, FlagSet, ImbalanceMsg, MboMsg, Mbp10Msg, Mbp1Msg,
+    OhlcvMsg, Record, RecordHeader, SType, SecurityUpdateAction, Side, StatUpdateAction,
     StatusAction, StatusMsg, StatusReason, SystemCode, TradeMsg, TradingEvent, TriState,
-    UserDefinedInstrument, WithTsOut, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
+    UserDefinedInstrument, UNDEF_ORDER_SIZE, UNDEF_PRICE, UNDEF_TIMESTAMP,
 };
 
-use super::{to_py_err, PyFieldDesc};
-
-fn char_to_c_char(c: char) -> crate::Result<c_char> {
-    if c.is_ascii() {
-        Ok(c as c_char)
-    } else {
-        Err(crate::Error::Conversion {
-            input: c.to_string(),
-            desired_type: "c_char",
-        })
-    }
-}
+use super::{
+    conversions::{char_to_c_char, new_py_timestamp_or_datetime},
+    to_py_err, PyFieldDesc,
+};
 
 #[pymethods]
 impl MboMsg {
@@ -3943,109 +3930,4 @@ impl v1::SystemMsg {
     fn py_ordered_fields() -> Vec<String> {
         Self::ordered_fields("")
     }
-}
-
-impl<const N: usize> PyFieldDesc for [BidAskPair; N] {
-    fn field_dtypes(_field_name: &str) -> Vec<(String, String)> {
-        let mut res = Vec::new();
-        let field_dtypes = BidAskPair::field_dtypes("");
-        for level in 0..N {
-            let mut dtypes = field_dtypes.clone();
-            for dtype in dtypes.iter_mut() {
-                dtype.0.push_str(&format!("_{level:02}"));
-            }
-            res.extend(dtypes);
-        }
-        res
-    }
-
-    fn price_fields(_field_name: &str) -> Vec<String> {
-        append_level_suffix::<N>(BidAskPair::price_fields(""))
-    }
-
-    fn ordered_fields(_field_name: &str) -> Vec<String> {
-        append_level_suffix::<N>(BidAskPair::ordered_fields(""))
-    }
-}
-
-impl<const N: usize> PyFieldDesc for [ConsolidatedBidAskPair; N] {
-    fn field_dtypes(_field_name: &str) -> Vec<(String, String)> {
-        let mut res = Vec::new();
-        let field_dtypes = ConsolidatedBidAskPair::field_dtypes("");
-        for level in 0..N {
-            let mut dtypes = field_dtypes.clone();
-            for dtype in dtypes.iter_mut() {
-                dtype.0.push_str(&format!("_{level:02}"));
-            }
-            res.extend(dtypes);
-        }
-        res
-    }
-
-    fn price_fields(_field_name: &str) -> Vec<String> {
-        append_level_suffix::<N>(ConsolidatedBidAskPair::price_fields(""))
-    }
-
-    fn ordered_fields(_field_name: &str) -> Vec<String> {
-        append_level_suffix::<N>(ConsolidatedBidAskPair::ordered_fields(""))
-    }
-
-    fn hidden_fields(_field_name: &str) -> Vec<String> {
-        append_level_suffix::<N>(ConsolidatedBidAskPair::hidden_fields(""))
-    }
-}
-
-fn append_level_suffix<const N: usize>(fields: Vec<String>) -> Vec<String> {
-    let mut res = Vec::new();
-    for level in 0..N {
-        let mut fields = fields.clone();
-        for field in fields.iter_mut() {
-            field.push_str(&format!("_{level:02}"));
-        }
-        res.extend(fields);
-    }
-    res
-}
-/// `WithTsOut` adds a `ts_out` field to the main record when converted to Python.
-impl<'py, R> IntoPyObject<'py> for WithTsOut<R>
-where
-    R: HasRType + IntoPyObject<'py>,
-{
-    type Target = PyAny;
-    type Output = Bound<'py, PyAny>;
-    type Error = PyErr;
-
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let obj = self.rec.into_bound_py_any(py)?;
-        obj.setattr(intern!(py, "ts_out"), self.ts_out).unwrap();
-        Ok(obj)
-    }
-}
-
-fn new_py_timestamp_or_datetime(
-    py: Python<'_>,
-    timestamp: u64,
-) -> PyResult<Option<Bound<'_, PyAny>>> {
-    if timestamp == UNDEF_TIMESTAMP {
-        return Ok(None);
-    }
-    if let Ok(pandas) = PyModule::import(py, intern!(py, "pandas")) {
-        let kwargs = PyDict::new(py);
-        if kwargs.set_item(intern!(py, "utc"), true).is_ok()
-            && kwargs
-                .set_item(intern!(py, "errors"), intern!(py, "coerce"))
-                .is_ok()
-            && kwargs
-                .set_item(intern!(py, "unit"), intern!(py, "ns"))
-                .is_ok()
-        {
-            return pandas
-                .call_method(intern!(py, "to_datetime"), (timestamp,), Some(&kwargs))
-                .map(|o| Some(o.into_pyobject(py).unwrap()));
-        }
-    }
-    let utc_tz = PyTzInfo::utc(py)?;
-    let timestamp_ms = timestamp as f64 / 1_000_000.0;
-    PyDateTime::from_timestamp(py, timestamp_ms, Some(&utc_tz))
-        .map(|o| Some(o.into_pyobject(py).unwrap().into_any()))
 }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -2646,6 +2646,11 @@ impl SystemMsg {
         Ok(mem::size_of::<Self>())
     }
 
+    #[pyo3(name = "is_heartbeat")]
+    fn py_is_heartbeat(&self) -> bool {
+        self.is_heartbeat()
+    }
+
     #[getter]
     fn get_msg(&self) -> PyResult<&str> {
         Ok(self.msg()?)
@@ -3551,6 +3556,11 @@ impl v1::SystemMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[pyo3(name = "is_heartbeat")]
+    fn py_is_heartbeat(&self) -> bool {
+        self.is_heartbeat()
     }
 
     #[getter]

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -2929,6 +2929,11 @@ impl ImbalanceMsg {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
 
+    #[getter]
+    fn get_pretty_auction_time<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.auction_time)
+    }
+
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
@@ -3347,7 +3352,7 @@ impl v2::ErrorMsg {
 
     #[getter]
     fn get_code(&self) -> Option<ErrorCode> {
-        self.code()
+        self.code().ok()
     }
 
     #[getter]
@@ -3800,7 +3805,7 @@ impl v2::SystemMsg {
 
     #[getter]
     fn get_code(&self) -> Option<SystemCode> {
-        self.code()
+        self.code().ok()
     }
 
     #[getter]

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -1097,6 +1097,7 @@ pub struct ImbalanceMsg {
     #[pyo3(get, set)]
     pub ref_price: i64,
     /// Reserved for future use.
+    #[dbn(unix_nanos)]
     #[pyo3(get, set)]
     pub auction_time: u64,
     /// The hypothetical auction-clearing price for both cross and continuous orders where every
@@ -1266,6 +1267,7 @@ pub struct ErrorMsg {
     pub err: [c_char; 302],
     /// The error code. See the [`ErrorCode`](crate::enums::ErrorCode) enum
     /// for possible values.
+    #[dbn(fmt_method)]
     #[pyo3(get, set)]
     pub code: u8,
     /// Sometimes multiple errors are sent together. This field will be non-zero for the
@@ -1344,6 +1346,7 @@ pub struct SystemMsg {
     pub msg: [c_char; 303],
     /// Type of system message. See the [`SystemCode`](crate::enums::SystemCode) enum
     /// for possible values.
+    #[dbn(fmt_method)]
     #[pyo3(get, set)]
     pub code: u8,
 }

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -5,7 +5,9 @@ pub(crate) mod conv;
 mod impl_default;
 mod layout_tests;
 mod methods;
+mod record_methods_tests;
 mod traits;
+mod with_ts_out_methods;
 
 use std::{ffi::CStr, mem, os::raw::c_char, ptr::NonNull, slice};
 
@@ -47,7 +49,7 @@ pub struct RecordHeader {
     /// The length of the record in 32-bit words.
     #[dbn(skip)]
     pub(crate) length: u8,
-    /// The record type; with `0xe0..0x0F` specifying MBP levels size. Record types
+    /// The record type; with `0x00..0x0F` specifying MBP levels size. Record types
     /// implement the trait [`HasRType`], and the [`has_rtype`][HasRType::has_rtype]
     /// function can be used to check if that type can be used to decode a message with
     /// a given rtype. The set of possible values is defined in [`rtype`].
@@ -1340,7 +1342,7 @@ pub struct SystemMsg {
     /// The common header.
     #[pyo3(get)]
     pub hd: RecordHeader,
-    /// The message from the Databento Live Subscription Gateway (LSG).
+    /// The message from the Databento gateway.
     #[dbn(fmt_method)]
     #[cfg_attr(feature = "serde", serde(with = "crate::record::cstr_serde"))]
     pub msg: [c_char; 303],

--- a/rust/dbn/src/record/methods.rs
+++ b/rust/dbn/src/record/methods.rs
@@ -89,24 +89,18 @@ impl Debug for RecordHeader {
 }
 
 impl MboMsg {
-    /// Returns the price as a floating point.
+    /// Converts the order price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn price_f64(&self) -> f64 {
         px_to_f64(self.price)
     }
 
-    /// Tries to convert the raw order side to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Tries to convert the raw event action to an enum.
+    /// Parses the action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `action` field does not
@@ -116,222 +110,109 @@ impl MboMsg {
             .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
     }
 
-    /// Parses the raw interval timestamp into a datetime. Returns `None` if `ts_recv`
-    /// contains the sentinel for a null timestamp.
+    /// Parses the side that initiates the event into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Parses the raw `ts_in_delta`—the delta of `ts_recv` - matching-engine-sending timestamp—
-    /// into a duration.
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
     pub fn ts_in_delta(&self) -> time::Duration {
         time::Duration::new(0, self.ts_in_delta)
     }
 }
 
 impl BidAskPair {
-    /// Returns the bid price as a floating point.
+    /// Converts the bid price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn bid_px_f64(&self) -> f64 {
         px_to_f64(self.bid_px)
     }
 
-    /// Returns the ask price as a floating point.
+    /// Converts the ask price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn ask_px_f64(&self) -> f64 {
         px_to_f64(self.ask_px)
-    }
-}
-
-impl TradeMsg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Tries to convert the raw order side to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Tries to convert the raw event action to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `action` field does not
-    /// contain a valid [`Action`].
-    pub fn action(&self) -> crate::Result<Action> {
-        Action::try_from(self.action as u8)
-            .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
-    }
-
-    /// Parses the raw `ts_in_delta` into a duration.
-    pub fn ts_in_delta(&self) -> time::Duration {
-        time::Duration::new(0, self.ts_in_delta)
-    }
-}
-
-impl BboMsg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Tries to convert the raw `side` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
-    }
-}
-
-impl Cmbp1Msg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Tries to convert the raw `side` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Tries to convert the raw event action to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `action` field does not
-    /// contain a valid [`Action`].
-    pub fn action(&self) -> crate::Result<Action> {
-        Action::try_from(self.action as u8)
-            .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
-    }
-
-    /// Parses the raw `ts_in_delta` into a duration.
-    pub fn ts_in_delta(&self) -> time::Duration {
-        time::Duration::new(0, self.ts_in_delta)
-    }
-}
-
-impl CbboMsg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Tries to convert the raw `side` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
     }
 }
 
 impl ConsolidatedBidAskPair {
-    /// Returns the bid price as a floating point.
+    /// Converts the bid price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn bid_px_f64(&self) -> f64 {
         px_to_f64(self.bid_px)
     }
 
-    /// Returns the ask price as a floating point.
+    /// Converts the ask price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn ask_px_f64(&self) -> f64 {
         px_to_f64(self.ask_px)
     }
 
-    /// Tries to convert the raw `bid_pb` into an enum which is useful for
-    /// exhaustive pattern matching.
+    /// Parses the bid publisher into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `publisher_id` does not correspond with
-    /// any known [`Publisher`].
+    /// This function returns an error if the `bid_pb` field does not
+    /// contain a valid [`Publisher`].
     pub fn bid_pb(&self) -> crate::Result<Publisher> {
         Publisher::try_from(self.bid_pb)
-            .map_err(|_| crate::error::Error::conversion::<Publisher>(self.bid_pb))
+            .map_err(|_| Error::conversion::<Publisher>(format!("{:#04X}", self.bid_pb)))
     }
 
-    /// Tries to convert the raw `ask_pb` into an enum which is useful for
-    /// exhaustive pattern matching.
+    /// Parses the ask publisher into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `ask_pb` does not correspond with
-    /// any known [`Publisher`].
+    /// This function returns an error if the `ask_pb` field does not
+    /// contain a valid [`Publisher`].
     pub fn ask_pb(&self) -> crate::Result<Publisher> {
         Publisher::try_from(self.ask_pb)
-            .map_err(|_| crate::error::Error::conversion::<Publisher>(self.ask_pb))
+            .map_err(|_| Error::conversion::<Publisher>(format!("{:#04X}", self.ask_pb)))
     }
 }
 
-impl Mbp1Msg {
-    /// Returns the price as a floating point.
+impl TradeMsg {
+    /// Converts the price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn price_f64(&self) -> f64 {
         px_to_f64(self.price)
     }
 
-    /// Tries to convert the raw `side` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> crate::Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Tries to convert the raw event action to an enum.
+    /// Parses the action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `action` field does not
@@ -341,120 +222,302 @@ impl Mbp1Msg {
             .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
     }
 
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the side into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Parses the raw `ts_in_delta` into a duration.
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
+    pub fn ts_in_delta(&self) -> time::Duration {
+        time::Duration::new(0, self.ts_in_delta)
+    }
+}
+
+impl Mbp1Msg {
+    /// Converts the order price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the action into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `action` field does not
+    /// contain a valid [`Action`].
+    pub fn action(&self) -> crate::Result<Action> {
+        Action::try_from(self.action as u8)
+            .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
+    }
+
+    /// Parses the side that initiates the event into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
     pub fn ts_in_delta(&self) -> time::Duration {
         time::Duration::new(0, self.ts_in_delta)
     }
 }
 
 impl Mbp10Msg {
-    /// Returns the price as a floating point.
+    /// Converts the order price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn price_f64(&self) -> f64 {
         px_to_f64(self.price)
     }
 
-    /// Tries to convert the raw `side` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `side` field does not
-    /// contain a valid [`Side`].
-    pub fn side(&self) -> Result<Side> {
-        Side::try_from(self.side as u8)
-            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
-    }
-
-    /// Tries to convert the raw event action to an enum.
+    /// Parses the action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `action` field does not
     /// contain a valid [`Action`].
-    pub fn action(&self) -> Result<Action> {
+    pub fn action(&self) -> crate::Result<Action> {
         Action::try_from(self.action as u8)
             .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
     }
 
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the side that initiates the event into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Parses the raw `ts_in_delta` into a duration.
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
     pub fn ts_in_delta(&self) -> time::Duration {
         time::Duration::new(0, self.ts_in_delta)
     }
 }
 
-impl OhlcvMsg {
-    /// Returns the open price as a floating point.
+impl BboMsg {
+    /// Converts the last trade price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the side that initiated the last trade into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the end timestamp of the interval capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+}
+
+impl Cmbp1Msg {
+    /// Converts the order price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the action into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `action` field does not
+    /// contain a valid [`Action`].
+    pub fn action(&self) -> crate::Result<Action> {
+        Action::try_from(self.action as u8)
+            .map_err(|_| Error::conversion::<Action>(format!("{:#04X}", self.action as u8)))
+    }
+
+    /// Parses the side that initiates the event into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
+    pub fn ts_in_delta(&self) -> time::Duration {
+        time::Duration::new(0, self.ts_in_delta)
+    }
+}
+
+impl CbboMsg {
+    /// Converts the last trade price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the side that initiated the last trade into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `side` field does not
+    /// contain a valid [`Side`].
+    pub fn side(&self) -> crate::Result<Side> {
+        Side::try_from(self.side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
+    }
+
+    /// Parses the end timestamp of the interval capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+}
+
+impl OhlcvMsg {
+    /// Converts the open price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn open_f64(&self) -> f64 {
         px_to_f64(self.open)
     }
 
-    /// Returns the high price as a floating point.
+    /// Converts the high price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn high_f64(&self) -> f64 {
         px_to_f64(self.high)
     }
 
-    /// Returns the low price as a floating point.
+    /// Converts the low price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn low_f64(&self) -> f64 {
         px_to_f64(self.low)
     }
 
-    /// Returns the close price as a floating point.
+    /// Converts the close price to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
     pub fn close_f64(&self) -> f64 {
         px_to_f64(self.close)
     }
 }
 
 impl StatusMsg {
-    /// Tries to convert the raw status action to an enum.
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+
+    /// Parses the action into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `action` field does not contain a valid
-    /// [`StatusAction`].
-    pub fn action(&self) -> Result<StatusAction> {
+    /// This function returns an error if the `action` field does not
+    /// contain a valid [`StatusAction`].
+    pub fn action(&self) -> crate::Result<StatusAction> {
         StatusAction::try_from(self.action)
-            .map_err(|_| Error::conversion::<StatusAction>(format!("{:#06X}", self.action)))
+            .map_err(|_| Error::conversion::<StatusAction>(format!("{:#04X}", self.action)))
     }
 
-    /// Tries to convert the raw status reason to an enum.
+    /// Parses the reason into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `reason` field does not contain a valid
-    /// [`StatusReason`].
-    pub fn reason(&self) -> Result<StatusReason> {
+    /// This function returns an error if the `reason` field does not
+    /// contain a valid [`StatusReason`].
+    pub fn reason(&self) -> crate::Result<StatusReason> {
         StatusReason::try_from(self.reason)
-            .map_err(|_| Error::conversion::<StatusReason>(format!("{:#06X}", self.reason)))
+            .map_err(|_| Error::conversion::<StatusReason>(format!("{:#04X}", self.reason)))
     }
 
-    /// Tries to convert the raw status trading event to an enum.
+    /// Parses the trading event into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `trading_event` field does not contain a
-    /// valid [`TradingEvent`].
-    pub fn trading_event(&self) -> Result<TradingEvent> {
+    /// This function returns an error if the `trading_event` field does not
+    /// contain a valid [`TradingEvent`].
+    pub fn trading_event(&self) -> crate::Result<TradingEvent> {
         TradingEvent::try_from(self.trading_event)
-            .map_err(|_| Error::conversion::<TradingEvent>(format!("{:#06X}", self.trading_event)))
+            .map_err(|_| Error::conversion::<TradingEvent>(format!("{:#04X}", self.trading_event)))
     }
 
-    /// Converts the raw `is_trading` state to an `Option<bool>` where `None` indicates
+    /// Parses the trading state into an `Option<bool>` where `None` indicates
     /// a value is not applicable or available.
     pub fn is_trading(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_trading as c_char as u8)
@@ -462,7 +525,7 @@ impl StatusMsg {
             .unwrap_or_default()
     }
 
-    /// Converts the raw `is_quoting` state to an `Option<bool>` where `None` indicates
+    /// Parses the quoting state into an `Option<bool>` where `None` indicates
     /// a value is not applicable or available.
     pub fn is_quoting(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_quoting as c_char as u8)
@@ -470,8 +533,8 @@ impl StatusMsg {
             .unwrap_or_default()
     }
 
-    /// Converts the raw `is_short_sell_restricted` state to an `Option<bool>` where
-    /// `None` indicates a value is not applicable or available.
+    /// Parses the short selling state into an `Option<bool>` where `None` indicates
+    /// a value is not applicable or available.
     pub fn is_short_sell_restricted(&self) -> Option<bool> {
         TriState::try_from_primitive(self.is_short_sell_restricted as c_char as u8)
             .map(Option::<bool>::from)
@@ -480,39 +543,146 @@ impl StatusMsg {
 }
 
 impl InstrumentDefMsg {
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Returns the unit of measure quantity as a floating point.
+    /// Converts the minimum constant tick to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn unit_of_measure_qty_f64(&self) -> f64 {
-        px_to_f64(self.unit_of_measure_qty)
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment)
     }
 
-    /// Returns the strike price as a floating point.
+    /// Converts the display factor to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn strike_price_f64(&self) -> f64 {
-        px_to_f64(self.strike_price)
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn display_factor_f64(&self) -> f64 {
+        px_to_f64(self.display_factor)
     }
 
-    /// Parses the raw last eligible trade time into a datetime. Returns `None` if
-    /// `expiration` contains the sentinel for a null timestamp.
+    /// Parses the last eligible trade time into a datetime.
+    /// Returns `None` if `expiration` contains the sentinel for a null timestamp.
     pub fn expiration(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.expiration)
     }
 
-    /// Parses the raw time of instrument action into a datetime. Returns `None` if
-    /// `activation` contains the sentinel for a null timestamp.
+    /// Parses the time of instrument activation into a datetime.
+    /// Returns `None` if `activation` contains the sentinel for a null timestamp.
     pub fn activation(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.activation)
     }
 
-    /// Returns currency used for price fields as a `&str`.
+    /// Converts the high limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn high_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.high_limit_price)
+    }
+
+    /// Converts the low limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn low_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.low_limit_price)
+    }
+
+    /// Converts the differential value for price banding to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn max_price_variation_f64(&self) -> f64 {
+        px_to_f64(self.max_price_variation)
+    }
+
+    /// Converts the contract size for each instrument to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn unit_of_measure_qty_f64(&self) -> f64 {
+        px_to_f64(self.unit_of_measure_qty)
+    }
+
+    /// Converts the min price increment amount to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_amount_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment_amount)
+    }
+
+    /// Converts the price ratio to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_ratio_f64(&self) -> f64 {
+        px_to_f64(self.price_ratio)
+    }
+
+    /// Converts the strike price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn strike_price_f64(&self) -> f64 {
+        px_to_f64(self.strike_price)
+    }
+
+    /// Converts the leg price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn leg_price_f64(&self) -> f64 {
+        px_to_f64(self.leg_price)
+    }
+
+    /// Converts the leg delta to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn leg_delta_f64(&self) -> f64 {
+        px_to_f64(self.leg_delta)
+    }
+
+    /// Parses the currency into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `currency` contains invalid UTF-8.
@@ -520,7 +690,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.currency)
     }
 
-    /// Returns currency used for settlement as a `&str`.
+    /// Parses the currency used for settlement into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `settl_currency` contains invalid UTF-8.
@@ -528,7 +698,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.settl_currency)
     }
 
-    /// Returns the strategy type of the spread as a `&str`.
+    /// Parses the strategy type of the spread into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `secsubtype` contains invalid UTF-8.
@@ -536,7 +706,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.secsubtype)
     }
 
-    /// Returns the instrument raw symbol assigned by the publisher as a `&str`.
+    /// Parses the raw symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `raw_symbol` contains invalid UTF-8.
@@ -544,65 +714,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.raw_symbol)
     }
 
-    /// Returns exchange used to identify the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `exchange` contains invalid UTF-8.
-    pub fn exchange(&self) -> Result<&str> {
-        c_chars_to_str(&self.exchange)
-    }
-
-    /// Returns the underlying asset code (product code) of the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `asset` contains invalid UTF-8.
-    pub fn asset(&self) -> Result<&str> {
-        c_chars_to_str(&self.asset)
-    }
-
-    /// Returns the ISO standard instrument categorization code as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `cfi` contains invalid UTF-8.
-    pub fn cfi(&self) -> Result<&str> {
-        c_chars_to_str(&self.cfi)
-    }
-
-    /// Returns the [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type)
-    /// of the instrument, e.g. FUT for future or future spread as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `security_type` contains invalid UTF-8.
-    pub fn security_type(&self) -> Result<&str> {
-        c_chars_to_str(&self.security_type)
-    }
-
-    /// Returns the unit of measure for the instrument's original contract size, e.g.
-    /// USD or LBS, as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
-    pub fn unit_of_measure(&self) -> Result<&str> {
-        c_chars_to_str(&self.unit_of_measure)
-    }
-
-    /// Returns the symbol of the first underlying instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `underlying` contains invalid UTF-8.
-    pub fn underlying(&self) -> Result<&str> {
-        c_chars_to_str(&self.underlying)
-    }
-
-    /// Returns the currency of [`strike_price`](Self::strike_price) as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
-    pub fn strike_price_currency(&self) -> Result<&str> {
-        c_chars_to_str(&self.strike_price_currency)
-    }
-
-    /// Returns the security group code of the instrumnet as a `&str`.
+    /// Parses the security group code into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `group` contains invalid UTF-8.
@@ -610,35 +722,98 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.group)
     }
 
-    /// Tries to convert the raw classification of the instrument to an enum.
+    /// Parses the exchange into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `exchange` contains invalid UTF-8.
+    pub fn exchange(&self) -> Result<&str> {
+        c_chars_to_str(&self.exchange)
+    }
+
+    /// Parses the asset into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `asset` contains invalid UTF-8.
+    pub fn asset(&self) -> Result<&str> {
+        c_chars_to_str(&self.asset)
+    }
+
+    /// Parses the CFI code into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `cfi` contains invalid UTF-8.
+    pub fn cfi(&self) -> Result<&str> {
+        c_chars_to_str(&self.cfi)
+    }
+
+    /// Parses the security type into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `security_type` contains invalid UTF-8.
+    pub fn security_type(&self) -> Result<&str> {
+        c_chars_to_str(&self.security_type)
+    }
+
+    /// Parses the unit of measure into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
+    pub fn unit_of_measure(&self) -> Result<&str> {
+        c_chars_to_str(&self.unit_of_measure)
+    }
+
+    /// Parses the underlying into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `underlying` contains invalid UTF-8.
+    pub fn underlying(&self) -> Result<&str> {
+        c_chars_to_str(&self.underlying)
+    }
+
+    /// Parses the strike price currency into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
+    pub fn strike_price_currency(&self) -> Result<&str> {
+        c_chars_to_str(&self.strike_price_currency)
+    }
+
+    /// Parses the leg raw symbol into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `leg_raw_symbol` contains invalid UTF-8.
+    pub fn leg_raw_symbol(&self) -> Result<&str> {
+        c_chars_to_str(&self.leg_raw_symbol)
+    }
+
+    /// Parses the instrument class into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `instrument_class` field does not
     /// contain a valid [`InstrumentClass`].
-    pub fn instrument_class(&self) -> Result<InstrumentClass> {
+    pub fn instrument_class(&self) -> crate::Result<InstrumentClass> {
         InstrumentClass::try_from(self.instrument_class as u8).map_err(|_| {
             Error::conversion::<InstrumentClass>(format!("{:#04X}", self.instrument_class as u8))
         })
     }
 
-    /// Tries to convert the raw matching algorithm used for the instrument to an enum.
+    /// Parses the match algorithm into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `match_algorithm` field does not
     /// contain a valid [`MatchAlgorithm`].
-    pub fn match_algorithm(&self) -> Result<MatchAlgorithm> {
+    pub fn match_algorithm(&self) -> crate::Result<MatchAlgorithm> {
         MatchAlgorithm::try_from(self.match_algorithm as u8).map_err(|_| {
             Error::conversion::<MatchAlgorithm>(format!("{:#04X}", self.match_algorithm as u8))
         })
     }
 
-    /// Returns the action indicating whether the instrument definition has been added,
-    /// modified, or deleted.
+    /// Parses the security update action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `security_update_action` field does not
     /// contain a valid [`SecurityUpdateAction`].
-    pub fn security_update_action(&self) -> Result<SecurityUpdateAction> {
+    pub fn security_update_action(&self) -> crate::Result<SecurityUpdateAction> {
         SecurityUpdateAction::try_from(self.security_update_action as u8).map_err(|_| {
             Error::conversion::<SecurityUpdateAction>(format!(
                 "{:#04X}",
@@ -647,12 +822,12 @@ impl InstrumentDefMsg {
         })
     }
 
-    /// Returns the enum whether the instrument definition is user-defined or not.
+    /// Parses the user-defined instrument flag into an enum.
     ///
     /// # Errors
-    /// This function returns an error if the `security_update_action` field does not
+    /// This function returns an error if the `user_defined_instrument` field does not
     /// contain a valid [`UserDefinedInstrument`].
-    pub fn user_defined_instrument(&self) -> Result<UserDefinedInstrument> {
+    pub fn user_defined_instrument(&self) -> crate::Result<UserDefinedInstrument> {
         UserDefinedInstrument::try_from(self.user_defined_instrument as u8).map_err(|_| {
             Error::conversion::<UserDefinedInstrument>(format!(
                 "{:#04X}",
@@ -661,20 +836,12 @@ impl InstrumentDefMsg {
         })
     }
 
-    /// Returns the leg's raw symbol assigned by the publisher as a `&str`.
+    /// Parses the leg instrument class into an enum.
     ///
     /// # Errors
-    /// This function returns an error if `raw_symbol` contains invalid UTF-8.
-    pub fn leg_raw_symbol(&self) -> Result<&str> {
-        c_chars_to_str(&self.leg_raw_symbol)
-    }
-
-    /// Tries to convert the raw classification of the leg instrument to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `instrument_class` field does not
+    /// This function returns an error if the `leg_instrument_class` field does not
     /// contain a valid [`InstrumentClass`].
-    pub fn leg_instrument_class(&self) -> Result<InstrumentClass> {
+    pub fn leg_instrument_class(&self) -> crate::Result<InstrumentClass> {
         InstrumentClass::try_from(self.leg_instrument_class as u8).map_err(|_| {
             Error::conversion::<InstrumentClass>(format!(
                 "{:#04X}",
@@ -683,35 +850,108 @@ impl InstrumentDefMsg {
         })
     }
 
-    /// Returns the leg price as a floating point.
+    /// Parses the leg side into an enum.
     ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn leg_price_f64(&self) -> f64 {
-        px_to_f64(self.leg_price)
-    }
-
-    /// Returns the leg delta as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn leg_delta_f64(&self) -> f64 {
-        px_to_f64(self.leg_delta)
+    /// # Errors
+    /// This function returns an error if the `leg_side` field does not
+    /// contain a valid [`Side`].
+    pub fn leg_side(&self) -> crate::Result<Side> {
+        Side::try_from(self.leg_side as u8)
+            .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.leg_side as u8)))
     }
 }
 
 impl ImbalanceMsg {
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Parses the raw auction timestamp into a datetime. Returns `None` if
-    /// `auction_time` contains the sentinel for a null timestamp.
+    /// Converts the ref price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn ref_price_f64(&self) -> f64 {
+        px_to_f64(self.ref_price)
+    }
+
+    /// Parses the auction time into a datetime.
+    /// Returns `None` if `auction_time` contains the sentinel for a null timestamp.
     pub fn auction_time(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.auction_time)
     }
 
-    /// Tries to convert the raw side to an enum.
+    /// Converts the cont book clr price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn cont_book_clr_price_f64(&self) -> f64 {
+        px_to_f64(self.cont_book_clr_price)
+    }
+
+    /// Converts the auct interest clr price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn auct_interest_clr_price_f64(&self) -> f64 {
+        px_to_f64(self.auct_interest_clr_price)
+    }
+
+    /// Converts the ssr filling price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn ssr_filling_price_f64(&self) -> f64 {
+        px_to_f64(self.ssr_filling_price)
+    }
+
+    /// Converts the ind match price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn ind_match_price_f64(&self) -> f64 {
+        px_to_f64(self.ind_match_price)
+    }
+
+    /// Converts the upper collar to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn upper_collar_f64(&self) -> f64 {
+        px_to_f64(self.upper_collar)
+    }
+
+    /// Converts the lower collar to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn lower_collar_f64(&self) -> f64 {
+        px_to_f64(self.lower_collar)
+    }
+
+    /// Parses the side into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `side` field does not
@@ -721,7 +961,7 @@ impl ImbalanceMsg {
             .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.side as u8)))
     }
 
-    /// Tries to convert the raw unpaired side to an enum.
+    /// Parses the unpaired side into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `unpaired_side` field does not
@@ -730,83 +970,61 @@ impl ImbalanceMsg {
         Side::try_from(self.unpaired_side as u8)
             .map_err(|_| Error::conversion::<Side>(format!("{:#04X}", self.unpaired_side as u8)))
     }
-
-    /// Returns the reference price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn ref_price_f64(&self) -> f64 {
-        px_to_f64(self.ref_price)
-    }
-
-    /// Returns the hypothetical auction-clearing price for cross and continuous orders
-    /// as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn cont_book_clr_price_f64(&self) -> f64 {
-        px_to_f64(self.cont_book_clr_price)
-    }
-
-    /// Returns the hypothetical auction-clearing price for cross orders only as a
-    /// floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn auct_interest_clr_price_f64(&self) -> f64 {
-        px_to_f64(self.auct_interest_clr_price)
-    }
 }
 
 impl StatMsg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Parses the raw reference timestamp of the statistic value into a datetime.
+    /// Parses the reference timestamp of the statistic value into a datetime.
     /// Returns `None` if `ts_ref` contains the sentinel for a null timestamp.
     pub fn ts_ref(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_ref)
     }
 
-    /// Tries to convert the raw type of the statistic value to an enum.
+    /// Converts the value for price statistics to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
+    pub fn ts_in_delta(&self) -> time::Duration {
+        time::Duration::new(0, self.ts_in_delta)
+    }
+
+    /// Parses the type of statistic value into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `stat_type` field does not
     /// contain a valid [`StatType`].
-    pub fn stat_type(&self) -> Result<StatType> {
+    pub fn stat_type(&self) -> crate::Result<StatType> {
         StatType::try_from(self.stat_type)
-            .map_err(|_| Error::conversion::<StatType>(self.stat_type))
+            .map_err(|_| Error::conversion::<StatType>(format!("{:#04X}", self.stat_type)))
     }
 
-    /// Tries to convert the raw `update_action` to an enum.
+    /// Parses the update action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `update_action` field does not
     /// contain a valid [`StatUpdateAction`].
-    pub fn update_action(&self) -> Result<StatUpdateAction> {
+    pub fn update_action(&self) -> crate::Result<StatUpdateAction> {
         StatUpdateAction::try_from(self.update_action).map_err(|_| {
-            Error::conversion::<StatUpdateAction>(format!("{:04X}", self.update_action))
+            Error::conversion::<StatUpdateAction>(format!("{:#04X}", self.update_action))
         })
-    }
-
-    /// Parses the raw `ts_in_delta` into a duration.
-    pub fn ts_in_delta(&self) -> time::Duration {
-        time::Duration::new(0, self.ts_in_delta)
     }
 }
 
 impl ErrorMsg {
-    /// Creates a new `ErrorMsg`.
-    ///
-    /// # Errors
-    /// This function returns an error if `msg` is too long.
+    /// Creates a new `ErrorMsg`. `msg` will be truncated if it's too long.
     pub fn new(ts_event: u64, code: Option<ErrorCode>, msg: &str, is_last: bool) -> Self {
         let mut error = Self {
             hd: RecordHeader::new::<Self>(rtype::ERROR, 0, 0, ts_event),
@@ -823,29 +1041,31 @@ impl ErrorMsg {
         error
     }
 
-    /// Returns the error code enum variant if one was specified.
-    ///
-    /// # Errors
-    /// Returns an error if the code field does not contain a valid `ErrorCode`.
-    pub fn code(&self) -> Result<ErrorCode> {
-        ErrorCode::try_from(self.code).map_err(|_| Error::conversion::<ErrorCode>(self.code))
-    }
-
-    /// Returns `err` as a `&str`.
+    /// Parses the error message into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `err` contains invalid UTF-8.
     pub fn err(&self) -> Result<&str> {
         c_chars_to_str(&self.err)
     }
+
+    /// Parses the error code into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `code` field does not
+    /// contain a valid [`ErrorCode`].
+    pub fn code(&self) -> crate::Result<ErrorCode> {
+        ErrorCode::try_from(self.code)
+            .map_err(|_| Error::conversion::<ErrorCode>(format!("{:#04X}", self.code)))
+    }
 }
 
 impl SymbolMappingMsg {
-    /// Creates a new `SymbolMappingMsgV2`.
+    /// Creates a new `SymbolMappingMsg`.
     ///
     /// # Errors
     /// This function returns an error if `stype_in_symbol` or `stype_out_symbol`
-    /// contain more than maximum number of characters of 70.
+    /// contain more than maximum number of 70 characters.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         instrument_id: u32,
@@ -869,15 +1089,17 @@ impl SymbolMappingMsg {
         })
     }
 
-    /// Returns the input symbology type.
+    /// Parses the stype in into an enum.
     ///
     /// # Errors
-    /// This function returns an error if `stype_in` does not contain a valid [`SType`].
-    pub fn stype_in(&self) -> Result<SType> {
-        SType::try_from(self.stype_in).map_err(|_| Error::conversion::<SType>(self.stype_in))
+    /// This function returns an error if the `stype_in` field does not
+    /// contain a valid [`SType`].
+    pub fn stype_in(&self) -> crate::Result<SType> {
+        SType::try_from(self.stype_in)
+            .map_err(|_| Error::conversion::<SType>(format!("{:#04X}", self.stype_in)))
     }
 
-    /// Returns the input symbol as a `&str`.
+    /// Parses the input symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `stype_in_symbol` contains invalid UTF-8.
@@ -885,15 +1107,17 @@ impl SymbolMappingMsg {
         c_chars_to_str(&self.stype_in_symbol)
     }
 
-    /// Returns the output symbology type.
+    /// Parses the stype out into an enum.
     ///
     /// # Errors
-    /// This function returns an error if `stype_out` does not contain a valid [`SType`].
-    pub fn stype_out(&self) -> Result<SType> {
-        SType::try_from(self.stype_out).map_err(|_| Error::conversion::<SType>(self.stype_out))
+    /// This function returns an error if the `stype_out` field does not
+    /// contain a valid [`SType`].
+    pub fn stype_out(&self) -> crate::Result<SType> {
+        SType::try_from(self.stype_out)
+            .map_err(|_| Error::conversion::<SType>(format!("{:#04X}", self.stype_out)))
     }
 
-    /// Returns the output symbol as a `&str`.
+    /// Parses the output symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `stype_out_symbol` contains invalid UTF-8.
@@ -901,14 +1125,14 @@ impl SymbolMappingMsg {
         c_chars_to_str(&self.stype_out_symbol)
     }
 
-    /// Parses the raw start of the mapping interval into a datetime. Returns `None` if
-    /// `start_ts` contains the sentinel for a null timestamp.
+    /// Parses the start of the mapping interval into a datetime.
+    /// Returns `None` if `start_ts` contains the sentinel for a null timestamp.
     pub fn start_ts(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.start_ts)
     }
 
-    /// Parses the raw end of the mapping interval into a datetime. Returns `None` if
-    /// `end_ts` contains the sentinel for a null timestamp.
+    /// Parses the end of the mapping interval into a datetime.
+    /// Returns `None` if `end_ts` contains the sentinel for a null timestamp.
     pub fn end_ts(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.end_ts)
     }
@@ -927,14 +1151,6 @@ impl SystemMsg {
             msg: str_to_c_chars(msg)?,
             code: code.map(u8::from).unwrap_or(u8::MAX),
         })
-    }
-
-    /// Returns the system code enum variant if one was specified.
-    ///
-    /// # Errors
-    /// Returns an error if the code field does not contain a valid `SystemCode`.
-    pub fn code(&self) -> Result<SystemCode> {
-        SystemCode::try_from(self.code).map_err(|_| Error::conversion::<SystemCode>(self.code))
     }
 
     /// Creates a new heartbeat `SystemMsg`.
@@ -957,159 +1173,21 @@ impl SystemMsg {
         }
     }
 
-    /// Returns the message from the Databento Live Subscription Gateway (LSG) as
-    /// a `&str`.
+    /// Parses the message from the Databento gateway into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `msg` contains invalid UTF-8.
     pub fn msg(&self) -> Result<&str> {
         c_chars_to_str(&self.msg)
     }
-}
 
-impl<T: HasRType> Record for WithTsOut<T> {
-    fn header(&self) -> &RecordHeader {
-        self.rec.header()
-    }
-
-    fn raw_index_ts(&self) -> u64 {
-        self.rec.raw_index_ts()
-    }
-}
-
-impl<T: HasRType> RecordMut for WithTsOut<T> {
-    fn header_mut(&mut self) -> &mut RecordHeader {
-        self.rec.header_mut()
-    }
-}
-
-impl<T: HasRType> HasRType for WithTsOut<T> {
-    fn has_rtype(rtype: u8) -> bool {
-        T::has_rtype(rtype)
-    }
-}
-
-impl<T> AsRef<[u8]> for WithTsOut<T>
-where
-    T: HasRType,
-{
-    fn as_ref(&self) -> &[u8] {
-        unsafe { as_u8_slice(self) }
-    }
-}
-
-impl<T: HasRType> WithTsOut<T> {
-    /// Creates a new record with `ts_out`. Updates the `length` property in
-    /// [`RecordHeader`] to ensure the additional field is accounted for.
-    pub fn new(rec: T, ts_out: u64) -> Self {
-        let mut res = Self { rec, ts_out };
-        res.header_mut().length = (mem::size_of_val(&res) / RecordHeader::LENGTH_MULTIPLIER) as u8;
-        res
-    }
-
-    /// Parses the raw live gateway send timestamp into a datetime.
-    pub fn ts_out(&self) -> time::OffsetDateTime {
-        // u64::MAX is within maximum allowable range
-        time::OffsetDateTime::from_unix_timestamp_nanos(self.ts_out as i128).unwrap()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn invalid_rtype_error() {
-        let header = RecordHeader::new::<MboMsg>(0xE, 1, 2, 3);
-        assert_eq!(
-            header.rtype().unwrap_err().to_string(),
-            "couldn't convert 0x0E to dbn::enums::RType"
-        );
-    }
-
-    #[test]
-    fn debug_mbo() {
-        let rec = MboMsg {
-            hd: RecordHeader::new::<MboMsg>(
-                rtype::MBO,
-                Publisher::OpraPillarXcbo as u16,
-                678,
-                1704468548242628731,
-            ),
-            flags: FlagSet::empty().set_last().set_bad_ts_recv(),
-            price: 4_500_500_000_000,
-            side: b'B' as c_char,
-            action: b'A' as c_char,
-            ..Default::default()
-        };
-        assert_eq!(
-            format!("{rec:?}"),
-            "MboMsg { hd: RecordHeader { length: 14, rtype: Mbo, publisher_id: OpraPillarXcbo, \
-            instrument_id: 678, ts_event: 1704468548242628731 }, order_id: 0, \
-            price: 4500.500000000, size: 4294967295, flags: LAST | BAD_TS_RECV (136), channel_id: 0, \
-            action: 'A', side: 'B', ts_recv: 18446744073709551615, ts_in_delta: 0, sequence: 0 }"
-        );
-    }
-
-    #[test]
-    fn debug_stats() {
-        let rec = StatMsg {
-            stat_type: StatType::OpenInterest as u16,
-            update_action: StatUpdateAction::New as u8,
-            quantity: 5,
-            stat_flags: 0b00000010,
-            ..Default::default()
-        };
-        assert_eq!(
-            format!("{rec:?}"),
-            "StatMsg { hd: RecordHeader { length: 20, rtype: Statistics, publisher_id: 0, \
-            instrument_id: 0, ts_event: 18446744073709551615 }, ts_recv: 18446744073709551615, \
-            ts_ref: 18446744073709551615, price: UNDEF_PRICE, quantity: 5, sequence: 0, ts_in_delta: 0, \
-            stat_type: OpenInterest, channel_id: 0, update_action: New, stat_flags: 0b00000010 }"
-        );
-    }
-
-    #[test]
-    fn debug_instrument_err() {
-        let rec = ErrorMsg {
-            err: str_to_c_chars("Missing stype_in").unwrap(),
-            ..Default::default()
-        };
-        assert_eq!(
-            format!("{rec:?}"),
-            "ErrorMsg { hd: RecordHeader { length: 80, rtype: Error, publisher_id: 0, \
-            instrument_id: 0, ts_event: 18446744073709551615 }, err: \"Missing stype_in\", code: 255, is_last: 255 }"
-        );
-    }
-
-    #[test]
-    fn debug_instrument_sys() {
-        let rec = SystemMsg::heartbeat(123);
-        assert_eq!(
-            format!("{rec:?}"),
-            "SystemMsg { hd: RecordHeader { length: 80, rtype: System, publisher_id: 0, \
-            instrument_id: 0, ts_event: 123 }, msg: \"Heartbeat\", code: Heartbeat }"
-        );
-    }
-
-    #[test]
-    fn debug_instrument_symbol_mapping() {
-        let rec = SymbolMappingMsg {
-            hd: RecordHeader::new::<SymbolMappingMsg>(
-                rtype::SYMBOL_MAPPING,
-                0,
-                5602,
-                1704466940331347283,
-            ),
-            stype_in: SType::RawSymbol as u8,
-            stype_in_symbol: str_to_c_chars("ESM4").unwrap(),
-            stype_out: SType::RawSymbol as u8,
-            stype_out_symbol: str_to_c_chars("ESM4").unwrap(),
-            ..Default::default()
-        };
-        assert_eq!(
-            format!("{rec:?}"),
-            "SymbolMappingMsg { hd: RecordHeader { length: 44, rtype: SymbolMapping, publisher_id: 0, instrument_id: 5602, ts_event: 1704466940331347283 }, stype_in: RawSymbol, stype_in_symbol: \"ESM4\", stype_out: RawSymbol, stype_out_symbol: \"ESM4\", start_ts: 18446744073709551615, end_ts: 18446744073709551615 }"
-        );
+    /// Parses the type of system message into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `code` field does not
+    /// contain a valid [`SystemCode`].
+    pub fn code(&self) -> crate::Result<SystemCode> {
+        SystemCode::try_from(self.code)
+            .map_err(|_| Error::conversion::<SystemCode>(format!("{:#04X}", self.code)))
     }
 }

--- a/rust/dbn/src/record/record_methods_tests.rs
+++ b/rust/dbn/src/record/record_methods_tests.rs
@@ -1,0 +1,100 @@
+#![cfg(test)]
+
+use crate::SType;
+
+use super::*;
+
+#[test]
+fn invalid_rtype_error() {
+    let header = RecordHeader::new::<MboMsg>(0xE, 1, 2, 3);
+    assert_eq!(
+        header.rtype().unwrap_err().to_string(),
+        "couldn't convert 0x0E to dbn::enums::RType"
+    );
+}
+
+#[test]
+fn debug_mbo() {
+    let rec = MboMsg {
+        hd: RecordHeader::new::<MboMsg>(
+            rtype::MBO,
+            Publisher::OpraPillarXcbo as u16,
+            678,
+            1704468548242628731,
+        ),
+        flags: FlagSet::empty().set_last().set_bad_ts_recv(),
+        price: 4_500_500_000_000,
+        side: b'B' as c_char,
+        action: b'A' as c_char,
+        ..Default::default()
+    };
+    assert_eq!(
+            format!("{rec:?}"),
+            "MboMsg { hd: RecordHeader { length: 14, rtype: Mbo, publisher_id: OpraPillarXcbo, \
+            instrument_id: 678, ts_event: 1704468548242628731 }, order_id: 0, \
+            price: 4500.500000000, size: 4294967295, flags: LAST | BAD_TS_RECV (136), channel_id: 0, \
+            action: 'A', side: 'B', ts_recv: 18446744073709551615, ts_in_delta: 0, sequence: 0 }"
+        );
+}
+
+#[test]
+fn debug_stats() {
+    let rec = StatMsg {
+        stat_type: StatType::OpenInterest as u16,
+        update_action: StatUpdateAction::New as u8,
+        quantity: 5,
+        stat_flags: 0b00000010,
+        ..Default::default()
+    };
+    assert_eq!(
+            format!("{rec:?}"),
+            "StatMsg { hd: RecordHeader { length: 20, rtype: Statistics, publisher_id: 0, \
+            instrument_id: 0, ts_event: 18446744073709551615 }, ts_recv: 18446744073709551615, \
+            ts_ref: 18446744073709551615, price: UNDEF_PRICE, quantity: 5, sequence: 0, ts_in_delta: 0, \
+            stat_type: OpenInterest, channel_id: 0, update_action: New, stat_flags: 0b00000010 }"
+        );
+}
+
+#[test]
+fn debug_instrument_err() {
+    let rec = ErrorMsg {
+        err: str_to_c_chars("Missing stype_in").unwrap(),
+        ..Default::default()
+    };
+    assert_eq!(
+            format!("{rec:?}"),
+            "ErrorMsg { hd: RecordHeader { length: 80, rtype: Error, publisher_id: 0, \
+            instrument_id: 0, ts_event: 18446744073709551615 }, err: \"Missing stype_in\", code: 255, is_last: 255 }"
+        );
+}
+
+#[test]
+fn debug_instrument_sys() {
+    let rec = SystemMsg::heartbeat(123);
+    assert_eq!(
+        format!("{rec:?}"),
+        "SystemMsg { hd: RecordHeader { length: 80, rtype: System, publisher_id: 0, \
+            instrument_id: 0, ts_event: 123 }, msg: \"Heartbeat\", code: Heartbeat }"
+    );
+}
+
+#[test]
+fn debug_instrument_symbol_mapping() {
+    let rec = SymbolMappingMsg {
+        hd: RecordHeader::new::<SymbolMappingMsg>(
+            rtype::SYMBOL_MAPPING,
+            0,
+            5602,
+            1704466940331347283,
+        ),
+        stype_in: SType::RawSymbol as u8,
+        stype_in_symbol: str_to_c_chars("ESM4").unwrap(),
+        stype_out: SType::RawSymbol as u8,
+        stype_out_symbol: str_to_c_chars("ESM4").unwrap(),
+        ..Default::default()
+    };
+    assert_eq!(
+            format!("{rec:?}"),
+            "SymbolMappingMsg { hd: RecordHeader { length: 44, rtype: SymbolMapping, publisher_id: 0, instrument_id: 5602, ts_event: 1704466940331347283 }, stype_in: RawSymbol, stype_in_symbol: \"ESM4\", stype_out: RawSymbol, stype_out_symbol: \"ESM4\", start_ts: 18446744073709551615, end_ts: 18446744073709551615 }"
+        );
+}

--- a/rust/dbn/src/record/with_ts_out_methods.rs
+++ b/rust/dbn/src/record/with_ts_out_methods.rs
@@ -1,0 +1,50 @@
+use std::mem;
+
+use crate::{record::as_u8_slice, HasRType, Record, RecordHeader, RecordMut, WithTsOut};
+
+impl<T: HasRType> Record for WithTsOut<T> {
+    fn header(&self) -> &RecordHeader {
+        self.rec.header()
+    }
+
+    fn raw_index_ts(&self) -> u64 {
+        self.rec.raw_index_ts()
+    }
+}
+
+impl<T: HasRType> RecordMut for WithTsOut<T> {
+    fn header_mut(&mut self) -> &mut RecordHeader {
+        self.rec.header_mut()
+    }
+}
+
+impl<T: HasRType> HasRType for WithTsOut<T> {
+    fn has_rtype(rtype: u8) -> bool {
+        T::has_rtype(rtype)
+    }
+}
+
+impl<T> AsRef<[u8]> for WithTsOut<T>
+where
+    T: HasRType,
+{
+    fn as_ref(&self) -> &[u8] {
+        unsafe { as_u8_slice(self) }
+    }
+}
+
+impl<T: HasRType> WithTsOut<T> {
+    /// Creates a new record with `ts_out`. Updates the `length` property in
+    /// [`RecordHeader`] to ensure the additional field is accounted for.
+    pub fn new(rec: T, ts_out: u64) -> Self {
+        let mut res = Self { rec, ts_out };
+        res.header_mut().length = (mem::size_of_val(&res) / RecordHeader::LENGTH_MULTIPLIER) as u8;
+        res
+    }
+
+    /// Parses the raw live gateway send timestamp into a datetime.
+    pub fn ts_out(&self) -> time::OffsetDateTime {
+        // u64::MAX is within maximum allowable range
+        time::OffsetDateTime::from_unix_timestamp_nanos(self.ts_out as i128).unwrap()
+    }
+}

--- a/rust/dbn/src/v1/methods.rs
+++ b/rust/dbn/src/v1/methods.rs
@@ -7,200 +7,10 @@ use crate::{
     StatUpdateAction,
 };
 
-use super::{ErrorMsg, InstrumentDefMsg, StatMsg, SymbolMappingMsg, SystemMsg};
-
-impl InstrumentDefMsg {
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
-    }
-
-    /// Parses the raw last eligible trade time into a datetime. Returns `None` if
-    /// `expiration` contains the sentinel for a null timestamp.
-    pub fn expiration(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.expiration)
-    }
-
-    /// Parses the raw time of instrument action into a datetime. Returns `None` if
-    /// `activation` contains the sentinel for a null timestamp.
-    pub fn activation(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.activation)
-    }
-
-    /// Returns currency used for price fields as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `currency` contains invalid UTF-8.
-    pub fn currency(&self) -> Result<&str> {
-        c_chars_to_str(&self.currency)
-    }
-
-    /// Returns currency used for settlement as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `settl_currency` contains invalid UTF-8.
-    pub fn settl_currency(&self) -> Result<&str> {
-        c_chars_to_str(&self.settl_currency)
-    }
-
-    /// Returns the strategy type of the spread as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `secsubtype` contains invalid UTF-8.
-    pub fn secsubtype(&self) -> Result<&str> {
-        c_chars_to_str(&self.secsubtype)
-    }
-
-    /// Returns the instrument raw symbol assigned by the publisher as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `raw_symbol` contains invalid UTF-8.
-    pub fn raw_symbol(&self) -> Result<&str> {
-        c_chars_to_str(&self.raw_symbol)
-    }
-
-    /// Returns exchange used to identify the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `exchange` contains invalid UTF-8.
-    pub fn exchange(&self) -> Result<&str> {
-        c_chars_to_str(&self.exchange)
-    }
-
-    /// Returns the underlying asset code (product code) of the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `asset` contains invalid UTF-8.
-    pub fn asset(&self) -> Result<&str> {
-        c_chars_to_str(&self.asset)
-    }
-
-    /// Returns the ISO standard instrument categorization code as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `cfi` contains invalid UTF-8.
-    pub fn cfi(&self) -> Result<&str> {
-        c_chars_to_str(&self.cfi)
-    }
-
-    /// Returns the [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type)
-    /// of the instrument, e.g. FUT for future or future spread as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `security_type` contains invalid UTF-8.
-    pub fn security_type(&self) -> Result<&str> {
-        c_chars_to_str(&self.security_type)
-    }
-
-    /// Returns the unit of measure for the instrument's original contract size, e.g.
-    /// USD or LBS, as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
-    pub fn unit_of_measure(&self) -> Result<&str> {
-        c_chars_to_str(&self.unit_of_measure)
-    }
-
-    /// Returns the symbol of the first underlying instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `underlying` contains invalid UTF-8.
-    pub fn underlying(&self) -> Result<&str> {
-        c_chars_to_str(&self.underlying)
-    }
-
-    /// Returns the currency of [`strike_price`](Self::strike_price) as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
-    pub fn strike_price_currency(&self) -> Result<&str> {
-        c_chars_to_str(&self.strike_price_currency)
-    }
-
-    /// Returns the security group code of the instrumnet as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `group` contains invalid UTF-8.
-    pub fn group(&self) -> Result<&str> {
-        c_chars_to_str(&self.group)
-    }
-
-    /// Tries to convert the raw classification of the instrument to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `instrument_class` field does not
-    /// contain a valid [`InstrumentClass`].
-    pub fn instrument_class(&self) -> Result<InstrumentClass> {
-        InstrumentClass::try_from(self.instrument_class as u8).map_err(|_| {
-            Error::conversion::<InstrumentClass>(format!("{:#04X}", self.instrument_class as u8))
-        })
-    }
-
-    /// Tries to convert the raw matching algorithm used for the instrument to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `match_algorithm` field does not
-    /// contain a valid [`MatchAlgorithm`].
-    pub fn match_algorithm(&self) -> Result<MatchAlgorithm> {
-        MatchAlgorithm::try_from(self.match_algorithm as u8).map_err(|_| {
-            Error::conversion::<MatchAlgorithm>(format!("{:#04X}", self.match_algorithm as u8))
-        })
-    }
-}
-
-impl StatMsg {
-    /// Returns the price as a floating point.
-    ///
-    /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn price_f64(&self) -> f64 {
-        px_to_f64(self.price)
-    }
-
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
-    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_recv)
-    }
-
-    /// Parses the raw reference timestamp of the statistic value into a datetime.
-    /// Returns `None` if `ts_ref` contains the sentinel for a null timestamp.
-    pub fn ts_ref(&self) -> Option<time::OffsetDateTime> {
-        ts_to_dt(self.ts_ref)
-    }
-
-    /// Tries to convert the raw type of the statistic value to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `stat_type` field does not
-    /// contain a valid [`StatType`].
-    pub fn stat_type(&self) -> Result<StatType> {
-        StatType::try_from(self.stat_type)
-            .map_err(|_| Error::conversion::<StatType>(self.stat_type))
-    }
-
-    /// Tries to convert the raw `update_action` to an enum.
-    ///
-    /// # Errors
-    /// This function returns an error if the `update_action` field does not
-    /// contain a valid [`StatUpdateAction`].
-    pub fn update_action(&self) -> Result<StatUpdateAction> {
-        StatUpdateAction::try_from(self.update_action).map_err(|_| {
-            Error::conversion::<StatUpdateAction>(format!("{:04X}", self.update_action))
-        })
-    }
-
-    /// Parses the raw `ts_in_delta`—the delta of `ts_recv - ts_exchange_send`—into a duration.
-    pub fn ts_in_delta(&self) -> time::Duration {
-        time::Duration::new(0, self.ts_in_delta)
-    }
-}
+use super::*;
 
 impl ErrorMsg {
-    /// Creates a new `ErrorMsgV1`.
-    ///
-    /// # Errors
-    /// This function returns an error if `msg` is too long.
+    /// Creates a new `ErrorMsg`. `msg` will be truncated if it's too long.
     pub fn new(ts_event: u64, msg: &str) -> Self {
         let mut error = Self {
             hd: RecordHeader::new::<Self>(rtype::ERROR, 0, 0, ts_event),
@@ -213,7 +23,7 @@ impl ErrorMsg {
         error
     }
 
-    /// Returns `err` as a `&str`.
+    /// Parses the error message into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `err` contains invalid UTF-8.
@@ -222,16 +32,317 @@ impl ErrorMsg {
     }
 }
 
+impl InstrumentDefMsg {
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+
+    /// Converts the minimum constant tick to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment)
+    }
+
+    /// Converts the display factor to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn display_factor_f64(&self) -> f64 {
+        px_to_f64(self.display_factor)
+    }
+
+    /// Parses the last eligible trade time into a datetime.
+    /// Returns `None` if `expiration` contains the sentinel for a null timestamp.
+    pub fn expiration(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.expiration)
+    }
+
+    /// Parses the time of instrument activation into a datetime.
+    /// Returns `None` if `activation` contains the sentinel for a null timestamp.
+    pub fn activation(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.activation)
+    }
+
+    /// Converts the high limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn high_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.high_limit_price)
+    }
+
+    /// Converts the low limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn low_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.low_limit_price)
+    }
+
+    /// Converts the differential value for price banding to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn max_price_variation_f64(&self) -> f64 {
+        px_to_f64(self.max_price_variation)
+    }
+
+    /// Converts the trading session settlement price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn trading_reference_price_f64(&self) -> f64 {
+        px_to_f64(self.trading_reference_price)
+    }
+
+    /// Converts the contract size for each instrument to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn unit_of_measure_qty_f64(&self) -> f64 {
+        px_to_f64(self.unit_of_measure_qty)
+    }
+
+    /// Converts the min price increment amount to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_amount_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment_amount)
+    }
+
+    /// Converts the price ratio to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_ratio_f64(&self) -> f64 {
+        px_to_f64(self.price_ratio)
+    }
+
+    /// Parses the currency into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `currency` contains invalid UTF-8.
+    pub fn currency(&self) -> Result<&str> {
+        c_chars_to_str(&self.currency)
+    }
+
+    /// Parses the currency used for settlement into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `settl_currency` contains invalid UTF-8.
+    pub fn settl_currency(&self) -> Result<&str> {
+        c_chars_to_str(&self.settl_currency)
+    }
+
+    /// Parses the strategy type of the spread into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `secsubtype` contains invalid UTF-8.
+    pub fn secsubtype(&self) -> Result<&str> {
+        c_chars_to_str(&self.secsubtype)
+    }
+
+    /// Parses the raw symbol into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `raw_symbol` contains invalid UTF-8.
+    pub fn raw_symbol(&self) -> Result<&str> {
+        c_chars_to_str(&self.raw_symbol)
+    }
+
+    /// Parses the security group code into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `group` contains invalid UTF-8.
+    pub fn group(&self) -> Result<&str> {
+        c_chars_to_str(&self.group)
+    }
+
+    /// Parses the exchange into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `exchange` contains invalid UTF-8.
+    pub fn exchange(&self) -> Result<&str> {
+        c_chars_to_str(&self.exchange)
+    }
+
+    /// Parses the asset into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `asset` contains invalid UTF-8.
+    pub fn asset(&self) -> Result<&str> {
+        c_chars_to_str(&self.asset)
+    }
+
+    /// Parses the CFI code into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `cfi` contains invalid UTF-8.
+    pub fn cfi(&self) -> Result<&str> {
+        c_chars_to_str(&self.cfi)
+    }
+
+    /// Parses the security type into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `security_type` contains invalid UTF-8.
+    pub fn security_type(&self) -> Result<&str> {
+        c_chars_to_str(&self.security_type)
+    }
+
+    /// Parses the unit of measure into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
+    pub fn unit_of_measure(&self) -> Result<&str> {
+        c_chars_to_str(&self.unit_of_measure)
+    }
+
+    /// Parses the underlying into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `underlying` contains invalid UTF-8.
+    pub fn underlying(&self) -> Result<&str> {
+        c_chars_to_str(&self.underlying)
+    }
+
+    /// Parses the strike price currency into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
+    pub fn strike_price_currency(&self) -> Result<&str> {
+        c_chars_to_str(&self.strike_price_currency)
+    }
+
+    /// Parses the instrument class into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `instrument_class` field does not
+    /// contain a valid [`InstrumentClass`].
+    pub fn instrument_class(&self) -> crate::Result<InstrumentClass> {
+        InstrumentClass::try_from(self.instrument_class as u8).map_err(|_| {
+            Error::conversion::<InstrumentClass>(format!("{:#04X}", self.instrument_class as u8))
+        })
+    }
+
+    /// Converts the strike price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn strike_price_f64(&self) -> f64 {
+        px_to_f64(self.strike_price)
+    }
+
+    /// Parses the match algorithm into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `match_algorithm` field does not
+    /// contain a valid [`MatchAlgorithm`].
+    pub fn match_algorithm(&self) -> crate::Result<MatchAlgorithm> {
+        MatchAlgorithm::try_from(self.match_algorithm as u8).map_err(|_| {
+            Error::conversion::<MatchAlgorithm>(format!("{:#04X}", self.match_algorithm as u8))
+        })
+    }
+}
+
+impl StatMsg {
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
+    pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_recv)
+    }
+
+    /// Parses the reference timestamp of the statistic value into a datetime.
+    /// Returns `None` if `ts_ref` contains the sentinel for a null timestamp.
+    pub fn ts_ref(&self) -> Option<time::OffsetDateTime> {
+        ts_to_dt(self.ts_ref)
+    }
+
+    /// Converts the value for price statistics to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_f64(&self) -> f64 {
+        px_to_f64(self.price)
+    }
+
+    /// Parses the difference between `ts_recv` and the matching-engine-sending timestamp into a duration.
+    pub fn ts_in_delta(&self) -> time::Duration {
+        time::Duration::new(0, self.ts_in_delta)
+    }
+
+    /// Parses the type of statistic value into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `stat_type` field does not
+    /// contain a valid [`StatType`].
+    pub fn stat_type(&self) -> crate::Result<StatType> {
+        StatType::try_from(self.stat_type)
+            .map_err(|_| Error::conversion::<StatType>(format!("{:#04X}", self.stat_type)))
+    }
+
+    /// Parses the update action into an enum.
+    ///
+    /// # Errors
+    /// This function returns an error if the `update_action` field does not
+    /// contain a valid [`StatUpdateAction`].
+    pub fn update_action(&self) -> crate::Result<StatUpdateAction> {
+        StatUpdateAction::try_from(self.update_action).map_err(|_| {
+            Error::conversion::<StatUpdateAction>(format!("{:#04X}", self.update_action))
+        })
+    }
+}
+
 impl SymbolMappingMsg {
     /// Creates a new `SymbolMappingMsg`.
     ///
     /// # Errors
     /// This function returns an error if `stype_in_symbol` or `stype_out_symbol`
-    /// contain more than maximum number of characters of 21.
+    /// contain more than maximum number of 21 characters.
     pub fn new(
         instrument_id: u32,
         ts_event: u64,
+
         stype_in_symbol: &str,
+
         stype_out_symbol: &str,
         start_ts: u64,
         end_ts: u64,
@@ -247,7 +358,7 @@ impl SymbolMappingMsg {
         })
     }
 
-    /// Returns the input symbol as a `&str`.
+    /// Parses the input symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `stype_in_symbol` contains invalid UTF-8.
@@ -255,7 +366,7 @@ impl SymbolMappingMsg {
         c_chars_to_str(&self.stype_in_symbol)
     }
 
-    /// Returns the output symbol as a `&str`.
+    /// Parses the output symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `stype_out_symbol` contains invalid UTF-8.
@@ -263,21 +374,21 @@ impl SymbolMappingMsg {
         c_chars_to_str(&self.stype_out_symbol)
     }
 
-    /// Parses the raw start of the mapping interval into a datetime. Returns `None` if
-    /// `start_ts` contains the sentinel for a null timestamp.
+    /// Parses the start of the mapping interval into a datetime.
+    /// Returns `None` if `start_ts` contains the sentinel for a null timestamp.
     pub fn start_ts(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.start_ts)
     }
 
-    /// Parses the raw end of the mapping interval into a datetime. Returns `None` if
-    /// `end_ts` contains the sentinel for a null timestamp.
+    /// Parses the end of the mapping interval into a datetime.
+    /// Returns `None` if `end_ts` contains the sentinel for a null timestamp.
     pub fn end_ts(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.end_ts)
     }
 }
 
 impl SystemMsg {
-    /// Creates a new `SystemMsgV1`.
+    /// Creates a new `SystemMsg`.
     ///
     /// # Errors
     /// This function returns an error if `msg` is too long.
@@ -303,8 +414,7 @@ impl SystemMsg {
             .unwrap_or_default()
     }
 
-    /// Returns the message from the Databento Live Subscription Gateway (LSG) as
-    /// a `&str`.
+    /// Parses the message from the Databento gateway into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `msg` contains invalid UTF-8.

--- a/rust/dbn/src/v2/methods.rs
+++ b/rust/dbn/src/v2/methods.rs
@@ -4,42 +4,138 @@ use crate::{
     Error, InstrumentClass, MatchAlgorithm, Result, SecurityUpdateAction,
 };
 
-use super::InstrumentDefMsg;
+use super::*;
 
 impl InstrumentDefMsg {
-    /// Parses the raw capture-server-received timestamp into a datetime. Returns `None`
-    /// if `ts_recv` contains the sentinel for a null timestamp.
+    /// Parses the capture-server-received timestamp into a datetime.
+    /// Returns `None` if `ts_recv` contains the sentinel for a null timestamp.
     pub fn ts_recv(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.ts_recv)
     }
 
-    /// Returns the unit of measure quantity as a floating point.
+    /// Converts the minimum constant tick to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn unit_of_measure_qty_f64(&self) -> f64 {
-        px_to_f64(self.unit_of_measure_qty)
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment)
     }
 
-    /// Returns the strike price as a floating point.
+    /// Converts the display factor to a floating point.
     ///
     /// `UNDEF_PRICE` will be converted to NaN.
-    pub fn strike_price_f64(&self) -> f64 {
-        px_to_f64(self.strike_price)
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn display_factor_f64(&self) -> f64 {
+        px_to_f64(self.display_factor)
     }
 
-    /// Parses the raw last eligible trade time into a datetime. Returns `None` if
-    /// `expiration` contains the sentinel for a null timestamp.
+    /// Parses the last eligible trade time into a datetime.
+    /// Returns `None` if `expiration` contains the sentinel for a null timestamp.
     pub fn expiration(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.expiration)
     }
 
-    /// Parses the raw time of instrument action into a datetime. Returns `None` if
-    /// `activation` contains the sentinel for a null timestamp.
+    /// Parses the time of instrument activation into a datetime.
+    /// Returns `None` if `activation` contains the sentinel for a null timestamp.
     pub fn activation(&self) -> Option<time::OffsetDateTime> {
         ts_to_dt(self.activation)
     }
 
-    /// Returns currency used for price fields as a `&str`.
+    /// Converts the high limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn high_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.high_limit_price)
+    }
+
+    /// Converts the low limit price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn low_limit_price_f64(&self) -> f64 {
+        px_to_f64(self.low_limit_price)
+    }
+
+    /// Converts the differential value for price banding to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn max_price_variation_f64(&self) -> f64 {
+        px_to_f64(self.max_price_variation)
+    }
+
+    /// Converts the trading session settlement price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn trading_reference_price_f64(&self) -> f64 {
+        px_to_f64(self.trading_reference_price)
+    }
+
+    /// Converts the contract size for each instrument to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn unit_of_measure_qty_f64(&self) -> f64 {
+        px_to_f64(self.unit_of_measure_qty)
+    }
+
+    /// Converts the min price increment amount to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn min_price_increment_amount_f64(&self) -> f64 {
+        px_to_f64(self.min_price_increment_amount)
+    }
+
+    /// Converts the price ratio to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn price_ratio_f64(&self) -> f64 {
+        px_to_f64(self.price_ratio)
+    }
+
+    /// Converts the strike price to a floating point.
+    ///
+    /// `UNDEF_PRICE` will be converted to NaN.
+    ///
+    /// <div class="warning">
+    /// This may introduce floating-point error.
+    /// </div>
+    pub fn strike_price_f64(&self) -> f64 {
+        px_to_f64(self.strike_price)
+    }
+
+    /// Parses the currency into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `currency` contains invalid UTF-8.
@@ -47,7 +143,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.currency)
     }
 
-    /// Returns currency used for settlement as a `&str`.
+    /// Parses the currency used for settlement into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `settl_currency` contains invalid UTF-8.
@@ -55,7 +151,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.settl_currency)
     }
 
-    /// Returns the strategy type of the spread as a `&str`.
+    /// Parses the strategy type of the spread into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `secsubtype` contains invalid UTF-8.
@@ -63,7 +159,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.secsubtype)
     }
 
-    /// Returns the instrument raw symbol assigned by the publisher as a `&str`.
+    /// Parses the raw symbol into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `raw_symbol` contains invalid UTF-8.
@@ -71,65 +167,7 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.raw_symbol)
     }
 
-    /// Returns exchange used to identify the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `exchange` contains invalid UTF-8.
-    pub fn exchange(&self) -> Result<&str> {
-        c_chars_to_str(&self.exchange)
-    }
-
-    /// Returns the underlying asset code (product code) of the instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `asset` contains invalid UTF-8.
-    pub fn asset(&self) -> Result<&str> {
-        c_chars_to_str(&self.asset)
-    }
-
-    /// Returns the ISO standard instrument categorization code as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `cfi` contains invalid UTF-8.
-    pub fn cfi(&self) -> Result<&str> {
-        c_chars_to_str(&self.cfi)
-    }
-
-    /// Returns the [Security type](https://databento.com/docs/schemas-and-data-formats/instrument-definitions#security-type)
-    /// of the instrument, e.g. FUT for future or future spread as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `security_type` contains invalid UTF-8.
-    pub fn security_type(&self) -> Result<&str> {
-        c_chars_to_str(&self.security_type)
-    }
-
-    /// Returns the unit of measure for the instrument's original contract size, e.g.
-    /// USD or LBS, as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
-    pub fn unit_of_measure(&self) -> Result<&str> {
-        c_chars_to_str(&self.unit_of_measure)
-    }
-
-    /// Returns the symbol of the first underlying instrument as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `underlying` contains invalid UTF-8.
-    pub fn underlying(&self) -> Result<&str> {
-        c_chars_to_str(&self.underlying)
-    }
-
-    /// Returns the currency of [`strike_price`](Self::strike_price) as a `&str`.
-    ///
-    /// # Errors
-    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
-    pub fn strike_price_currency(&self) -> Result<&str> {
-        c_chars_to_str(&self.strike_price_currency)
-    }
-
-    /// Returns the security group code of the instrumnet as a `&str`.
+    /// Parses the security group code into a `&str`.
     ///
     /// # Errors
     /// This function returns an error if `group` contains invalid UTF-8.
@@ -137,35 +175,90 @@ impl InstrumentDefMsg {
         c_chars_to_str(&self.group)
     }
 
-    /// Tries to convert the raw classification of the instrument to an enum.
+    /// Parses the exchange into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `exchange` contains invalid UTF-8.
+    pub fn exchange(&self) -> Result<&str> {
+        c_chars_to_str(&self.exchange)
+    }
+
+    /// Parses the asset into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `asset` contains invalid UTF-8.
+    pub fn asset(&self) -> Result<&str> {
+        c_chars_to_str(&self.asset)
+    }
+
+    /// Parses the CFI code into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `cfi` contains invalid UTF-8.
+    pub fn cfi(&self) -> Result<&str> {
+        c_chars_to_str(&self.cfi)
+    }
+
+    /// Parses the security type into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `security_type` contains invalid UTF-8.
+    pub fn security_type(&self) -> Result<&str> {
+        c_chars_to_str(&self.security_type)
+    }
+
+    /// Parses the unit of measure into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `unit_of_measure` contains invalid UTF-8.
+    pub fn unit_of_measure(&self) -> Result<&str> {
+        c_chars_to_str(&self.unit_of_measure)
+    }
+
+    /// Parses the underlying into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `underlying` contains invalid UTF-8.
+    pub fn underlying(&self) -> Result<&str> {
+        c_chars_to_str(&self.underlying)
+    }
+
+    /// Parses the strike price currency into a `&str`.
+    ///
+    /// # Errors
+    /// This function returns an error if `strike_price_currency` contains invalid UTF-8.
+    pub fn strike_price_currency(&self) -> Result<&str> {
+        c_chars_to_str(&self.strike_price_currency)
+    }
+
+    /// Parses the instrument class into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `instrument_class` field does not
     /// contain a valid [`InstrumentClass`].
-    pub fn instrument_class(&self) -> Result<InstrumentClass> {
+    pub fn instrument_class(&self) -> crate::Result<InstrumentClass> {
         InstrumentClass::try_from(self.instrument_class as u8).map_err(|_| {
             Error::conversion::<InstrumentClass>(format!("{:#04X}", self.instrument_class as u8))
         })
     }
 
-    /// Tries to convert the raw matching algorithm used for the instrument to an enum.
+    /// Parses the match algorithm into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `match_algorithm` field does not
     /// contain a valid [`MatchAlgorithm`].
-    pub fn match_algorithm(&self) -> Result<MatchAlgorithm> {
+    pub fn match_algorithm(&self) -> crate::Result<MatchAlgorithm> {
         MatchAlgorithm::try_from(self.match_algorithm as u8).map_err(|_| {
             Error::conversion::<MatchAlgorithm>(format!("{:#04X}", self.match_algorithm as u8))
         })
     }
 
-    /// Returns the action indicating whether the instrument definition has been added,
-    /// modified, or deleted.
+    /// Parses the security update action into an enum.
     ///
     /// # Errors
     /// This function returns an error if the `security_update_action` field does not
     /// contain a valid [`SecurityUpdateAction`].
-    pub fn security_update_action(&self) -> Result<SecurityUpdateAction> {
+    pub fn security_update_action(&self) -> crate::Result<SecurityUpdateAction> {
         SecurityUpdateAction::try_from(self.security_update_action as u8).map_err(|_| {
             Error::conversion::<SecurityUpdateAction>(format!(
                 "{:#04X}",


### PR DESCRIPTION
### Enhancements
- Added `side()` and `unpaired_side()` methods to `ImbalanceMsg` that convert the fields
  of the same name to the `Side` enum
- Added `pretty_auction_time` property in Python for `ImbalanceMsg`
- Added `Default` implementation for `StatUpdateAction`
- Added warnings to the floating-point getter methods' docstrings
- Added `action` and `ts_in_delta` getters to `BboMsg`
- Added `ts_recv` getter to `StatusMsg`
- Added missing floating-point price getters to `InstrumentDefMsg` record types from all
  DBN versions
- Added more floating-point price getters to `ImbalanceMsg`
- Added floating-point price getter to `StatMsg` and `v1::StatMsg`
- Standardize Python `__init__` type signatures
- Upgraded `async-compression` dependency version to 0.4.27

### Breaking changes
- Changed `SystemMsg::code()` and `ErrorMsg::code()` methods to return a `Result`
  instead of an `Option` to be consistent with other enum conversion methods
- Changed `auction_time` field in `ImbalanceMsg` to be formatted as a timestamp

### Bug fixes
- Fixed a regression where some enum constructors no longer raised a `DBNError` in
  Python
- Fixed typo in `RecordHeader`'s `rtype` docstring
- Removed error documentation from `ErrorMsg::new` because the function never returns an
  error

