### PR TITLE
FIX: Doctest examples using DbnDecoder::from_file on .dbn.zst paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Bug fixes
 - Removed unsound `Copy` and `Clone` implementations for `RecordRefMut`
+- Fixed doctests calling `DbnDecoder::from_file` on `.dbn.zst` paths; switched
+  to `from_zstd_file` (credit: @wtn)
 
 ## 0.54.0 - 2026-04-14
 

--- a/rust/dbn/src/decode.rs
+++ b/rust/dbn/src/decode.rs
@@ -15,7 +15,7 @@
 //! use dbn::decode::{DbnDecoder, DecodeRecordRef, DbnMetadata};
 //! use dbn::{TradeMsg, OhlcvMsg, Record};
 //!
-//! let mut decoder = DbnDecoder::from_file("20241007.dbn.zst")?;
+//! let mut decoder = DbnDecoder::from_zstd_file("20241007.dbn.zst")?;
 //! println!("schema: {:?}", decoder.metadata().schema);
 //!
 //! while let Some(rec_ref) = decoder.decode_record_ref()? {
@@ -33,7 +33,7 @@
 //! use dbn::decode::{DbnDecoder, DecodeRecord};
 //! use dbn::MboMsg;
 //!
-//! let decoder = DbnDecoder::from_file("20241007.mbo.dbn.zst")?;
+//! let decoder = DbnDecoder::from_zstd_file("20241007.mbo.dbn.zst")?;
 //! let records: Vec<MboMsg> = decoder.decode_records()?;
 //! println!("{} MBO records", records.len());
 //! # Ok::<(), dbn::Error>(())

--- a/rust/dbn/src/lib.rs
+++ b/rust/dbn/src/lib.rs
@@ -33,7 +33,7 @@
 //! ```no_run
 //! use dbn::{decode::{DbnDecoder, DecodeRecordRef, DbnMetadata}, TradeMsg};
 //!
-//! let mut decoder = DbnDecoder::from_file("20241007.trades.dbn.zst")?;
+//! let mut decoder = DbnDecoder::from_zstd_file("20241007.trades.dbn.zst")?;
 //! println!("Dataset: {}", decoder.metadata().dataset);
 //! while let Some(rec_ref) = decoder.decode_record_ref()? {
 //!     if let Some(trade) = rec_ref.get::<TradeMsg>() {

--- a/rust/dbn/src/symbol_map.rs
+++ b/rust/dbn/src/symbol_map.rs
@@ -19,7 +19,7 @@ use crate::{compat, v1, Error, HasRType, Metadata, Record, RecordRef, SymbolMapp
 ///     TradeMsg,
 /// };
 ///
-/// let mut decoder = DbnDecoder::from_file("20241007.trades.dbn.zst")?;
+/// let mut decoder = DbnDecoder::from_zstd_file("20241007.trades.dbn.zst")?;
 /// let symbol_map = decoder.metadata().symbol_map()?;
 ///
 /// while let Some(trade) = decoder.decode_record::<TradeMsg>()? {
@@ -53,7 +53,7 @@ pub struct TsSymbolMap(HashMap<(time::Date, u32), Arc<String>>);
 ///     Mbp1Msg,
 /// };
 ///
-/// let mut decoder = DbnDecoder::from_file("mbp1.dbn.zst")?;
+/// let mut decoder = DbnDecoder::from_zstd_file("mbp1.dbn.zst")?;
 /// let date = decoder.metadata().start().date();
 /// let symbol_map = decoder.metadata().symbol_map_for_date(date)?;
 ///


### PR DESCRIPTION
Swap `DbnDecoder::from_file` → `from_zstd_file` in the five doctests whose paths end in `.dbn.zst` (`lib.rs`, `decode.rs`, `symbol_map.rs`).

## Type of change

- [x] Documentation fix

## Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`)
- [x] My code follows the style guidelines (`scripts/lint.sh` and `scripts/format.sh`)
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)

## Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority
necessary to make this contribution on behalf of its copyright owner.