### PR TITLE
OPT: Skip upgrade_record match when upgrade not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 - Added new publisher values for OPRA MEMX MX2 Options and IEX Options
+- Improved `DbnFsm` decode throughput on current-version data or `AsIs` workloads by
+  caching whether the upgrade policy-version combination requires upgrading, skipping
+  the per-record `upgrade_record` dispatch on the fast path (credit: @wtn)
 
 ### Bug fixes
 - Removed unsound `Copy` and `Clone` implementations for `RecordRefMut`

--- a/rust/dbn/src/decode/dbn/fsm.rs
+++ b/rust/dbn/src/decode/dbn/fsm.rs
@@ -23,6 +23,7 @@ use crate::{
 pub struct DbnFsm {
     input_dbn_version: Option<DbnVersion>,
     upgrade_policy: VersionUpgradePolicy,
+    needs_upgrade: bool,
     ts_out: bool,
     state: State,
     buffer: AlignedBuffer,
@@ -35,6 +36,7 @@ impl std::fmt::Debug for DbnFsm {
         f.debug_struct("DbnFsm")
             .field("input_dbn_version", &self.input_dbn_version)
             .field("upgrade_policy", &self.upgrade_policy)
+            .field("needs_upgrade", &self.needs_upgrade)
             .field("ts_out", &self.ts_out)
             .field("state", &self.state)
             .field(
@@ -108,13 +110,26 @@ impl DbnFsm {
     /// Creates a new decoder with the specified buffer sizes. Assumes the
     /// data being decoded is packed.
     pub fn new(buffer_size: usize, compat_size: usize) -> Self {
+        let upgrade_policy = VersionUpgradePolicy::default();
         Self {
             input_dbn_version: None,
+            upgrade_policy,
+            needs_upgrade: Self::compute_needs_upgrade(upgrade_policy, None),
             ts_out: false,
-            upgrade_policy: VersionUpgradePolicy::default(),
             state: State::default(),
             buffer: AlignedBuffer::with_capacity(buffer_size),
             compat_buffer: AlignedBuffer::with_capacity(compat_size),
+        }
+    }
+
+    fn compute_needs_upgrade(
+        upgrade_policy: VersionUpgradePolicy,
+        input_dbn_version: Option<DbnVersion>,
+    ) -> bool {
+        match (upgrade_policy, input_dbn_version) {
+            (VersionUpgradePolicy::AsIs, _) => false,
+            (_, Some(DbnVersion(v))) => upgrade_policy.is_upgrade_situation(v),
+            (_, None) => true,
         }
     }
 
@@ -137,6 +152,7 @@ impl DbnFsm {
         let version = DbnVersion::try_from(version)?;
         self.upgrade_policy.validate_compatibility(version.0)?;
         self.input_dbn_version = Some(version);
+        self.needs_upgrade = Self::compute_needs_upgrade(self.upgrade_policy, Some(version));
         Ok(())
     }
 
@@ -162,10 +178,10 @@ impl DbnFsm {
     /// incompatible.
     pub fn set_upgrade_policy(&mut self, upgrade_policy: VersionUpgradePolicy) -> Result<()> {
         if let Some(DbnVersion(input_dbn_version)) = self.input_dbn_version {
-            self.upgrade_policy
-                .validate_compatibility(input_dbn_version)?;
+            upgrade_policy.validate_compatibility(input_dbn_version)?;
         }
         self.upgrade_policy = upgrade_policy;
+        self.needs_upgrade = Self::compute_needs_upgrade(upgrade_policy, self.input_dbn_version);
         Ok(())
     }
 
@@ -260,6 +276,7 @@ impl DbnFsm {
         self.buffer.reset();
         self.compat_buffer.reset();
         self.input_dbn_version = None;
+        self.needs_upgrade = Self::compute_needs_upgrade(self.upgrade_policy, None);
     }
 
     /// Skips ahead `nbytes`. Returns the actual number of bytes skipped.
@@ -318,6 +335,15 @@ impl DbnFsm {
                     }
                     if length > available_data {
                         return ProcessResult::ReadMore(length - available_data);
+                    }
+                    if !self.needs_upgrade {
+                        self.state = State::Consume {
+                            read: length,
+                            compat: 0,
+                            compat_fill: 0,
+                            expand_compat: false,
+                        };
+                        return ProcessResult::Record(());
                     }
                     let prev_compat_cap = self.compat_buffer.available_space();
                     let (rem_compat_buffer, rec) = unsafe {
@@ -443,6 +469,14 @@ impl DbnFsm {
             if length > remaining_data.len() {
                 break;
             }
+            if !self.needs_upgrade {
+                // SAFETY: previously validated as record
+                let rec = unsafe { RecordRef::new(remaining_data) };
+                rec_ref_buf.push(record_count, rec);
+                record_count += 1;
+                read_bytes += length;
+                continue;
+            }
             let prev_compat_cap = remaining_compat.len();
             let (new_rem_compat, rec) = unsafe {
                 Self::upgrade_record(
@@ -495,6 +529,8 @@ impl DbnFsm {
         }
         let version = data[DBN_PREFIX_LEN];
         self.input_dbn_version = Some(DbnVersion(version));
+        self.needs_upgrade =
+            Self::compute_needs_upgrade(self.upgrade_policy, Some(DbnVersion(version)));
         if version > DBN_VERSION {
             return Err(Error::decode(format!("can't decode newer version of DBN. Decoder version is {DBN_VERSION}, input version is {version}")));
         }
@@ -827,6 +863,10 @@ impl DbnFsm {
     /// More dynamic upgrading of records when we don't know the input DBN version:
     /// when reading DBN fragments (no metadata) and an input version wasn't specified.
     /// If the DBN version can be inferred, `input_dbn_version` will be set.
+    ///
+    /// Invariant: this only writes old versions (1 or 2) to `input_dbn_version`.
+    /// `needs_upgrade` is not refreshed after these writes; keep it that way by
+    /// never writing `DBN_VERSION` here, or refresh the cache at the call site.
     unsafe fn upgrade_record_detect_version<'a>(
         input_dbn_version: &mut Option<DbnVersion>,
         upgrade_policy: VersionUpgradePolicy,
@@ -930,6 +970,10 @@ impl DbnFsmBuilder {
         Ok(DbnFsm {
             input_dbn_version: self.input_dbn_version,
             upgrade_policy: self.upgrade_policy,
+            needs_upgrade: DbnFsm::compute_needs_upgrade(
+                self.upgrade_policy,
+                self.input_dbn_version,
+            ),
             ts_out: self.ts_out,
             state,
             buffer: AlignedBuffer::with_capacity(self.buffer_size),
@@ -1071,10 +1115,12 @@ where
 
 impl Default for DbnFsm {
     fn default() -> Self {
+        let upgrade_policy = VersionUpgradePolicy::default();
         Self {
             input_dbn_version: None,
+            upgrade_policy,
+            needs_upgrade: Self::compute_needs_upgrade(upgrade_policy, None),
             ts_out: false,
-            upgrade_policy: VersionUpgradePolicy::default(),
             state: State::default(),
             buffer: AlignedBuffer::with_capacity(Self::DEFAULT_BUF_SIZE),
             compat_buffer: AlignedBuffer::with_capacity(0),
@@ -1106,6 +1152,63 @@ mod tests {
         let mut pos = 0;
         let res = DbnFsm::decode_metadata_symbol(bytes.len(), bytes.as_slice(), &mut pos);
         assert!(res.is_err());
+    }
+
+    #[rstest]
+    #[case::asis_v1(VersionUpgradePolicy::AsIs, Some(1), false)]
+    #[case::asis_v2(VersionUpgradePolicy::AsIs, Some(2), false)]
+    #[case::asis_v3(VersionUpgradePolicy::AsIs, Some(3), false)]
+    #[case::asis_unknown(VersionUpgradePolicy::AsIs, None, false)]
+    #[case::v2_from_v1(VersionUpgradePolicy::UpgradeToV2, Some(1), true)]
+    #[case::v2_from_v2(VersionUpgradePolicy::UpgradeToV2, Some(2), false)]
+    #[case::v3_from_v1(VersionUpgradePolicy::UpgradeToV3, Some(1), true)]
+    #[case::v3_from_v2(VersionUpgradePolicy::UpgradeToV3, Some(2), true)]
+    #[case::v3_from_v3(VersionUpgradePolicy::UpgradeToV3, Some(3), false)]
+    #[case::v2_unknown(VersionUpgradePolicy::UpgradeToV2, None, true)]
+    #[case::v3_unknown(VersionUpgradePolicy::UpgradeToV3, None, true)]
+    fn test_compute_needs_upgrade(
+        #[case] policy: VersionUpgradePolicy,
+        #[case] version: Option<u8>,
+        #[case] expected: bool,
+    ) {
+        let dbn_version = version.map(DbnVersion);
+        assert_eq!(DbnFsm::compute_needs_upgrade(policy, dbn_version), expected);
+    }
+
+    #[test]
+    fn test_needs_upgrade_refreshed_on_setters() {
+        let mut fsm = DbnFsm::default();
+        assert_eq!(fsm.upgrade_policy, VersionUpgradePolicy::UpgradeToV3);
+        assert!(fsm.input_dbn_version.is_none());
+        assert!(fsm.needs_upgrade);
+
+        fsm.set_input_dbn_version(3).unwrap();
+        assert!(!fsm.needs_upgrade);
+
+        fsm.set_input_dbn_version(1).unwrap();
+        assert!(fsm.needs_upgrade);
+
+        fsm.set_upgrade_policy(VersionUpgradePolicy::AsIs).unwrap();
+        assert!(!fsm.needs_upgrade);
+
+        fsm.reset();
+        assert!(!fsm.needs_upgrade);
+
+        fsm.set_upgrade_policy(VersionUpgradePolicy::UpgradeToV3)
+            .unwrap();
+        assert!(fsm.needs_upgrade);
+    }
+
+    #[test]
+    fn test_set_upgrade_policy_validates_new_policy_not_old() {
+        let mut fsm = DbnFsm::default();
+        fsm.set_upgrade_policy(VersionUpgradePolicy::AsIs).unwrap();
+        fsm.set_input_dbn_version(3).unwrap();
+        assert!(
+            fsm.set_upgrade_policy(VersionUpgradePolicy::UpgradeToV2)
+                .is_err(),
+            "UpgradeToV2 is incompatible with input version 3"
+        );
     }
 
     #[test]


### PR DESCRIPTION
While profiling a local replay scenario, I saw `DbnFsm::upgrade_record` taking a meaningful share of decode CPU on current-version data decoded with `VersionUpgradePolicy::AsIs`, a workload where the function has nothing to do. The per-record match over `(version, policy, rtype)` runs and falls through every arm.

The proposed change caches whether the `(policy, version)` combo can ever trigger an upgrade. When it can't, `process()` skips the dispatch and transitions straight to `Consume`.

<details>
<summary>Implementation, benchmark, and reproducer script</summary>

### Implementation

`upgrade_record_with_version` is the match in question. Its arms only fire on old-version data under a non-`AsIs` policy (v1→v2 `InstrumentDefMsg`, v2→v3 `StatMsg`, etc.); for current-version data or `AsIs`, every arm is skipped and the function returns the record unchanged. The work is wasted on the common path.

Approach:

1. Add a cached `needs_upgrade: bool` on `DbnFsm`.
2. Refresh it at every site that writes `upgrade_policy` or `input_dbn_version`: `new`, `Default`, the builder's `build`, `set_input_dbn_version`, `set_upgrade_policy`, `decode_prelude` (metadata path), `reset`.
3. In `process()` and `process_multiple()`, when `!needs_upgrade`, skip the `upgrade_record` call and the compat-buffer bookkeeping, transitioning to `Consume` with a `RecordRef` built directly from the main buffer.

No public API change; `upgrade_record` stays in place for the slow path.

### Benchmark

MacOS `sample(1)` on a 395 MiB MBO replay (5 s): `upgrade_record` took ~14% of decode-loop CPU on upstream `main`. After PR #122 lands, that same absolute time is ~19% of the smaller total. Expected throughput gain on `AsIs` workloads of 15-25%.

Synthetic `decode_ref`, peak throughput over N=2M records, 30 iters, `arm64-darwin25`:

| schema | record size | before | after | Δ |
|---|---:|---:|---:|---:|
| trade   |  48 B |  5.15 GB/s |  6.34 GB/s | +23% |
| mbo     |  56 B |  5.78 GB/s |  7.27 GB/s | +26% |
| mbp1    |  80 B |  7.33 GB/s |  8.94 GB/s | +22% |
| mbp10   | 368 B | 19.67 GB/s | 21.71 GB/s | +10% |
| ohlcv1s |  56 B |  5.73 GB/s |  7.22 GB/s | +26% |

### Reproducer

Copy the script below into `rust/dbn/examples/decode_bench.rs`, then:

```sh
cargo run --release --example decode_bench -p dbn
```

Defaults: `N=1_000_000` records × 5 schemas, 20 timed iters, 3 warmup. Override via env vars (`N`, `ITERS`, `WARMUP`).

For a before/after comparison: run on `main` for a baseline, `git switch` to this branch, re-run.

```rust
//! Synthetic `RecordDecoder::decode_ref` throughput benchmark.
//!
//! Encodes `N` default records of several schemas into an in-memory buffer,
//! then runs a timed decode loop over each. Reports per-iteration min and
//! median time, peak and median throughput in GB/s, and records/sec.
//!
//! `N`, `ITERS`, and `WARMUP` are read from the environment (defaults:
//! 1_000_000 / 20 / 3). Records are default-constructed; only record size
//! affects decode throughput.
//!
//! ```sh
//! cargo run --release --example decode_bench -p dbn
//! ```

use std::env;
use std::hint::black_box;
use std::time::Instant;

use dbn::decode::{DbnRecordDecoder, DecodeRecordRef};
use dbn::encode::{DbnEncodable, DbnRecordEncoder, EncodeRecord};
use dbn::{MboMsg, Mbp10Msg, Mbp1Msg, OhlcvMsg, Schema, TradeMsg};

fn env_usize(key: &str, default: usize) -> usize {
    env::var(key)
        .ok()
        .and_then(|v| v.replace('_', "").parse().ok())
        .unwrap_or(default)
}

fn encode_repeated<R: DbnEncodable>(n: usize, rec: &R) -> Vec<u8> {
    let mut buf = Vec::with_capacity(n * std::mem::size_of::<R>());
    let mut enc = DbnRecordEncoder::new(&mut buf);
    for _ in 0..n {
        enc.encode_record(rec).unwrap();
    }
    buf
}

fn bench(name: &str, record_size: usize, bytes: &[u8], iters: usize, warmup: usize) {
    let mut timings = Vec::with_capacity(iters);
    let mut records_per_iter: u64 = 0;
    for i in 0..(iters + warmup) {
        let mut decoder = DbnRecordDecoder::new(bytes);
        let mut count: u64 = 0;
        let t0 = Instant::now();
        while let Ok(Some(rec)) = decoder.decode_record_ref() {
            black_box(&rec);
            count += 1;
        }
        let elapsed = t0.elapsed();
        black_box(count);
        if i >= warmup {
            timings.push(elapsed.as_secs_f64());
            records_per_iter = count;
        }
    }
    timings.sort_by(|a, b| a.partial_cmp(b).unwrap());
    let min = timings[0];
    let med = timings[timings.len() / 2];
    let bytes_per_iter = bytes.len();
    let gbps_med = (bytes_per_iter as f64) / med / 1e9;
    let gbps_min = (bytes_per_iter as f64) / min / 1e9;
    let recs_per_s = (records_per_iter as f64) / med;
    println!(
        "{:<8} rec={:>4}B  count={:>10}  bytes={:>10}  min={:>8.4}ms  med={:>8.4}ms  {:>6.2} GB/s (peak {:>6.2})  {:>10.2} Mrec/s",
        name,
        record_size,
        records_per_iter,
        bytes_per_iter,
        min * 1e3,
        med * 1e3,
        gbps_med,
        gbps_min,
        recs_per_s / 1e6,
    );
}

fn main() {
    let n = env_usize("N", 1_000_000);
    let iters = env_usize("ITERS", 20);
    let warmup = env_usize("WARMUP", 3);

    println!(
        "DBN decode bench (synthetic) — N={n}, iters={iters}, warmup={warmup} — dbn v{}",
        env!("CARGO_PKG_VERSION"),
    );
    println!("records default-constructed; only layout size affects decoder throughput");
    println!();

    let trade = TradeMsg::default();
    let trade_bytes = encode_repeated(n, &trade);
    bench("trade", std::mem::size_of::<TradeMsg>(), &trade_bytes, iters, warmup);

    let mbo = MboMsg::default();
    let mbo_bytes = encode_repeated(n, &mbo);
    bench("mbo", std::mem::size_of::<MboMsg>(), &mbo_bytes, iters, warmup);

    let mbp1 = Mbp1Msg::default();
    let mbp1_bytes = encode_repeated(n, &mbp1);
    bench("mbp1", std::mem::size_of::<Mbp1Msg>(), &mbp1_bytes, iters, warmup);

    let mbp10 = Mbp10Msg::default();
    let mbp10_bytes = encode_repeated(n, &mbp10);
    bench("mbp10", std::mem::size_of::<Mbp10Msg>(), &mbp10_bytes, iters, warmup);

    let ohlcv = OhlcvMsg::default_for_schema(Schema::Ohlcv1S);
    let ohlcv_bytes = encode_repeated(n, &ohlcv);
    bench("ohlcv1s", std::mem::size_of::<OhlcvMsg>(), &ohlcv_bytes, iters, warmup);
}
```

</details>

### Type of change

- [x] Performance optimization

### How has this change been tested?

- `test_compute_needs_upgrade`: parameterized rstest (11 cases) covering each policy and version combination (including unknown version).
- `test_needs_upgrade_refreshed_on_setters`: walks each mutation site (`set_input_dbn_version`, `set_upgrade_policy`, `reset`) and asserts the cache stays consistent.
- Existing `test_dbn_identity` rstest matrix covers both branches: `(v3, AsIs)`/`(v3, UpgradeToV3)`/`(v2, UpgradeToV2)` hit the fast path; `(v1, UpgradeToV2)`/`(v1, UpgradeToV3)`/`(v2, UpgradeToV3)` hit the slow path.
- `cargo test -p dbn --features async --lib` passes

### Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`)
- [x] My code follows the style guidelines (`scripts/lint.sh` and `scripts/format.sh`)
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [ ] I have made corresponding changes to the documentation (not applicable; internal)
- [x] I have added tests that prove my fix is effective

### Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.