### PR TITLE
VER: Release 0.42.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           body_path: ./NOTES.md
           prerelease: false
 
-  macos-release:
+  macos-python-release:
     needs: [tag-release]
     strategy:
       fail-fast: false
@@ -89,7 +89,7 @@ jobs:
           name: wheel-macos-${{ matrix.python-version }}
           path: dist
 
-  windows-release:
+  windows-python-release:
     needs: [tag-release]
     strategy:
       fail-fast: false
@@ -132,7 +132,7 @@ jobs:
           name: wheel-windows-${{ matrix.python-version }}
           path: dist
 
-  linux-release:
+  linux-python-release:
     needs: [tag-release]
     strategy:
       fail-fast: false
@@ -176,7 +176,7 @@ jobs:
           name: wheel-linux-${{ matrix.target }}-${{ matrix.python-version }}
           path: dist
 
-  linux-musl-release:
+  linux-musl-python-release:
     needs: [tag-release]
     strategy:
       fail-fast: false
@@ -225,10 +225,10 @@ jobs:
     needs:
       [
         tag-release,
-        macos-release,
-        windows-release,
-        linux-release,
-        linux-musl-release,
+        macos-python-release,
+        windows-python-release,
+        linux-python-release,
+        linux-musl-python-release,
       ]
     steps:
       - uses: actions/download-artifact@v4
@@ -252,10 +252,10 @@ jobs:
     needs:
       [
         tag-release,
-        macos-release,
-        windows-release,
-        linux-release,
-        linux-musl-release,
+        macos-python-release,
+        windows-python-release,
+        linux-python-release,
+        linux-musl-python-release,
       ]
     steps:
       - name: Checkout repository
@@ -288,3 +288,105 @@ jobs:
         run: cargo publish --token ${CARGO_REGISTRY_TOKEN} --package dbn-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  build-cli-artifacts:
+    name: build-release
+    needs: [tag-release]
+    runs-on: ${{ matrix.os }}
+    env:
+      TARGET_FLAGS:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - os: ubuntu-latest
+          target: aarch64-unknown-linux-musl
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: macos-latest
+          target: aarch64-apple-darwin
+        - os: windows-latest
+          target: aarch64-pc-windows-msvc
+        - os: windows-latest
+          target: x86_64-pc-windows-gnu
+        - os: windows-latest
+          target: x86_64-pc-windows-gnu
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Rust
+      run: rustup toolchain add --profile minimal --target ${{ matrix.target }} stable
+
+    - name: Set target variables
+      shell: bash
+      run: |
+        echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
+        echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
+
+    - name: Show command used for Cargo
+      shell: bash
+      run: |
+        echo "cargo command is: ${{ env.CARGO }}"
+        echo "target flag is: ${{ env.TARGET_FLAGS }}"
+        echo "target dir is: ${{ env.TARGET_DIR }}"
+
+    - name: Build release binary
+      shell: bash
+      run: |
+        cargo build --verbose --release dbn-cli ${{ env.TARGET_FLAGS }}
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          bin="target/${{ matrix.target }}/release/dbn.exe"
+        else
+          bin="target/${{ matrix.target }}/release/dbn"
+        fi
+        echo "BIN=$bin" >> $GITHUB_ENV
+
+    - name: Determine archive name
+      shell: bash
+      run: |
+        version="${{ needs.create-release.outputs.version }}"
+        echo "ARCHIVE=ripgrep-$version-${{ matrix.target }}" >> $GITHUB_ENV
+
+    - name: Creating directory for archive
+      shell: bash
+      run: |
+        mkdir -p "$ARCHIVE"/{complete,doc}
+        cp "$BIN" "$ARCHIVE"/
+        cp {rust/src/dbn-cli/README.md,LICENSE} "$ARCHIVE"/
+        cp {CHANGELOG.md} "$ARCHIVE"/doc/
+
+    - name: Build archive (Windows)
+      shell: bash
+      if: matrix.os == 'windows-latest'
+      run: |
+        7z a "$ARCHIVE.zip" "$ARCHIVE"
+        certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
+        echo "ASSET=$ARCHIVE.zip" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> $GITHUB_ENV
+
+    - name: Build archive (Unix)
+      shell: bash
+      if: matrix.os != 'windows-latest'
+      run: |
+        tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+        shasum -a 256 "$ARCHIVE.tar.gz" > "$ARCHIVE.tar.gz.sha256"
+        echo "ASSET=$ARCHIVE.tar.gz" >> $GITHUB_ENV
+        echo "ASSET_SUM=$ARCHIVE.tar.gz.sha256" >> $GITHUB_ENV
+
+    - name: Upload release archive
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        version="$(scripts/get_version.sh)"
+        gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.41.0 - 2025-08-26
 
 ### Enhancements
-- Added `interval` method `RType` and `Schema` to get the duration for subsample schemas
-  like `Ohlcv1H` and `Cbbo1S`
+- Added `interval` method to `RType` and `Schema` to get the duration for subsampled
+  schemas like `Ohlcv1H` and `Cbbo1S`
 
 ### Breaking changes
 - Changed the default value for `channel_id` to be `u8::MAX` in `MboMsg` and `u16::MAX`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.42.0 - TBD
+
+### Enhancements
+- Added `ts_index` and `pretty_ts_index` property for records in Python which provides
+  the timestamp that is most appropriate for indexing
+
+### Bug fixes
+- Fixed type stub for `channel_id` in Python to allow `None`
+
 ## 0.41.0 - 2025-08-26
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.42.0 - TBD
+## 0.42.0 - 2025-09-23
 
 ### Enhancements
-- Added `ts_index` and `pretty_ts_index` property for records in Python which provides
+- Added `ts_index` and `pretty_ts_index` properties for records in Python which provides
   the timestamp that is most appropriate for indexing
+- Upgraded `pyo3` version to 0.26.0
 
 ### Bug fixes
 - Fixed type stub for `channel_id` in Python to allow `None`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 - Fixed type stub for `channel_id` in Python to allow `None`
+- Fixed missing re-export for `record::TcbboMsg`
 
 ## 0.41.0 - 2025-08-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "assert_cmd"
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "csv",
  "dbn",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -472,9 +472,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
@@ -694,27 +694,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.6",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
  "libc",
@@ -729,19 +729,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -749,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -761,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -899,18 +898,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1026,9 +1035,9 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1084,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -1099,15 +1108,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1145,7 +1154,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.8",
- "toml_edit",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -1157,7 +1166,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1174,11 +1183,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1195,10 +1204,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.1"
+name = "toml_edit"
+version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
@@ -1211,9 +1232,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "trybuild"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e257d7246e7a9fd015fb0b28b330a8d4142151a33f03e6a497754f4b1f6a8e"
+checksum = "0ded9fdb81f30a5708920310bfcd9ea7482ff9cba5f54601f7a19a877d5c2392"
 dependencies = [
  "glob",
  "serde",
@@ -1365,9 +1386,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.41.0"
+version = "0.42.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 csv = "1.3"
-pyo3 = "0.25.1"
-pyo3-build-config = "0.25.1"
+pyo3 = "0.26.0"
+pyo3-build-config = "0.26.0"
 rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
-time = "0.3.41"
+time = "0.3.44"
 zstd = "0.13"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = { workspace = true }
 dbn = { path = "../rust/dbn", features = [] }
-libc = "0.2.175"
+libc = "0.2.176"
 
 [build-dependencies]
 cbindgen = { version = "0.29.0", default-features = false }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databento-dbn"
-version = "0.41.0"
+version = "0.42.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 authors = ["Databento <support@databento.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ build-backend = "maturin"
 
 [project]
 name = "databento-dbn"
-version = "0.41.0"
+version = "0.42.0"
 authors = [
     { name = "Databento", email = "support@databento.com" }
 ]

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -7384,7 +7384,7 @@ class Transcoder:
     pretty_px : bool, default True
         Whether to serialize fixed-precision prices as decimal strings. Only applicable
         to CSV and JSON.
-    pretty_ts : bool, default Tru | Nonee
+    pretty_ts : bool, default True | None
         Whether to serialize nanosecond UNIX timestamps as ISO8601 datetime strings.
         Only applicable to CSV and JSON.
     map_symbols : bool, default None

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: UP007 PYI021 PYI011 PYI014
+# ruff: noqa: UP007, PYI021, PYI011
 from __future__ import annotations
 
 import datetime as dt

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -327,6 +327,44 @@ class Record(SupportsBytes):
         """
 
     @property
+    def ts_index(self) -> int:
+        """
+        The raw primary timestamp for the record as the number of nanoseconds since the
+        UNIX epoch. For records that define a `ts_recv` and `ts_event`, this method will
+        return the appropriate timestamp for indexing based on the record's type.
+
+        This timestamp should be used for sorting records as well as indexing into any
+        symbology data structure.
+
+        See `ts_event` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-event.
+        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+
+        Returns
+        -------
+        int
+
+        """
+
+    @property
+    def pretty_ts_index(self) -> dt.datetime | None:
+        """
+        The primary timestamp for the record as the expressed as a datetime or a
+        `pandas.Timestamp`, if available. For records that define a `ts_recv` and `ts_event`,
+        this method will return the appropriate timestamp for indexing based on the record's type.
+
+        This timestamp should be used for sorting records as well as indexing into any
+        symbology data structure.
+
+        See `ts_event` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-event.
+        See `ts_recv` https://databento.com/docs/standards-and-conventions/common-fields-enums-types#ts-recv.
+
+        Returns
+        -------
+        datetime.datetime
+
+        """
+
+    @property
     def pretty_ts_event(self) -> dt.datetime | None:
         """
         The matching-engine-received timestamp expressed as a
@@ -1324,7 +1362,7 @@ class MBOMsg(Record):
         side: Side,
         ts_recv: int,
         flags: int | None = None,
-        channel_id: int = 0,
+        channel_id: int | None = None,
         ts_in_delta: int = 0,
         sequence: int = 0,
     ) -> None: ...
@@ -3016,7 +3054,7 @@ class InstrumentDefMsg(Record):
         raw_instrument_id: int = 0,
         leg_price: int = UNDEF_PRICE,
         leg_delta: int = UNDEF_PRICE,
-        inst_attrib_value: int = 0,
+        inst_attrib_value: int | None = None,
         underlying_id: int = 0,
         market_depth_implied: int | None = None,
         market_depth: int | None = None,
@@ -3038,7 +3076,7 @@ class InstrumentDefMsg(Record):
         appl_id: int | None = None,
         maturity_year: int | None = None,
         decay_start_date: int | None = None,
-        channel_id: int = 0,
+        channel_id: int | None = None,
         leg_count: int = 0,
         leg_index: int = 0,
         currency: str = "",
@@ -4559,7 +4597,7 @@ class StatMsg(Record):
         stat_type: StatType,
         sequence: int = 0,
         ts_in_delta: int = 0,
-        channel_id: int = 0,
+        channel_id: int | None = None,
         update_action: StatUpdateAction | None = None,
         stat_flags: int = 0,
     ) -> None: ...
@@ -5965,7 +6003,7 @@ class StatMsgV1(Record):
         stat_type: StatType,
         sequence: int = 0,
         ts_in_delta: int = 0,
-        channel_id: int = 0,
+        channel_id: int | None = None,
         update_action: StatUpdateAction | None = None,
         stat_flags: int = 0,
     ) -> None: ...

--- a/python/python/databento_dbn/v1.py
+++ b/python/python/databento_dbn/v1.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, F811
+# ruff: noqa: F401
 from ._lib import BBOMsg
 from ._lib import CBBOMsg
 from ._lib import CMBP1Msg

--- a/python/python/databento_dbn/v2.py
+++ b/python/python/databento_dbn/v2.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, F811
+# ruff: noqa: F401
 from ._lib import BBOMsg
 from ._lib import CBBOMsg
 from ._lib import CMBP1Msg

--- a/python/python/databento_dbn/v3.py
+++ b/python/python/databento_dbn/v3.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, F811
+# ruff: noqa: F401
 from ._lib import BBOMsg
 from ._lib import CBBOMsg
 from ._lib import CMBP1Msg

--- a/python/src/enums.rs
+++ b/python/src/enums.rs
@@ -11,7 +11,7 @@ mod tests {
     #[case("Schema")]
     #[case("SType")]
     fn test_enum_name_coercion(_python: (), #[case] enum_name: &str) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             pyo3::py_run!(
                 py,
                 enum_name,
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     fn test_compression_none_coercible(_python: ()) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             py.run(
                 c_str!(
                     r#"import _lib as db
@@ -54,7 +54,7 @@ assert db.Compression(None) == db.Compression.NONE
     #[case("Schema")]
     #[case("SType")]
     fn test_enum_none_not_coercible(_python: (), #[case] enum_name: &str) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             pyo3::py_run!(
                 py,
                 enum_name,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -128,7 +128,7 @@ mod tests {
     fn test_metadata_identity(_python: ()) {
         let stype_in = SType::RawSymbol as u8;
         let stype_out = SType::InstrumentId as u8;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             pyo3::py_run!(
                   py,
                   stype_in stype_out,
@@ -162,7 +162,7 @@ assert metadata.ts_out is False"#
 
     #[rstest]
     fn test_dbn_decoder_metadata_error(_python: ()) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             py.run(
                 c_str!(
                     r#"from _lib import DBNDecoder
@@ -194,7 +194,7 @@ except Exception:
         #[case] variant: &str,
         #[case] val: &str,
     ) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             pyo3::py_run!(
                   py,
                   enum_name variant val,
@@ -221,7 +221,7 @@ assert hash(val) == hash(variant), f"{val = }, {variant = } {hash(val) = }, {has
         #[case] variant: &str,
         #[case] val: u32,
     ) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             pyo3::py_run!(
                   py,
                   enum_name variant val,

--- a/python/src/transcoder.rs
+++ b/python/src/transcoder.rs
@@ -416,7 +416,7 @@ mod tests {
     fn test_partial_metadata_and_records(_python: ()) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut target = Python::with_gil(|py| {
+        let mut target = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 Encoding::Json,
@@ -455,7 +455,7 @@ mod tests {
         let metadata_pos = encoder.get_ref().len();
         let rec = ErrorMsg::new(1680708278000000000, None, "This is a test", true);
         encoder.encode_record(&rec).unwrap();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(target.buffer(py).is_empty().unwrap());
         });
         let record_pos = encoder.get_ref().len();
@@ -466,13 +466,13 @@ mod tests {
             if i == record_pos - 1 {
                 break;
             }
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 assert_eq!(target.buffer(py).len().unwrap(), i + 1 - metadata_pos);
             });
         }
         // writing the remainder of the record should have the transcoder
         // transcode the record to the output file
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(target.buffer(py).is_empty().unwrap());
         });
         assert_eq!(record_pos - metadata_pos, std::mem::size_of_val(&rec));
@@ -486,7 +486,7 @@ mod tests {
     fn test_full_with_partial_record(_python: ()) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut transcoder = Python::with_gil(|py| {
+        let mut transcoder = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 Encoding::Csv,
@@ -529,7 +529,7 @@ mod tests {
         encoder.encode_record(&rec1).unwrap();
         let rec1_pos = encoder.get_ref().len();
         encoder.encode_record(&rec2).unwrap();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(transcoder.buffer(py).is_empty().unwrap());
         });
         // Write first record and part of second
@@ -560,7 +560,7 @@ mod tests {
     ) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut transcoder = Python::with_gil(|py| {
+        let mut transcoder = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 encoding,
@@ -649,7 +649,7 @@ mod tests {
         );
         encoder.encode_record(&rec1).unwrap();
         encoder.encode_record(&rec2).unwrap();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(transcoder.buffer(py).is_empty().unwrap());
         });
         // Write first record and part of second
@@ -687,7 +687,7 @@ mod tests {
     fn test_map_symbols_live(_python: (), #[case] encoding: Encoding, #[case] map_symbols: bool) {
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut transcoder = Python::with_gil(|py| {
+        let mut transcoder = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 encoding,
@@ -779,7 +779,7 @@ mod tests {
             .unwrap();
         encoder.encode_record(&rec1).unwrap();
         encoder.encode_record(&rec2).unwrap();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(transcoder.buffer(py).is_empty().unwrap());
         });
         // Write first record and part of second
@@ -818,7 +818,7 @@ mod tests {
         .unwrap();
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut transcoder = Python::with_gil(|py| {
+        let mut transcoder = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 encoding,
@@ -860,7 +860,7 @@ mod tests {
         input_file.read_to_end(&mut input).unwrap();
         let file = MockPyFile::new();
         let output_buf = file.inner();
-        let mut transcoder = Python::with_gil(|py| {
+        let mut transcoder = Python::attach(|py| {
             Transcoder::new(
                 Py::new(py, file).unwrap().extract(py).unwrap(),
                 Encoding::Csv,

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.41.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.42.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
@@ -27,4 +27,4 @@ zstd = { workspace = true }
 assert_cmd = "2.0"
 predicates = "3.1"
 rstest = { workspace = true }
-tempfile = "3.20"
+tempfile = "3.23"

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -11,12 +11,12 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "3.3.0"
-proc-macro2 = "1.0.97"
+proc-macro-crate = "3.4.0"
+proc-macro2 = "1.0.101"
 quote = "1.0.40"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 csv = { workspace = true }
 dbn = { path = "../dbn" }
-trybuild = "1.0.110"
+trybuild = "1.0.111"

--- a/rust/dbn-macros/tests/ui/csv_serialize_duplicate_encode_orders.stderr
+++ b/rust/dbn-macros/tests/ui/csv_serialize_duplicate_encode_orders.stderr
@@ -1,6 +1,6 @@
 error: Specified duplicate encode order `1` for field
   --> tests/ui/csv_serialize_duplicate_encode_orders.rs:9:5
    |
-9  | /     #[dbn(encode_order(1))]
+ 9 | /     #[dbn(encode_order(1))]
 10 | |     pub c: u8,
    | |_____________^

--- a/rust/dbn-macros/tests/ui/json_serialize_duplicate_encode_orders.stderr
+++ b/rust/dbn-macros/tests/ui/json_serialize_duplicate_encode_orders.stderr
@@ -1,6 +1,6 @@
 error: Specified duplicate encode order `1` for field
   --> tests/ui/json_serialize_duplicate_encode_orders.rs:9:5
    |
-9  | /     #[dbn(encode_order(1))]
+ 9 | /     #[dbn(encode_order(1))]
 10 | |     pub c: u8,
    | |_____________^

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.41.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.42.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.27", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/decode.rs
+++ b/rust/dbn/src/decode.rs
@@ -214,7 +214,7 @@ pub mod private {
     use crate::RecordRef;
 
     /// An implementation detail for the interaction between [`StreamingIterator`] and
-    /// implementors of [`DecodeRecord`].
+    /// implementers of [`DecodeRecord`].
     #[doc(hidden)]
     pub trait LastRecord {
         fn last_record(&self) -> Option<RecordRef<'_>>;

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -75,7 +75,7 @@ pub use crate::{
         Bbo1MMsg, Bbo1SMsg, BboMsg, BidAskPair, Cbbo1MMsg, Cbbo1SMsg, CbboMsg, Cmbp1Msg,
         ConsolidatedBidAskPair, ErrorMsg, HasRType, ImbalanceMsg, InstrumentDefMsg, MboMsg,
         Mbp10Msg, Mbp1Msg, OhlcvMsg, Record, RecordHeader, RecordMut, StatMsg, StatusMsg,
-        SymbolMappingMsg, SystemMsg, TbboMsg, TradeMsg, WithTsOut,
+        SymbolMappingMsg, SystemMsg, TbboMsg, TcbboMsg, TradeMsg, WithTsOut,
     },
     record_enum::{RecordEnum, RecordRefEnum},
     record_ref::RecordRef,

--- a/rust/dbn/src/metadata.rs
+++ b/rust/dbn/src/metadata.rs
@@ -101,7 +101,7 @@ impl Metadata {
     ///
     /// This method is useful when working with a historical request over a single day
     /// or in other situations where you're sure the mappings don't change during the
-    /// time range of the request. Otherwise, [`Self::symbol_map()`] is recommmended.
+    /// time range of the request. Otherwise, [`Self::symbol_map()`] is recommended.
     ///
     /// # Errors
     /// This function returns an error if `stype_out` is not [`SType::InstrumentId`] or

--- a/rust/dbn/src/python.rs
+++ b/rust/dbn/src/python.rs
@@ -43,7 +43,7 @@ impl From<Error> for PyErr {
 #[pyclass(module = "databento_dbn")]
 pub struct EnumIterator {
     // Type erasure for code reuse. Generic types can't be exposed to Python.
-    iter: Box<dyn Iterator<Item = PyObject> + Send + Sync>,
+    iter: Box<dyn Iterator<Item = Py<PyAny>> + Send + Sync>,
 }
 
 #[pymethods]
@@ -52,7 +52,7 @@ impl EnumIterator {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<PyObject> {
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<Py<PyAny>> {
         slf.iter.next()
     }
 }

--- a/rust/dbn/src/python/record.rs
+++ b/rust/dbn/src/python/record.rs
@@ -119,6 +119,15 @@ impl MboMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_price(&self) -> f64 {
         self.price_f64()
     }
@@ -367,6 +376,15 @@ impl TradeMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_price(&self) -> f64 {
         self.price_f64()
     }
@@ -525,6 +543,15 @@ impl Mbp1Msg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -689,6 +716,15 @@ impl Mbp10Msg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_price(&self) -> f64 {
         self.price_f64()
     }
@@ -846,6 +882,15 @@ impl BboMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_price(&self) -> f64 {
         self.price_f64()
     }
@@ -993,6 +1038,15 @@ impl Cmbp1Msg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -1150,6 +1204,15 @@ impl CbboMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_price(&self) -> f64 {
         self.price_f64()
     }
@@ -1286,6 +1349,15 @@ impl OhlcvMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -1431,6 +1503,15 @@ impl StatusMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -1799,6 +1880,15 @@ impl InstrumentDefMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
@@ -2153,6 +2243,15 @@ impl ImbalanceMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
@@ -2370,6 +2469,15 @@ impl StatMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
@@ -2493,6 +2601,15 @@ impl ErrorMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -2636,6 +2753,15 @@ impl SymbolMappingMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_stype_in(&self) -> PyResult<SType> {
         self.stype_in().map_err(to_py_err)
     }
@@ -2766,6 +2892,15 @@ impl SystemMsg {
         Ok(mem::size_of::<Self>())
     }
 
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
     #[pyo3(name = "is_heartbeat")]
     fn py_is_heartbeat(&self) -> bool {
         self.is_heartbeat()
@@ -2875,6 +3010,15 @@ impl v1::ErrorMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]
@@ -3176,6 +3320,15 @@ impl v1::InstrumentDefMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
@@ -3453,6 +3606,15 @@ impl v1::StatMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_pretty_ts_recv<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         new_py_timestamp_or_datetime(py, self.ts_recv)
     }
@@ -3607,6 +3769,15 @@ impl v1::SymbolMappingMsg {
     }
 
     #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
+    }
+
+    #[getter]
     fn get_stype_in_symbol(&self) -> PyResult<&str> {
         Ok(self.stype_in_symbol()?)
     }
@@ -3716,6 +3887,15 @@ impl v1::SystemMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[pyo3(name = "is_heartbeat")]
@@ -4015,6 +4195,15 @@ impl v2::InstrumentDefMsg {
     #[classattr]
     fn size_hint() -> PyResult<usize> {
         Ok(mem::size_of::<Self>())
+    }
+
+    #[getter]
+    fn ts_index(&self) -> u64 {
+        self.raw_index_ts()
+    }
+    #[getter]
+    fn get_pretty_ts_index<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        new_py_timestamp_or_datetime(py, self.raw_index_ts())
     }
 
     #[getter]


### PR DESCRIPTION
### Enhancements
- Added `ts_index` and `pretty_ts_index` properties for records in Python which provides
  the timestamp that is most appropriate for indexing
- Upgraded `pyo3` version to 0.26.0

### Bug fixes
- Fixed type stub for `channel_id` in Python to allow `None`
- Fixed missing re-export for `record::TcbboMsg`
