### PR TITLE
ADD: Add decoding more than buffer capacity test

### DIFF
--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -694,9 +694,9 @@ mod tests {
             dbn::{AsyncEncoder, AsyncRecordEncoder},
             AsyncEncodeRecord, DbnEncodable,
         },
-        rtype, v1, v2, Bbo1SMsg, CbboMsg, Cmbp1Msg, Error, ErrorMsg, ImbalanceMsg,
-        InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Record, RecordHeader, Result,
-        Schema, StatMsg, StatusMsg, TbboMsg, TradeMsg, WithTsOut,
+        rtype, v1, v2, Bbo1SMsg, CbboMsg, Cmbp1Msg, Dataset, Error, ErrorMsg, ImbalanceMsg,
+        InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, MetadataBuilder, OhlcvMsg, Record,
+        RecordHeader, Result, SType, Schema, StatMsg, StatusMsg, TbboMsg, TradeMsg, WithTsOut,
     };
 
     #[rstest]
@@ -911,5 +911,34 @@ mod tests {
         }
         assert!(has_decoded);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_decode_past_capacity() {
+        const N: u64 = 5_000;
+        let metadata = MetadataBuilder::new()
+            .dataset(Dataset::XnasItch.to_string())
+            .schema(Some(Schema::Mbo))
+            .start(0)
+            .stype_in(Some(SType::InstrumentId))
+            .stype_out(SType::InstrumentId)
+            .build();
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = AsyncEncoder::new(&mut buf, &metadata).await.unwrap();
+            for i in 0..N {
+                let mut rec = MboMsg::default();
+                rec.hd.ts_event = i;
+                encoder.encode_record(&rec).await.unwrap();
+            }
+        }
+        assert!(buf.len() > DbnFsm::DEFAULT_BUF_SIZE * 2);
+        let mut decoder = Decoder::new(buf.as_slice()).await.unwrap();
+        let mut count: u64 = 0;
+        while let Some(rec) = decoder.decode_record::<MboMsg>().await.unwrap() {
+            assert_eq!(rec.hd.ts_event, count);
+            count += 1;
+        }
+        assert_eq!(count, N);
     }
 }

--- a/rust/dbn/src/decode/dbn/async.rs
+++ b/rust/dbn/src/decode/dbn/async.rs
@@ -694,9 +694,9 @@ mod tests {
             dbn::{AsyncEncoder, AsyncRecordEncoder},
             AsyncEncodeRecord, DbnEncodable,
         },
-        rtype, v1, v2, Bbo1SMsg, CbboMsg, Cmbp1Msg, Dataset, Error, ErrorMsg, ImbalanceMsg,
-        InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, MetadataBuilder, OhlcvMsg, Record,
-        RecordHeader, Result, SType, Schema, StatMsg, StatusMsg, TbboMsg, TradeMsg, WithTsOut,
+        rtype, v1, v2, Bbo1SMsg, CbboMsg, Cmbp1Msg, Error, ErrorMsg, ImbalanceMsg,
+        InstrumentDefMsg, MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Record, RecordHeader, Result,
+        Schema, StatMsg, StatusMsg, TbboMsg, TradeMsg, WithTsOut,
     };
 
     #[rstest]
@@ -916,29 +916,23 @@ mod tests {
     #[tokio::test]
     async fn test_decode_past_capacity() {
         const N: u64 = 5_000;
-        let metadata = MetadataBuilder::new()
-            .dataset(Dataset::XnasItch.to_string())
-            .schema(Some(Schema::Mbo))
-            .start(0)
-            .stype_in(Some(SType::InstrumentId))
-            .stype_out(SType::InstrumentId)
-            .build();
         let mut buf: Vec<u8> = Vec::new();
         {
-            let mut encoder = AsyncEncoder::new(&mut buf, &metadata).await.unwrap();
+            let mut encoder = AsyncRecordEncoder::new(&mut buf);
             for i in 0..N {
                 let mut rec = MboMsg::default();
                 rec.hd.ts_event = i;
-                encoder.encode_record(&rec).await.unwrap();
+                encoder.encode(&rec).await.unwrap();
             }
         }
         assert!(buf.len() > DbnFsm::DEFAULT_BUF_SIZE * 2);
-        let mut decoder = Decoder::new(buf.as_slice()).await.unwrap();
-        let mut count: u64 = 0;
-        while let Some(rec) = decoder.decode_record::<MboMsg>().await.unwrap() {
-            assert_eq!(rec.hd.ts_event, count);
-            count += 1;
+        let records = RecordDecoder::new(buf.as_slice())
+            .decode_records::<MboMsg>()
+            .await
+            .unwrap();
+        assert_eq!(records.len(), N as usize);
+        for (i, rec) in records.iter().enumerate() {
+            assert_eq!(rec.hd.ts_event, i as u64);
         }
-        assert_eq!(count, N);
     }
 }

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -785,35 +785,6 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_past_capacity() {
-        const N: u64 = 5_000;
-        let metadata = MetadataBuilder::new()
-            .dataset(Dataset::XnasItch.to_string())
-            .schema(Some(Schema::Mbo))
-            .start(0)
-            .stype_in(Some(SType::InstrumentId))
-            .stype_out(SType::InstrumentId)
-            .build();
-        let mut buf = Vec::new();
-        {
-            let mut encoder = Encoder::new(&mut buf, &metadata).unwrap();
-            for i in 0..N {
-                let mut rec = MboMsg::default();
-                rec.hd.ts_event = i;
-                encoder.encode_record(&rec).unwrap();
-            }
-        }
-        assert!(buf.len() > DbnFsm::DEFAULT_BUF_SIZE * 2);
-        let mut decoder = Decoder::new(buf.as_slice()).unwrap();
-        let mut count: u64 = 0;
-        while let Some(rec) = decoder.decode_record::<MboMsg>().unwrap() {
-            assert_eq!(rec.hd.ts_event, count);
-            count += 1;
-        }
-        assert_eq!(count, N);
-    }
-
-    #[test]
     fn test_record_decoder_past_capacity() {
         const N: u64 = 5_000;
         let mut buf = Vec::new();

--- a/rust/dbn/src/decode/dbn/sync.rs
+++ b/rust/dbn/src/decode/dbn/sync.rs
@@ -783,4 +783,55 @@ mod tests {
         decoder.decode_records::<v3::InstrumentDefMsg>()?;
         Ok(())
     }
+
+    #[test]
+    fn test_decode_past_capacity() {
+        const N: u64 = 5_000;
+        let metadata = MetadataBuilder::new()
+            .dataset(Dataset::XnasItch.to_string())
+            .schema(Some(Schema::Mbo))
+            .start(0)
+            .stype_in(Some(SType::InstrumentId))
+            .stype_out(SType::InstrumentId)
+            .build();
+        let mut buf = Vec::new();
+        {
+            let mut encoder = Encoder::new(&mut buf, &metadata).unwrap();
+            for i in 0..N {
+                let mut rec = MboMsg::default();
+                rec.hd.ts_event = i;
+                encoder.encode_record(&rec).unwrap();
+            }
+        }
+        assert!(buf.len() > DbnFsm::DEFAULT_BUF_SIZE * 2);
+        let mut decoder = Decoder::new(buf.as_slice()).unwrap();
+        let mut count: u64 = 0;
+        while let Some(rec) = decoder.decode_record::<MboMsg>().unwrap() {
+            assert_eq!(rec.hd.ts_event, count);
+            count += 1;
+        }
+        assert_eq!(count, N);
+    }
+
+    #[test]
+    fn test_record_decoder_past_capacity() {
+        const N: u64 = 5_000;
+        let mut buf = Vec::new();
+        {
+            let mut encoder = DbnRecordEncoder::new(&mut buf);
+            for i in 0..N {
+                let mut rec = MboMsg::default();
+                rec.hd.ts_event = i;
+                encoder.encode_record(&rec).unwrap();
+            }
+        }
+        assert!(buf.len() > DbnFsm::DEFAULT_BUF_SIZE * 2);
+        let mut decoder = RecordDecoder::new(buf.as_slice());
+        let mut count: u64 = 0;
+        while let Some(rec) = decoder.decode::<MboMsg>().unwrap() {
+            assert_eq!(rec.hd.ts_event, count);
+            count += 1;
+        }
+        assert_eq!(count, N);
+    }
 }


### PR DESCRIPTION
Adds tests that exercise the buffer-refill path in the sync and async IO decoders.

Each new test synthesizes ~250 KiB of `MboMsg` records via `DbnEncoder`/`DbnRecordEncoder`, runs them back through an IO decoder, and asserts all records come back.

### Background

The existing fixtures in tests/data/ are under 1 KiB, so currently no test fills the internal 64 KiB buffer. A decoder that silently terminated after 64 KiB would not fail.

### Type of change

Additional tests.

### Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`)
- [x] My code follows the style guidelines (`scripts/lint.sh` and `scripts/format.sh`)
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [x] ~~I have made corresponding changes to the documentation~~ (not applicable)
- [x] I have added tests ~~that prove my fix is effective or that my feature works~~ (no new fix or feature)

### Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority
necessary to make this contribution on behalf of its copyright owner.
