### PR TITLE
VER: Release 0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
+## 0.46.0 - TBD
+
+### Breaking changes
+- Added `DBNRecord` union type to Python which includes all record types
+- Removed `Record` class from Python type stubs to match code: the record classes don't
+  share a base class. Use `DBNRecord` instead.
+- Removed `_DBNRecord` union type alias which only existed in typestub and wasn't
+  importable. Use `DBNRecord | Metadata` instead
+
 ## 0.45.0 - 2025-12-09
 
-#### Enhancements
+### Enhancements
 - Added new venue, dataset, and publisher for Cboe Futures Exchange (`XCBF.PITCH`)
 - Added support for Python 3.14 to `databento_dbn`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.46.0 - TBD
+## 0.46.0 - 2026-01-06
 
 ### Breaking changes
 - Added `DBNRecord` union type to Python which includes all record types

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-info@nautechsystems.io.
+support@databento.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "databento-dbn"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "dbn",
  "pyo3",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "dbn"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "async-compression",
  "csv",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-c"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-cli"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "dbn-macros"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "csv",
  "dbn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Databento <support@databento.com>"]
 edition = "2021"
-version = "0.45.0"
+version = "0.46.0"
 documentation = "https://databento.com/docs"
 repository = "https://github.com/databento/dbn"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databento-dbn"
-version = "0.45.0"
+version = "0.46.0"
 description = "Python bindings for encoding and decoding Databento Binary Encoding (DBN)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/python/databento_dbn/__init__.py
+++ b/python/python/databento_dbn/__init__.py
@@ -1,56 +1,34 @@
-import datetime as dt
-from collections.abc import Sequence
-from typing import Protocol
-from typing import TypedDict
+# ruff: noqa: F401, F405, UP007
+from typing import Union
+
+from databento_dbn.metadata import MappingInterval
+from databento_dbn.metadata import MappingIntervalDict
+from databento_dbn.metadata import SymbolMapping
 
 # Import native module
 from ._lib import *  # noqa: F403
 
 
-class MappingInterval(Protocol):
-    """
-    Represents a symbol mapping over a start and end date range interval.
-
-    Parameters
-    ----------
-    start_date : dt.date
-        The start of the mapping period.
-    end_date : dt.date
-        The end of the mapping period.
-    symbol : str
-        The symbol value.
-
-    """
-
-    start_date: dt.date
-    end_date: dt.date
-    symbol: str
-
-
-class MappingIntervalDict(TypedDict):
-    """
-    Represents a symbol mapping over a start and end date range interval.
-
-    Parameters
-    ----------
-    start_date : dt.date
-        The start of the mapping period.
-    end_date : dt.date
-        The end of the mapping period.
-    symbol : str
-        The symbol value.
-
-    """
-
-    start_date: dt.date
-    end_date: dt.date
-    symbol: str
-
-
-class SymbolMapping(Protocol):
-    """
-    Represents the mappings for one native symbol.
-    """
-
-    raw_symbol: str
-    intervals: Sequence[MappingInterval]
+DBNRecord = Union[
+    MBOMsg,
+    TradeMsg,
+    MBP1Msg,
+    MBP10Msg,
+    BBOMsg,
+    CMBP1Msg,
+    CBBOMsg,
+    OHLCVMsg,
+    StatusMsg,
+    InstrumentDefMsg,
+    ImbalanceMsg,
+    StatMsg,
+    ErrorMsg,
+    SymbolMappingMsg,
+    SystemMsg,
+    ErrorMsgV1,
+    InstrumentDefMsgV1,
+    StatMsgV1,
+    SymbolMappingMsgV1,
+    SystemMsgV1,
+    InstrumentDefMsgV2,
+]

--- a/python/python/databento_dbn/metadata.py
+++ b/python/python/databento_dbn/metadata.py
@@ -1,0 +1,53 @@
+import datetime as dt
+from collections.abc import Sequence
+from typing import Protocol
+from typing import TypedDict
+
+
+class MappingInterval(Protocol):
+    """
+    Represents a symbol mapping over a start and end date range interval.
+
+    Parameters
+    ----------
+    start_date : dt.date
+        The start of the mapping period.
+    end_date : dt.date
+        The end of the mapping period.
+    symbol : str
+        The symbol value.
+
+    """
+
+    start_date: dt.date
+    end_date: dt.date
+    symbol: str
+
+
+class MappingIntervalDict(TypedDict):
+    """
+    Represents a symbol mapping over a start and end date range interval.
+
+    Parameters
+    ----------
+    start_date : dt.date
+        The start of the mapping period.
+    end_date : dt.date
+        The end of the mapping period.
+    symbol : str
+        The symbol value.
+
+    """
+
+    start_date: dt.date
+    end_date: dt.date
+    symbol: str
+
+
+class SymbolMapping(Protocol):
+    """
+    Represents the mappings for one native symbol.
+    """
+
+    raw_symbol: str
+    intervals: Sequence[MappingInterval]

--- a/rust/dbn-cli/Cargo.toml
+++ b/rust/dbn-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "dbn"
 path = "src/main.rs"
 
 [dependencies]
-dbn = { path = "../dbn", version = "=0.45.0", default-features = false }
+dbn = { path = "../dbn", version = "=0.46.0", default-features = false }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }

--- a/rust/dbn/Cargo.toml
+++ b/rust/dbn/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "time/parsing", "time/serde"]
 trivial_copy = []
 
 [dependencies]
-dbn-macros = { version = "=0.45.0", path = "../dbn-macros" }
+dbn-macros = { version = "=0.46.0", path = "../dbn-macros" }
 
 async-compression = { version = "0.4.33", features = ["tokio", "zstd"], optional = true }
 csv = { workspace = true }


### PR DESCRIPTION
### Breaking changes
- Added `DBNRecord` union type to Python which includes all record types
- Removed `Record` class from Python type stubs to match code: the record classes don't
  share a base class. Use `DBNRecord` instead.
- Removed `_DBNRecord` union type alias which only existed in typestub and wasn't
  importable. Use `DBNRecord | Metadata` instead
