### PR TITLE
Raw Python decoder (data records as bytes)

### DIFF
--- a/python/python/databento_dbn/_lib.pyi
+++ b/python/python/databento_dbn/_lib.pyi
@@ -10423,6 +10423,28 @@ class DBNDecoder:
 
         """
 
+    def decode_raw(
+        self,
+    ) -> list[Metadata | bytes | DBNRecord]:
+        """
+        Decode the buffered data. Only control records are decoded, data
+        records are returned as raw bytes.
+
+        Returns
+        -------
+        list[Metadata | bytes | DBNRecord]
+
+        Raises
+        ------
+        DBNError
+            When the decoding fails.
+
+        See Also
+        --------
+        decode
+
+        """
+
     def write(
         self,
         bytes: bytes,

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -5,7 +5,7 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*, IntoPyObjectExt};
 use dbn::{
     decode::dbn::fsm::{DbnFsm, ProcessResult},
     python::to_py_err,
-    rtype_dispatch, Compression, HasRType, VersionUpgradePolicy,
+    rtype_dispatch, Compression, HasRType, Record, VersionUpgradePolicy,
 };
 
 #[pyclass(module = "databento_dbn", name = "DBNDecoder")]
@@ -71,17 +71,7 @@ impl DbnDecoder {
     }
 
     fn decode(&mut self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
-        // Flush all decompressed data to FSM
-        if let Some(zstd_decoder) = &mut self.zstd_decoder {
-            zstd_decoder
-                .flush()
-                .map_err(|e| PyErr::new::<PyRuntimeError, _>(e.to_string()))?;
-            let decompressed = zstd_decoder.get_mut();
-            if !decompressed.is_empty() {
-                self.fsm.write_all(decompressed);
-                decompressed.clear();
-            }
-        }
+        self.flush_to_fsm()?;
 
         let mut ts_out = self.fsm.ts_out();
         let mut py_recs = Vec::new();
@@ -114,6 +104,64 @@ impl DbnDecoder {
                 ProcessResult::Err(error) => return Err(PyErr::from(error)),
             }
         }
+    }
+
+    fn decode_raw(&mut self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+        self.flush_to_fsm()?;
+
+        let mut ts_out = self.fsm.ts_out();
+        let mut py_recs = Vec::new();
+        loop {
+            match self.fsm.process() {
+                ProcessResult::ReadMore(_) => return Ok(py_recs),
+                ProcessResult::Metadata(metadata) => {
+                    ts_out = self.fsm.ts_out();
+                    py_recs.push(metadata.into_py_any(py)?)
+                }
+                ProcessResult::Record(_) => {
+                    let rec = self.fsm.last_record().ok_or_else(|| {
+                        PyRuntimeError::new_err("Error while decoding DBN stream")
+                    })?;
+                    let is_control = rec.rtype().ok().map_or(false, |r| matches!(
+                        r,
+                        dbn::RType::Error | dbn::RType::SymbolMapping | dbn::RType::System
+                    ));
+                    if is_control {
+                        // Control records: still decoded as Python objects.
+                        fn push_rec<'py, R>(rec: &R, py: Python<'py>, py_recs: &mut Vec<Py<PyAny>>)
+                        where
+                            R: Clone + HasRType + IntoPyObject<'py>,
+                        {
+                            py_recs.push(rec.clone().into_py_any(py).unwrap());
+                        }
+                        rtype_dispatch!(rec, ts_out: ts_out, push_rec(py, &mut py_recs))
+                            .map_err(PyErr::from)?;
+                    } else {
+                        // Data records: return raw bytes, no Python object overhead.
+                        let raw: &[u8] = rec.as_ref();
+                        py_recs.push(pyo3::types::PyBytes::new(py, raw).into_py_any(py)?);
+                    }
+                }
+                ProcessResult::Err(error) => return Err(PyErr::from(error)),
+            }
+        }
+    }
+}
+
+impl DbnDecoder {
+    /// Flush any buffered zstd-decompressed data into the FSM.
+    fn flush_to_fsm(&mut self) -> PyResult<()> {
+        if let Some(zstd_decoder) = &mut self.zstd_decoder {
+            zstd_decoder
+                .flush()
+                .map_err(|e| PyErr::new::<PyRuntimeError, _>(e.to_string()))?;
+            let decompressed = zstd_decoder.get_mut();
+            if !decompressed.is_empty() {
+                self.fsm.write_all(decompressed);
+                decompressed.clear();
+            }
+        }
+        Ok(())
     }
 }
 

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -525,4 +525,71 @@ assert len(records) == 3  # metadata + 2 records
             assert_eq!(records.len(), 3);
         });
     }
+
+    /// Mirrors test_full_with_partial_record but uses decode_raw().
+    /// Verifies: control records → Python objects, data records → bytes,
+    /// and ts_out is correctly applied to control records after metadata.
+    #[rstest]
+    fn test_decode_raw(_python: ()) {
+        let mut decoder = DbnDecoder::new(
+            true,
+            false,
+            None,
+            VersionUpgradePolicy::default(),
+            Compression::None,
+        )
+        .unwrap();
+        let mut encoder = Encoder::new(
+            Vec::new(),
+            &MetadataBuilder::new()
+                .dataset(Dataset::XnasItch.to_string())
+                .schema(Some(Schema::Ohlcv1S))
+                .stype_in(Some(SType::RawSymbol))
+                .stype_out(SType::InstrumentId)
+                .start(0)
+                .ts_out(true)
+                .build(),
+        )
+        .unwrap();
+        // ErrorMsg (control) + OhlcvMsg (data), both wrapped with ts_out.
+        let error = dbn::record::WithTsOut::new(
+            ErrorMsg::new(1680708278000000000, None, "Python", true),
+            42,
+        );
+        let data = dbn::record::WithTsOut::new(
+            OhlcvMsg {
+                hd: RecordHeader::new::<OhlcvMsg>(rtype::OHLCV_1S, 1, 1, 1681228173000000000),
+                open: 100,
+                high: 200,
+                low: 50,
+                close: 150,
+                volume: 1000,
+            },
+            99,
+        );
+        encoder.encode_record(&error).unwrap();
+        encoder.encode_record(&data).unwrap();
+
+        decoder.write(encoder.get_ref()).unwrap();
+
+        Python::attach(|py| {
+            let records = decoder.decode_raw(py).unwrap();
+            assert_eq!(records.len(), 3, "expected Metadata + ErrorMsg + OhlcvMsg");
+
+            // [0] Metadata
+            assert!(records[0].bind(py).is_instance_of::<dbn::Metadata>());
+
+            // [1] ErrorMsg — control record, decoded as Python object with ts_out
+            let error_obj = records[1].bind(py);
+            assert!(error_obj.is_instance_of::<ErrorMsg>());
+            assert!(error_obj.hasattr("ts_out").unwrap(), "ts_out missing after metadata");
+
+            // [2] OhlcvMsg — data record, returned as raw bytes
+            let data_obj = records[2].bind(py);
+            assert!(data_obj.is_instance_of::<pyo3::types::PyBytes>());
+            let raw: &[u8] = data_obj.extract().unwrap();
+            // Raw bytes include ts_out suffix: OhlcvMsg size + 8
+            assert_eq!(raw.len(), std::mem::size_of::<OhlcvMsg>() + 8);
+        });
+    }
 }


### PR DESCRIPTION
## Description

This implements an additional Python decoder that passes data records as `bytes`, while still creating Python objects for system (control) messages as required by Python clients.

Workaround for #116 , but also a more efficient code path that eliminates ~10K objects per second for subscribers that don't need them.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Added a new test matching the existing decoder test.

With a corresponding `add_raw_callback()` in [databento-python #130](https://github.com/databento/databento-python/pull/130), this minimal example shows stable memory usage:
https://gist.github.com/alexandervlpl/a0ef774ee3a1dcea7909627af1d9c3da

Ran as part of our service for several market days (streaming from a local gateway) and now deployed to stage with the live stream.

## Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`)
- [ ] My code follows the style guidelines (`scripts/lint.sh` and `scripts/format.sh`)
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority
necessary to make this contribution on behalf of its copyright owner.
