### PR TITLE
FIX: Propagate record conversion errors as PyErr in DBNDecoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Bug fixes
 - Removed unsound `Copy` and `Clone` implementations for `RecordRefMut`
+- Fixed Python `DBNDecoder.decode()` panicking on record conversion failure; errors now
+  propagate as `PyErr`
 
 ## 0.54.0 - 2026-04-14
 

--- a/python/src/dbn_decoder.rs
+++ b/python/src/dbn_decoder.rs
@@ -8,6 +8,15 @@ use dbn::{
     rtype_dispatch, Compression, HasRType, VersionUpgradePolicy,
 };
 
+#[allow(clippy::clone_on_copy)]
+fn push_rec<'py, R>(rec: &R, py: Python<'py>, py_recs: &mut Vec<Py<PyAny>>) -> PyResult<()>
+where
+    R: Clone + HasRType + IntoPyObject<'py>,
+{
+    py_recs.push(rec.clone().into_py_any(py)?);
+    Ok(())
+}
+
 #[pyclass(module = "databento_dbn", name = "DBNDecoder")]
 pub struct DbnDecoder {
     fsm: DbnFsm,
@@ -93,15 +102,6 @@ impl DbnDecoder {
                     py_recs.push(metadata.into_py_any(py)?)
                 }
                 ProcessResult::Record(_) => {
-                    // Bug in clippy generates an error here. trivial_copy feature isn't enabled,
-                    // but clippy thinks these records are `Copy`
-                    fn push_rec<'py, R>(rec: &R, py: Python<'py>, py_recs: &mut Vec<Py<PyAny>>)
-                    where
-                        R: Clone + HasRType + IntoPyObject<'py>,
-                    {
-                        py_recs.push(rec.clone().into_py_any(py).unwrap());
-                    }
-
                     let rec = self.fsm.last_record().ok_or_else(|| {
                         PyRuntimeError::new_err("Error while decoding DBN stream")
                     })?;
@@ -109,7 +109,7 @@ impl DbnDecoder {
                     // Safety: It's safe to cast to `WithTsOut` because we're passing in the `ts_out`
                     // from the metadata header.
                     rtype_dispatch!(rec, ts_out: ts_out, push_rec(py, &mut py_recs))
-                        .map_err(PyErr::from)?;
+                        .map_err(PyErr::from)??;
                 }
                 ProcessResult::Err(error) => return Err(PyErr::from(error)),
             }


### PR DESCRIPTION
`DBNDecoder.decode()` panicked on record conversion failure because the inner `push_rec` called `.unwrap()` on `into_py_any(py)`.

This change extracts `push_rec` to module scope with return type `PyResult<()>` so errors propagate to the Python caller instead.

**Motivation:** The existing code was not breaking, but had a comment referencing a clippy bug. I found that the clippy behavior is OK, so I fixed up the code here.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

I ran tests locally and with a regression test (not necessary to keep permanently).

## Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`)
- [x] My code follows the style guidelines (`scripts/lint.sh` and `scripts/format.sh`)
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)

## Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority
necessary to make this contribution on behalf of its copyright owner.
