### PR TITLE
VER: Release 0.44.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -252,10 +252,6 @@ jobs:
     needs:
       [
         tag-release,
-        macos-python-release,
-        windows-python-release,
-        linux-python-release,
-        linux-musl-python-release,
       ]
     steps:
       - name: Checkout repository
@@ -343,7 +339,7 @@ jobs:
     - name: Build release binary
       shell: bash
       run: |
-        cargo build --verbose --release --bin dbn-cli ${{ env.TARGET_FLAGS }}
+        cargo build --verbose --release --bin dbn ${{ env.TARGET_FLAGS }}
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           bin="target/${{ matrix.target }}/release/dbn.exe"
         else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.44.0 - TBD
+## 0.44.0 - 2025-11-18
 
 ### Enhancements
 - Added logic to set `code` when upgrading version 1 `SystemMsg` to newer versions
 - Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
   each decoder
-- Added `Dataset::publishes()` method to retrieve all `Publisher` values for a dataset
+- Added `Dataset::publishers()` method to retrieve all `Publisher` values for a dataset
 
 ### Breaking changes
 - Updated the minimum supported `tokio` version to 1.41, which was released one year ago

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.43.1 - TBD
+
+### Enhancements
+- Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
+  each decoder
+
 ## 0.43.0 - 2025-10-22
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added logic to set `code` when upgrading version 1 `SystemMsg` to newer versions
 - Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
   each decoder
+- Added `Dataset::publishes()` method to retrieve all `Publisher` values for a dataset
 
 ### Breaking changes
 - Updated the minimum supported `tokio` version to 1.41, which was released one year ago

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.43.1 - TBD
+
+## 0.44.0 - TBD
 
 ### Enhancements
+- Added logic to set `code` when upgrading version 1 `SystemMsg` to newer versions
 - Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
   each decoder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-
 ## 0.44.0 - TBD
 
 ### Enhancements
 - Added logic to set `code` when upgrading version 1 `SystemMsg` to newer versions
 - Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
   each decoder
+
+### Breaking changes
+- Updated the minimum supported `tokio` version to 1.41, which was released one year ago
 
 ### Bug fixes
 - Fixed bug in `DbnFsm::consume`, though it should have no impact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
   each decoder
 
+### Bug fixes
+- Fixed bug in `DbnFsm::consume`, though it should have no impact
+
 ## 0.43.0 - 2025-10-22
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,37 +28,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -84,13 +69,12 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -100,50 +84,34 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
 dependencies = [
+ "compression-codecs",
+ "compression-core",
  "futures-core",
- "memchr",
  "pin-project-lite",
  "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -158,9 +126,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cbindgen"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "heck",
  "indexmap",
@@ -169,17 +137,18 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.110",
  "tempfile",
- "toml 0.8.20",
+ "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -187,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -216,45 +185,62 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -328,18 +314,18 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
  "trybuild",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -349,12 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,12 +342,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -381,6 +361,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "float-cmp"
@@ -405,7 +391,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -436,33 +422,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -472,9 +452,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -482,15 +462,18 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -500,9 +483,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom",
  "libc",
@@ -520,27 +503,27 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -558,15 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
 ]
 
 [[package]]
@@ -592,32 +566,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -625,6 +591,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oval"
@@ -652,9 +624,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -698,14 +670,14 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.6",
+ "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -755,7 +727,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -768,29 +740,29 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -800,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -811,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "relative-path"
@@ -846,15 +818,9 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.100",
+ "syn 2.0.110",
  "unicode-ident",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -867,22 +833,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -892,15 +858,15 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -908,52 +874,44 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -964,12 +922,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "strsim"
@@ -979,24 +934,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1012,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1023,15 +977,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "target-triple"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
@@ -1043,7 +997,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1057,12 +1011,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1073,22 +1027,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1124,11 +1078,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "pin-project-lite",
  "tokio-macros",
@@ -1136,37 +1089,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
- "toml_edit 0.22.24",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.2",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1174,67 +1115,45 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.2",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "trybuild"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ded9fdb81f30a5708920310bfcd9ea7482ff9cba5f54601f7a19a877d5c2392"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
 dependencies = [
  "glob",
  "serde",
@@ -1242,7 +1161,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.3",
+ "toml",
 ]
 
 [[package]]
@@ -1268,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unindent"
@@ -1294,38 +1213,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1338,51 +1273,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1394,13 +1329,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zstd"
@@ -1422,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 anyhow = "1.0.100"
-csv = "1.3"
+csv = "1.4"
 pyo3 = "0.26.0"
 pyo3-build-config = "0.26.0"
 rstest = "0.26.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.43.0"
+version = "0.44.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -19,4 +19,4 @@ dbn = { path = "../rust/dbn", features = [] }
 libc = "0.2.176"
 
 [build-dependencies]
-cbindgen = { version = "0.29.0", default-features = false }
+cbindgen = { version = "0.29.2", default-features = false }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databento-dbn"
-version = "0.43.0"
+version = "0.44.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -4246,7 +4246,7 @@ class ImbalanceMsg(Record):
     def ref_price(self) -> int:
         """
         The price at which the imbalance shares are calculated, where every 1 unit corresponds
-        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
 
         See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
@@ -4275,7 +4275,8 @@ class ImbalanceMsg(Record):
     @property
     def auction_time(self) -> int:
         """
-        Reserved for future use.
+        Projected auction timestamp expressed as the number of nanoseconds since the UNIX epoch.
+        Will be `UNDEF_TIMESTAMP` when unused.
 
         Returns
         -------
@@ -4302,7 +4303,7 @@ class ImbalanceMsg(Record):
     def cont_book_clr_price(self) -> int:
         """
         The hypothetical auction-clearing price for both cross and continuous orders where every
-        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
 
         See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
@@ -4335,7 +4336,7 @@ class ImbalanceMsg(Record):
     def auct_interest_clr_price(self) -> int:
         """
         The hypothetical auction-clearing price for cross orders only where every 1 unit corresponds
-        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
 
         See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
@@ -4367,7 +4368,11 @@ class ImbalanceMsg(Record):
     @property
     def ssr_filling_price(self) -> int:
         """
-        Reserved for future use.
+        The price at which sell short interest will be filed if a sell short restriction is
+        in effect, where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        Will be `UNDEF_PRICE` when unused.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -4397,7 +4402,11 @@ class ImbalanceMsg(Record):
     @property
     def ind_match_price(self) -> int:
         """
-        Reserved for future use.
+        The price at which the highest number of shares would trade, subject to auction collars,
+        where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+        Will be `UNDEF_PRICE` when unused.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -4427,7 +4436,10 @@ class ImbalanceMsg(Record):
     @property
     def upper_collar(self) -> int:
         """
-        Reserved for future use.
+        Upper limit of the auction collar, where every 1 unit corresponds
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -4457,7 +4469,10 @@ class ImbalanceMsg(Record):
     @property
     def lower_collar(self) -> int:
         """
-        Reserved for future use.
+        Upper limit of the auction collar, where every 1 unit corresponds
+        to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be `UNDEF_PRICE` when unused.
+
+        See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
 
         Returns
         -------
@@ -4473,6 +4488,7 @@ class ImbalanceMsg(Record):
     def paired_qty(self) -> int:
         """
         The quantity of shares that are eligible to be matched at `ref_price`.
+        Will be `UNDEF_ORDER_SIZE` when unused.
 
         Returns
         -------
@@ -4484,6 +4500,7 @@ class ImbalanceMsg(Record):
     def total_imbalance_qty(self) -> int:
         """
         The quantity of shares that are not paired at `ref_price`.
+        Will be `UNDEF_ORDER_SIZE` when not used.
 
         Returns
         -------
@@ -4494,7 +4511,8 @@ class ImbalanceMsg(Record):
     @property
     def market_imbalance_qty(self) -> int:
         """
-        Reserved for future use.
+        The total market order imbalance quantity at the `ref_price`.
+        Will be `UNDEF_ORDER_SIZE` when unused.
 
         Returns
         -------
@@ -4505,7 +4523,8 @@ class ImbalanceMsg(Record):
     @property
     def unpaired_qty(self) -> int:
         """
-        Reserved for future use.
+        During the Closing Auction, the number of unpaired shares priced at or better than the `ref_price`.
+        Will be `UNDEF_ORDER_SIZE` when unused.
 
         Returns
         -------
@@ -4516,7 +4535,9 @@ class ImbalanceMsg(Record):
     @property
     def auction_type(self) -> str:
         """
-        Venue-specific character code indicating the auction type.
+        Venue-specific character code indicating the auction type. Will be `~` when unused.
+
+        Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
 
         Returns
         -------
@@ -4528,6 +4549,7 @@ class ImbalanceMsg(Record):
     def side(self) -> Side | str:
         """
         The market side of the `total_imbalance_qty`. Can be **A**sk, **B**id, or **N**one.
+        Will be **N**one when unused or not applicable.
 
         See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
@@ -4540,7 +4562,9 @@ class ImbalanceMsg(Record):
     @property
     def auction_status(self) -> int:
         """
-        Reserved for future use.
+        Venue-specific status code.
+
+        Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
 
         Returns
         -------
@@ -4551,7 +4575,9 @@ class ImbalanceMsg(Record):
     @property
     def freeze_status(self) -> int:
         """
-        Reserved for future use.
+        Venue-specific status code.
+
+        Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
 
         Returns
         -------
@@ -4562,7 +4588,7 @@ class ImbalanceMsg(Record):
     @property
     def num_extensions(self) -> int:
         """
-        Reserved for future use.
+        The number of times the halt period has been extended.
 
         Returns
         -------
@@ -4573,7 +4599,9 @@ class ImbalanceMsg(Record):
     @property
     def unpaired_side(self) -> Side | str:
         """
-        Reserved for future use.
+        The side of the `unpaired_qty`. Will be **N**one when unused or not applicable.
+
+        See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
 
         Returns
         -------
@@ -4585,6 +4613,8 @@ class ImbalanceMsg(Record):
     def significant_imbalance(self) -> str:
         """
         Venue-specific character code. For Nasdaq, contains the raw Price Variation Indicator.
+
+        Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
 
         Returns
         -------

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: UP007 PYI021 PYI011 PYI014
+# ruff: noqa: UP007, PYI021, PYI011
 from __future__ import annotations
 
 import datetime as dt

--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -1212,7 +1212,7 @@ class TradingEvent(Enum):
     NONE
         No additional information given.
     NO_CANCEL
-        Order entry and modification are not allowed.
+        Order entry is allowed. Modification and cancellation are not allowed.
     CHANGE_TRADING_SESSION
         A change of trading session occurred. Daily statistics are reset.
     IMPLIED_MATCHING_ON

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.43.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.44.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 zstd = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2.1"
 predicates = "3.1"
 rstest = { workspace = true }
 tempfile = "3.23"

--- a/rust/dbn-macros/Cargo.toml
+++ b/rust/dbn-macros/Cargo.toml
@@ -12,11 +12,11 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.4.0"
-proc-macro2 = "1.0.101"
-quote = "1.0.40"
+proc-macro2 = "1.0.103"
+quote = "1.0.42"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 csv = { workspace = true }
 dbn = { path = "../dbn" }
-trybuild = "1.0.111"
+trybuild = "1.0.114"

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -27,7 +27,7 @@ trivial_copy = []
 [dependencies]
 dbn-macros = { version = "=0.43.0", path = "../dbn-macros" }
 
-async-compression = { version = "0.4.27", features = ["tokio", "zstd"], optional = true }
+async-compression = { version = "0.4.33", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }
 fallible-streaming-iterator = { version = "0.1.9", features = ["std"] }
 # Fast integer to string conversion
@@ -41,7 +41,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 strum = { version = "0.27", features = ["derive"], optional = true }
 thiserror = "2.0"
 time = { workspace = true, features = ["formatting", "macros"] }
-tokio = { version = ">=1.38", features = ["fs", "io-util"], optional = true }
+tokio = { version = ">=1.41", features = ["fs", "io-util"], optional = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.43.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.44.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.33", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }

--- a/rust/dbn/src/compat.rs
+++ b/rust/dbn/src/compat.rs
@@ -119,7 +119,7 @@ pub struct InstrumentDefMsgV1 {
     /// The last eligible trade time expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -127,7 +127,7 @@ pub struct InstrumentDefMsgV1 {
     /// The time of instrument activation expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -392,7 +392,7 @@ pub struct StatMsgV1 {
     #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The reference timestamp of the statistic value expressed as the number of
-    /// nanoseconds since the UNIX epoch. Will be [`crate::UNDEF_TIMESTAMP`] when
+    /// nanoseconds since the UNIX epoch. Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when
     /// unused.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -405,8 +405,8 @@ pub struct StatMsgV1 {
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub price: i64,
-    /// The value for non-price statistics. Will be [`crate::UNDEF_STAT_QUANTITY`] when
-    /// unused.
+    /// The value for non-price statistics. Will be [`UNDEF_STAT_QUANTITY`](crate::UNDEF_STAT_QUANTITY)
+    /// when unused.
     #[pyo3(get, set)]
     pub quantity: i32,
     /// The message sequence number assigned at the venue.
@@ -541,7 +541,7 @@ pub struct InstrumentDefMsgV2 {
     /// The last eligible trade time expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -549,7 +549,7 @@ pub struct InstrumentDefMsgV2 {
     /// The time of instrument activation expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]

--- a/rust/dbn/src/decode/dbn/fsm.rs
+++ b/rust/dbn/src/decode/dbn/fsm.rs
@@ -462,7 +462,7 @@ impl DbnFsm {
     fn consume(&mut self, read: usize, compat: usize, compat_fill: usize, expand_compat: bool) {
         self.buffer.consume(read);
         if compat_fill > 0 {
-            self.compat_buffer.fill(compat);
+            self.compat_buffer.fill(compat_fill);
         }
         if compat > 0 {
             self.compat_buffer.consume(compat);

--- a/rust/dbn/src/enums.rs
+++ b/rust/dbn/src/enums.rs
@@ -1293,7 +1293,7 @@ pub enum TradingEvent {
     #[default]
     #[pyo3(name = "NONE")]
     None = 0,
-    /// Order entry and modification are not allowed.
+    /// Order entry is allowed. Modification and cancellation are not allowed.
     #[pyo3(name = "NO_CANCEL")]
     NoCancel = 1,
     /// A change of trading session occurred. Daily statistics are reset.

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -31,8 +31,7 @@
 //! - `serde`: enables deriving `serde` traits for types
 //! - `trivial_copy`: enables deriving the `Copy` trait for records
 
-// Experimental feature to allow docs.rs to display features
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::missing_errors_doc)]

--- a/rust/dbn/src/publishers.rs
+++ b/rust/dbn/src/publishers.rs
@@ -117,11 +117,11 @@ pub enum Venue {
     Xeee = 51,
 }
 
-/// The number of Venue variants.
+/// The number of [`Venue`] variants.
 pub const VENUE_COUNT: usize = 51;
 
 impl Venue {
-    /// Convert a Venue to its `str` representation.
+    /// Converts the venue to its `str` representation.
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Glbx => "GLBX",
@@ -341,11 +341,11 @@ pub enum Dataset {
     XeeeEobi = 39,
 }
 
-/// The number of Dataset variants.
+/// The number of [`Dataset`] variants.
 pub const DATASET_COUNT: usize = 39;
 
 impl Dataset {
-    /// Convert a Dataset to its `str` representation.
+    /// Converts the dataset to its `str` representation.
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::GlbxMdp3 => "GLBX.MDP3",
@@ -389,6 +389,128 @@ impl Dataset {
             Self::IfllImpact => "IFLL.IMPACT",
             Self::XeurEobi => "XEUR.EOBI",
             Self::XeeeEobi => "XEEE.EOBI",
+        }
+    }
+
+    /// Returns all [`Publisher`] values associated with a dataset.
+    pub const fn publishers(&self) -> &'static [Publisher] {
+        match self {
+            Self::GlbxMdp3 => &[Publisher::GlbxMdp3Glbx],
+            Self::XnasItch => &[Publisher::XnasItchXnas],
+            Self::XbosItch => &[Publisher::XbosItchXbos],
+            Self::XpsxItch => &[Publisher::XpsxItchXpsx],
+            Self::BatsPitch => &[Publisher::BatsPitchBats],
+            Self::BatyPitch => &[Publisher::BatyPitchBaty],
+            Self::EdgaPitch => &[Publisher::EdgaPitchEdga],
+            Self::EdgxPitch => &[Publisher::EdgxPitchEdgx],
+            Self::XnysPillar => &[Publisher::XnysPillarXnys],
+            Self::XcisPillar => &[Publisher::XcisPillarXcis],
+            Self::XasePillar => &[Publisher::XasePillarXase],
+            Self::XchiPillar => &[Publisher::XchiPillarXchi],
+            Self::XcisBbo => &[Publisher::XcisBboXcis],
+            Self::XcisTrades => &[Publisher::XcisTradesXcis],
+            Self::MemxMemoir => &[Publisher::MemxMemoirMemx],
+            Self::EprlDom => &[Publisher::EprlDomEprl],
+            #[allow(deprecated)]
+            Self::FinnNls => &[],
+            #[allow(deprecated)]
+            Self::FinyTrades => &[],
+            Self::OpraPillar => &[
+                Publisher::OpraPillarAmxo,
+                Publisher::OpraPillarXbox,
+                Publisher::OpraPillarXcbo,
+                Publisher::OpraPillarEmld,
+                Publisher::OpraPillarEdgo,
+                Publisher::OpraPillarGmni,
+                Publisher::OpraPillarXisx,
+                Publisher::OpraPillarMcry,
+                Publisher::OpraPillarXmio,
+                Publisher::OpraPillarArco,
+                Publisher::OpraPillarOpra,
+                Publisher::OpraPillarMprl,
+                Publisher::OpraPillarXndq,
+                Publisher::OpraPillarXbxo,
+                Publisher::OpraPillarC2Ox,
+                Publisher::OpraPillarXphl,
+                Publisher::OpraPillarBato,
+                Publisher::OpraPillarMxop,
+                Publisher::OpraPillarSphr,
+            ],
+            Self::DbeqBasic => &[
+                Publisher::DbeqBasicXchi,
+                Publisher::DbeqBasicXcis,
+                Publisher::DbeqBasicIexg,
+                Publisher::DbeqBasicEprl,
+                Publisher::DbeqBasicDbeq,
+            ],
+            Self::ArcxPillar => &[Publisher::ArcxPillarArcx],
+            Self::IexgTops => &[Publisher::IexgTopsIexg],
+            Self::EqusPlus => &[
+                Publisher::EqusPlusXchi,
+                Publisher::EqusPlusXcis,
+                Publisher::EqusPlusIexg,
+                Publisher::EqusPlusEprl,
+                Publisher::EqusPlusXnas,
+                Publisher::EqusPlusXnys,
+                Publisher::EqusPlusFinn,
+                Publisher::EqusPlusFiny,
+                Publisher::EqusPlusFinc,
+                Publisher::EqusPlusEqus,
+            ],
+            Self::XnysBbo => &[Publisher::XnysBboXnys],
+            Self::XnysTrades => &[
+                Publisher::XnysTradesFiny,
+                Publisher::XnysTradesXnys,
+                Publisher::XnysTradesEqus,
+            ],
+            Self::XnasQbbo => &[Publisher::XnasQbboXnas],
+            Self::XnasNls => &[
+                Publisher::XnasNlsFinn,
+                Publisher::XnasNlsFinc,
+                Publisher::XnasNlsXnas,
+                Publisher::XnasNlsXbos,
+                Publisher::XnasNlsXpsx,
+            ],
+            Self::IfeuImpact => &[Publisher::IfeuImpactIfeu, Publisher::IfeuImpactXoff],
+            Self::NdexImpact => &[Publisher::NdexImpactNdex, Publisher::NdexImpactXoff],
+            Self::EqusAll => &[
+                Publisher::EqusAllXchi,
+                Publisher::EqusAllXcis,
+                Publisher::EqusAllIexg,
+                Publisher::EqusAllEprl,
+                Publisher::EqusAllXnas,
+                Publisher::EqusAllXnys,
+                Publisher::EqusAllFinn,
+                Publisher::EqusAllFiny,
+                Publisher::EqusAllFinc,
+                Publisher::EqusAllBats,
+                Publisher::EqusAllBaty,
+                Publisher::EqusAllEdga,
+                Publisher::EqusAllEdgx,
+                Publisher::EqusAllXbos,
+                Publisher::EqusAllXpsx,
+                Publisher::EqusAllMemx,
+                Publisher::EqusAllXase,
+                Publisher::EqusAllArcx,
+                Publisher::EqusAllLtse,
+                Publisher::EqusAllEqus,
+            ],
+            Self::XnasBasic => &[
+                Publisher::XnasBasicXnas,
+                Publisher::XnasBasicFinn,
+                Publisher::XnasBasicFinc,
+                Publisher::XnasBasicXbos,
+                Publisher::XnasBasicXpsx,
+                Publisher::XnasBasicEqus,
+            ],
+            Self::EqusSummary => &[Publisher::EqusSummaryEqus],
+            Self::XcisTradesbbo => &[Publisher::XcisTradesbboXcis],
+            Self::XnysTradesbbo => &[Publisher::XnysTradesbboXnys],
+            Self::EqusMini => &[Publisher::EqusMiniEqus],
+            Self::IfusImpact => &[Publisher::IfusImpactIfus, Publisher::IfusImpactXoff],
+            Self::IfllImpact => &[Publisher::IfllImpactIfll, Publisher::IfllImpactXoff],
+            Self::XeurEobi => &[Publisher::XeurEobiXeur, Publisher::XeurEobiXoff],
+            Self::XeeeEobi => &[Publisher::XeeeEobiXeee, Publisher::XeeeEobiXoff],
         }
     }
 }
@@ -673,11 +795,11 @@ pub enum Publisher {
     XeeeEobiXoff = 104,
 }
 
-/// The number of Publisher variants.
+/// The number of [`Publisher`] variants.
 pub const PUBLISHER_COUNT: usize = 104;
 
 impl Publisher {
-    /// Convert a Publisher to its `str` representation.
+    /// Converts the publisher to its `str` representation.
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::GlbxMdp3Glbx => "GLBX.MDP3.GLBX",
@@ -787,7 +909,7 @@ impl Publisher {
         }
     }
 
-    /// Get a Publisher's Venue.
+    /// Returns the publisher's [`Venue`].
     pub const fn venue(&self) -> Venue {
         match self {
             Self::GlbxMdp3Glbx => Venue::Glbx,
@@ -897,7 +1019,7 @@ impl Publisher {
         }
     }
 
-    /// Get a Publisher's Dataset.
+    /// Returns the publisher's [`Dataset`].
     pub const fn dataset(&self) -> Dataset {
         match self {
             Self::GlbxMdp3Glbx => Dataset::GlbxMdp3,
@@ -1007,9 +1129,10 @@ impl Publisher {
         }
     }
 
-    /// Construct a Publisher from its components.
+    /// Construct a [`Publisher`] from its components.
+    ///
     /// # Errors
-    /// Returns an error if there's no `Publisher` with the corresponding `Dataset`/`Venue` combination.
+    /// Returns an error if there's no [`Publisher`] with the corresponding [`Dataset`] and [`Venue`] combination.
     pub fn from_dataset_venue(dataset: Dataset, venue: Venue) -> Result<Self> {
         match (dataset, venue) {
             (Dataset::GlbxMdp3, Venue::Glbx) => Ok(Self::GlbxMdp3Glbx),

--- a/rust/dbn/src/record.rs
+++ b/rust/dbn/src/record.rs
@@ -775,7 +775,7 @@ pub struct InstrumentDefMsg {
     /// The last eligible trade time expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -783,7 +783,7 @@ pub struct InstrumentDefMsg {
     /// The time of instrument activation expressed as the number of nanoseconds since the
     /// UNIX epoch.
     ///
-    /// Will be [`crate::UNDEF_TIMESTAMP`] when null, such as for equities. Some publishers
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when null, such as for equities. Some publishers
     /// only provide date-level granularity.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -1073,79 +1073,112 @@ pub struct ImbalanceMsg {
     #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The price at which the imbalance shares are calculated, where every 1 unit corresponds
-    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE)
+    /// when unused.
     ///
     /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub ref_price: i64,
-    /// Reserved for future use.
+    /// Projected auction timestamp expressed as the number of nanoseconds since the UNIX epoch.
+    /// Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when unused.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
     pub auction_time: u64,
     /// The hypothetical auction-clearing price for both cross and continuous orders where every
     /// 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
     ///
     /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub cont_book_clr_price: i64,
     /// The hypothetical auction-clearing price for cross orders only where every 1 unit corresponds
-    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
     ///
     /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub auct_interest_clr_price: i64,
-    /// Reserved for future use.
+    /// The price at which sell short interest will be filed if a sell short restriction is
+    /// in effect, where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
+    ///
+    /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub ssr_filling_price: i64,
-    /// Reserved for future use.
+    /// The price at which the highest number of shares would trade, subject to auction collars,
+    /// where every 1 unit corresponds to 1e-9, i.e. 1/1,000,000,000 or 0.000000001.
+    /// Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
+    ///
+    /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub ind_match_price: i64,
-    /// Reserved for future use.
+    /// Upper limit of the auction collar, where every 1 unit corresponds
+    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
+    ///
+    /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub upper_collar: i64,
-    /// Reserved for future use.
+    /// Lower limit of the auction collar, where every 1 unit corresponds
+    /// to 1e-9, i.e. 1/1,000,000,000 or 0.000000001. Will be [`UNDEF_PRICE`](crate::UNDEF_PRICE) when unused.
+    ///
+    /// See [Prices](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#prices).
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub lower_collar: i64,
-    /// The quantity of shares that are eligible to be matched at `ref_price`.
+    /// The quantity of shares that are eligible to be matched at [`ref_price`](Self::ref_price).
+    /// Will be [`UNDEF_ORDER_SIZE`](crate::UNDEF_ORDER_SIZE) when unused.
     #[pyo3(get, set)]
     pub paired_qty: u32,
-    /// The quantity of shares that are not paired at `ref_price`.
+    /// The quantity of shares that are not paired at [`ref_price`](Self::ref_price).
+    /// Will be [`UNDEF_ORDER_SIZE`](crate::UNDEF_ORDER_SIZE) when not used.
     #[pyo3(get, set)]
     pub total_imbalance_qty: u32,
-    /// Reserved for future use.
+    /// The total market order imbalance quantity at the [`ref_price`](Self::ref_price).
+    /// Will be [`UNDEF_ORDER_SIZE`](crate::UNDEF_ORDER_SIZE) when unused.
     #[pyo3(get, set)]
     pub market_imbalance_qty: u32,
-    /// Reserved for future use.
+    /// During the Closing Auction, the number of unpaired shares priced at or better than the
+    /// [`ref_price`](Self::ref_price). Will be `UNDEF_ORDER_SIZE` when unused.
     #[pyo3(get, set)]
     pub unpaired_qty: u32,
-    /// Venue-specific character code indicating the auction type.
+    /// Venue-specific character code indicating the auction type. Will be `~` when unused.
+    ///
+    /// Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
     #[dbn(c_char)]
     pub auction_type: c_char,
-    /// The market side of the `total_imbalance_qty`. Can be **A**sk, **B**id, or **N**one.
+    /// The market side of the [`total_imbalance_qty`](Self::total_imbalance_qty).
+    /// Can be **A**sk, **B**id, or **N**one.
     ///
     /// See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
     #[dbn(c_char)]
     pub side: c_char,
-    /// Reserved for future use.
+    /// Venue-specific status code.
+    ///
+    /// Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
     #[pyo3(get, set)]
     pub auction_status: u8,
-    /// Reserved for future use.
+    /// Venue-specific status code.
+    ///
+    /// Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
     #[pyo3(get, set)]
     pub freeze_status: u8,
-    /// Reserved for future use.
+    /// The number of times the halt period has been extended.
     #[pyo3(get, set)]
     pub num_extensions: u8,
-    /// Reserved for future use.
+    /// The side of the [`unpaired_qty`](Self::unpaired_qty).
+    /// Can be **A**sk, **B**id, or **N**one. Will be **N**one when unused or not applicable.
+    ///
+    /// See [Side](https://databento.com/docs/standards-and-conventions/common-fields-enums-types#side).
     #[dbn(c_char)]
     pub unpaired_side: c_char,
     /// Venue-specific character code. For Nasdaq, contains the raw Price Variation Indicator.
+    ///
+    /// Refer to the [venue-specific documentation](https://databento.com/docs/venues-and-datasets).
     #[dbn(c_char)]
     pub significant_imbalance: c_char,
     #[doc(hidden)]
@@ -1178,7 +1211,7 @@ pub struct StatMsg {
     #[pyo3(get, set)]
     pub ts_recv: u64,
     /// The reference timestamp of the statistic value expressed as the number of
-    /// nanoseconds since the UNIX epoch. Will be [`crate::UNDEF_TIMESTAMP`] when
+    /// nanoseconds since the UNIX epoch. Will be [`UNDEF_TIMESTAMP`](crate::UNDEF_TIMESTAMP) when
     /// unused.
     #[dbn(unix_nanos)]
     #[pyo3(get, set)]
@@ -1191,8 +1224,8 @@ pub struct StatMsg {
     #[dbn(fixed_price)]
     #[pyo3(get, set)]
     pub price: i64,
-    /// The value for non-price statistics. Will be [`crate::UNDEF_STAT_QUANTITY`] when
-    /// unused.
+    /// The value for non-price statistics. Will be [`UNDEF_STAT_QUANTITY`](crate::UNDEF_STAT_QUANTITY)
+    /// when unused.
     #[pyo3(get, set)]
     pub quantity: i64,
     /// The message sequence number assigned at the venue.

--- a/rust/dbn/src/v2.rs
+++ b/rust/dbn/src/v2.rs
@@ -150,6 +150,16 @@ impl From<&v1::SystemMsg> for SystemMsg {
         };
         if old.is_heartbeat() {
             new.code = SystemCode::Heartbeat as u8;
+        } else if let Ok(msg) = old.msg() {
+            if msg.starts_with("End of interval for ") {
+                new.code = SystemCode::EndOfInterval as u8;
+            } else if msg.starts_with("Subscription request ") && msg.ends_with(" succeeded") {
+                new.code = SystemCode::SubscriptionAck as u8;
+            } else if msg.starts_with("Warning: slow reading") {
+                new.code = SystemCode::SlowReaderWarning as u8;
+            } else if msg.starts_with("Finished ") && msg.ends_with(" replay") {
+                new.code = SystemCode::ReplayCompleted as u8;
+            }
         }
         new.msg[..old.msg.len()].copy_from_slice(old.msg.as_slice());
         new

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ cargo --version
 cargo clippy --all-features -- --deny warnings
 # `cargo doc` does not have a `--deny warnings` flag like clippy, workaround from:
 # https://github.com/rust-lang/cargo/issues/8424#issuecomment-1070988443
-RUSTDOCFLAGS='--deny warnings' cargo doc --all-features
+RUSTDOCFLAGS='--deny warnings' cargo doc --all-features --no-deps


### PR DESCRIPTION
### Enhancements
- Added logic to set `code` when upgrading version 1 `SystemMsg` to newer versions
- Added `MergeRecordDecoder::with_hints` that allows hinting the minimum timestamp from
  each decoder
- Added `Dataset::publishers()` method to retrieve all `Publisher` values for a dataset

### Breaking changes
- Updated the minimum supported `tokio` version to 1.41, which was released one year ago

### Bug fixes
- Fixed bug in `DbnFsm::consume`, though it should have no impact

